### PR TITLE
fix: Argument Editor - Fixed Dialog double click and movement issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "localforage": "^1.10.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-draggable": "^4.4.6",
         "react-dropzone": "^14.3.5",
         "react-scan": "^0.2.4",
         "tailwindcss": "^4.0.6"
@@ -4665,6 +4666,29 @@
       },
       "peerDependencies": {
         "react": "^19.0.0"
+      }
+    },
+    "node_modules/react-draggable": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.6.tgz",
+      "integrity": "sha512-LtY5Xw1zTPqHkVmtM3X8MUOxNDOUhv/khTgBgrUvwaS064bwVvxT+q5El0uUFNx5IEPKXuRejr7UqLwBIg5pdw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^1.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-draggable/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/react-dropzone": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "localforage": "^1.10.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-draggable": "^4.4.6",
     "react-dropzone": "^14.3.5",
     "react-scan": "^0.2.4",
     "tailwindcss": "^4.0.6"

--- a/src/DragNDrop/ArgumentsEditorDialog.tsx
+++ b/src/DragNDrop/ArgumentsEditorDialog.tsx
@@ -6,9 +6,32 @@
  * @copyright 2021 Alexey Volkov <alexey.volkov+oss@ark-kun.com>
  */
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import type { ArgumentType, TaskSpec } from "../componentSpec";
 import ArgumentsEditor from "./ArgumentsEditor";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Paper,
+  type PaperProps,
+} from "@mui/material";
+import Draggable from "react-draggable";
+
+function PaperComponent(props: PaperProps) {
+  const nodeRef = useRef<HTMLDivElement>(null);
+  return (
+    <Draggable
+      nodeRef={nodeRef as React.RefObject<HTMLDivElement>}
+      handle="#draggable-dialog-title"
+      cancel={'[class*="MuiDialogContent-root"]'}
+    >
+      <Paper {...props} ref={nodeRef} />
+    </Draggable>
+  );
+}
 
 interface ArgumentsEditorDialogProps {
   taskSpec: TaskSpec;
@@ -34,42 +57,43 @@ const ArgumentsEditorDialog = ({
     return <></>;
   }
 
+  const handleApply = () => {
+    setArguments?.(currentArguments);
+    closeEditor?.();
+  };
+
   return (
-    <form
-      onSubmit={async (e) => {
-        e.preventDefault();
-      }}
-      // Does not work
-      // draggable={false}
-      style={{
-        position: "fixed",
-        background: "white",
-        border: "1px solid black",
-        borderRadius: "4px",
-        padding: "15px",
-        // Does not work
-        // zIndex: 11,
+    <Dialog
+      open
+      onClose={closeEditor}
+      PaperComponent={PaperComponent}
+      aria-labelledby="draggable-dialog-title"
+      hideBackdrop={true}
+      disableEnforceFocus={true}
+      disableAutoFocus={true}
+      disableScrollLock={true}
+      className="absolute pointer-events-none"
+      slotProps={{
+        paper: {
+          className: "pointer-events-auto shadow-md m-0",
+        }
       }}
     >
-      <legend>Input arguments for {componentSpec.name}</legend>
-      <ArgumentsEditor
-        componentSpec={componentSpec}
-        componentArguments={currentArguments}
-        setComponentArguments={setCurrentArguments}
-      />
-      <button type="button" onClick={closeEditor}>
-        Close
-      </button>
-      <button
-        type="button"
-        onClick={() => {
-          setArguments?.(currentArguments);
-          closeEditor?.();
-        }}
-      >
-        Apply
-      </button>
-    </form>
+      <DialogTitle className="cursor-move" id="draggable-dialog-title">
+        Input arguments for {componentSpec.name}
+      </DialogTitle>
+      <DialogContent>
+        <ArgumentsEditor
+          componentSpec={componentSpec}
+          componentArguments={currentArguments}
+          setComponentArguments={setCurrentArguments}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={closeEditor}>Close</Button>
+        <Button onClick={handleApply}>Apply</Button>
+      </DialogActions>
+    </Dialog>
   );
 };
 

--- a/src/DragNDrop/ComponentTaskNode.tsx
+++ b/src/DragNDrop/ComponentTaskNode.tsx
@@ -189,15 +189,18 @@ const ComponentTaskNode = ({ data }: NodeProps) => {
     setIsArgumentsEditorOpen(false);
   };
 
+  const handleDoubleClick = () => {
+    if (!isArgumentsEditorOpen) {
+      setIsArgumentsEditorOpen(true);
+    }
+  };
+
   return (
-    <div
-      onDoubleClick={() => {
-        setIsArgumentsEditorOpen(!isArgumentsEditorOpen);
-      }}
-      title={title}
-    >
-      {label}
-      {handleComponents}
+    <>
+      <div onDoubleClick={handleDoubleClick} title={title}>
+        {label}
+        {handleComponents}
+      </div>
       {isArgumentsEditorOpen && (
         <ArgumentsEditorDialog
           taskSpec={taskSpec}
@@ -205,7 +208,7 @@ const ComponentTaskNode = ({ data }: NodeProps) => {
           setArguments={typedData.setArguments}
         />
       )}
-    </div>
+    </>
   );
 };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,7 +26,9 @@ const rootRoute = createRootRoute({
   component: () => (
     <>
       <Outlet />
-      {import.meta.env.VITE_ENABLE_ROUTER_DEVTOOLS === "true" && <TanStackRouterDevtools />}
+      {import.meta.env.VITE_ENABLE_ROUTER_DEVTOOLS === "true" && (
+        <TanStackRouterDevtools />
+      )}
     </>
   ),
 });


### PR DESCRIPTION
closes: https://github.com/Shopify/oasis-project/issues/5 https://github.com/Shopify/oasis-project/issues/4

Currently, the dialog box for arguments has two bugs:
1: Moving the box moves the node
2: double clicking the box closes it

This PR aims to address those two issues by using MUI dialog and `react-draggable`.

- I've moved the dialog outside of the  `src/DragNDrop/ComponentTaskNode.tsx`  main `div` that had the double click handler on it. Instead this component now has two components; the main `div` with the click handler and the dialog, which are both wrapped in a react fragment <></>. This allows us to double click anywhere on the argument box.
- The dialog box itself uses portals, allowing us to drag anywhere we want
- I've also cleaned up some of the styles that were previously needed to display the dialog box.



Before
<img width="1097" alt="Screenshot 2025-03-03 at 7 15 11 PM" src="https://github.com/user-attachments/assets/6a87f8da-f367-4e62-b496-d464505e1e82" />


Now:
<img width="1199" alt="Screenshot 2025-03-03 at 7 19 28 PM" src="https://github.com/user-attachments/assets/64b62f22-7110-49dc-a03b-34b57c9db0a2" />

Note: This PR does NOT style the dialog, and relies on MUIs default for now. Updated styles may come later.
