### PR TITLE
Adds scan and router dev tools though env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.env
 
 npm-debug.log*
 yarn-debug.log*

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,14 +19,14 @@ import App from "./App.tsx";
 const queryClient = new QueryClient();
 
 scan({
-  enabled: true,
+  enabled: import.meta.env.VITE_ENABLE_SCAN === "true",
 });
 
 const rootRoute = createRootRoute({
   component: () => (
     <>
       <Outlet />
-      <TanStackRouterDevtools />
+      {import.meta.env.VITE_ENABLE_ROUTER_DEVTOOLS === "true" && <TanStackRouterDevtools />}
     </>
   ),
 });


### PR DESCRIPTION
This PR adds environment variables responsible for toggling `scan` and `router dev tools`. In VITE you have to prefix your variables with VITE_


```
VITE_ENABLE_SCAN=true
VITE_ENABLE_ROUTER_DEVTOOLS=false
```