### PR TITLE
Updates path for component library and pipeline library

### DIFF
--- a/src/appSettings.ts
+++ b/src/appSettings.ts
@@ -8,12 +8,12 @@
 
 // Settings: Default values and local storage configuration keys
 const COMPONENT_LIBRARY_URL_DEFAULT_VALUE =
-  import.meta.env.BASE_URL + "/component_library.yaml";
+  import.meta.env.BASE_URL + "component_library.yaml";
 const COMPONENT_LIBRARY_URL_LOCAL_STORAGE_KEY =
   "ComponentLibrary/component_library_url";
 
 const PIPELINE_LIBRARY_URL_DEFAULT_VALUE =
-  import.meta.env.BASE_URL + "/pipeline_library.yaml";
+  import.meta.env.BASE_URL + "pipeline_library.yaml";
 const PIPELINE_LIBRARY_URL_LOCAL_STORAGE_KEY =
   "PipelineLibrary/pipeline_library_url";
 


### PR DESCRIPTION
Create React App (CRA): When using process.env.PUBLIC_URL in Create React App, it typically does not include a trailing slash. You often need to manually add a trailing slash if you're constructing paths based on it. For instance, you might end up doing something like ${process.env.PUBLIC_URL}/path instead of assuming the slash is already present.

Vite with Tanstack (or other modern tools): In Vite, import.meta.env.BASE_URL generally includes a trailing slash at the end. This means if you're constructing paths, you don't need to add another slash manually; you can simply use it like ${import.meta.env.BASE_URL}path.