### PR TITLE
Remove refetchInterval from details and don't refetch in background

### DIFF
--- a/src/routes/RunDetails.tsx
+++ b/src/routes/RunDetails.tsx
@@ -28,8 +28,6 @@ const RunDetails = () => {
       fetch(
         `${import.meta.env.VITE_BACKEND_API_URL ?? ""}/api/executions/${id}/details`,
       ).then((response) => response.json()),
-    refetchInterval: 5000,
-    refetchIntervalInBackground: true,
   });
 
   const { data: stateData, isLoading: stateLoading } = useQuery({
@@ -39,7 +37,7 @@ const RunDetails = () => {
         `${import.meta.env.VITE_BACKEND_API_URL ?? ""}/api/executions/${id}/state`,
       ).then((response) => response.json()),
     refetchInterval: 5000,
-    refetchIntervalInBackground: true,
+    refetchIntervalInBackground: false,
   });
 
   useEffect(() => {


### PR DESCRIPTION
We only need to refetch the state as the details will not change. I've also set the state refetchIntervalInBackground to false. It defaults to false, but I wanted to leave it in to be explicit.