### PR TITLE
Adds clone button to graph controls

### DIFF
--- a/src/routes/RunDetails.tsx
+++ b/src/routes/RunDetails.tsx
@@ -4,6 +4,7 @@ import {
   Controls,
   Background,
   MiniMap,
+  ControlButton,
 } from "@xyflow/react";
 import { useQuery } from "@tanstack/react-query";
 import type { ComponentSpec } from "../componentSpec";
@@ -11,13 +12,17 @@ import GraphComponentSpecFlow from "../DragNDrop/GraphComponentSpecFlow";
 import { prepareComponentRefForEditor } from "@/utils/prepareComponentRefForEditor";
 import { type ComponentReferenceWithSpec } from "../componentStore";
 import { DndContext } from "@dnd-kit/core";
+import { useNavigate } from "@tanstack/react-router";
 
 import { runDetailRoute, type RunDetailParams } from "@/router";
+import { CopyIcon } from "lucide-react";
+import { copyRunToPipeline } from "@/utils/copyRunToPipeline";
 
 const GRID_SIZE = 10;
 
 const RunDetails = () => {
   const { id } = runDetailRoute.useParams() as RunDetailParams;
+  const navigate = useNavigate();
   const [componentSpec, setComponentSpec] = useState<
     ComponentSpec | undefined
   >();
@@ -152,6 +157,15 @@ const RunDetails = () => {
     );
   }
 
+  const handleCopy = async () => {
+    const result = await copyRunToPipeline(componentSpec);
+    if (result?.url) {
+      navigate({ to: result.url });
+    } else {
+      console.error("Failed to copy run to pipeline");
+    }
+  };
+
   return (
     <div className="dndflow">
       <DndContext>
@@ -162,9 +176,15 @@ const RunDetails = () => {
               setComponentSpec={() => {}}
               snapToGrid={true}
               snapGrid={[GRID_SIZE, GRID_SIZE]}
+              nodesDraggable={false}
+              fitView
             >
               <MiniMap />
-              <Controls />
+              <Controls className="transform scale-150 translate-y-[-40px]">
+                <ControlButton onClick={handleCopy}>
+                  <CopyIcon />
+                </ControlButton>
+              </Controls>
               <Background gap={GRID_SIZE} />
             </GraphComponentSpecFlow>
           </div>

--- a/src/utils/copyRunToPipeline.ts
+++ b/src/utils/copyRunToPipeline.ts
@@ -1,0 +1,71 @@
+import type { ComponentSpec } from "@/componentSpec";
+import { componentSpecToYaml, getComponentFileFromList, writeComponentToFileListFromText } from "@/componentStore";
+import { APP_ROUTES, USER_PIPELINES_LIST_NAME } from "./constants";
+
+export const copyRunToPipeline = async (componentSpec: ComponentSpec) => {
+    if (!componentSpec) {
+      console.error("No component spec found to copy");
+      return {
+        url: null,
+        name: null
+      }
+    }
+
+    try {
+      const cleanComponentSpec = JSON.parse(JSON.stringify(componentSpec));
+
+      if (cleanComponentSpec.implementation?.graph?.tasks) {
+        Object.values(cleanComponentSpec.implementation.graph.tasks).forEach((task: any) => {
+          if (task.annotations && 'status' in task.annotations) {
+            delete task.annotations.status;
+          }
+        });
+      }
+
+      // Generate a name for the copied pipeline
+      const originalName = cleanComponentSpec.name || "Unnamed Pipeline";
+      let newName = originalName;
+
+      // Check if the name already exists and append a number if needed
+      let nameExists = true;
+      let counter = 1;
+
+      while (nameExists) {
+        const existingFile = await getComponentFileFromList(
+          USER_PIPELINES_LIST_NAME,
+          newName
+        );
+
+        if (existingFile === null) {
+          nameExists = false;
+        } else {
+          const countNumber = counter > 1 ? " " + counter : "";
+          newName = `${originalName} (Copy${countNumber})`;
+          counter++;
+        }
+      }
+
+      cleanComponentSpec.name = newName;
+
+      const componentText = componentSpecToYaml(cleanComponentSpec);
+      await writeComponentToFileListFromText(
+        USER_PIPELINES_LIST_NAME,
+        newName,
+        componentText
+      );
+
+      const urlName = encodeURIComponent(newName);
+
+      return {
+        url: APP_ROUTES.PIPELINE_EDITOR.replace('$name', urlName),
+        name: newName
+      }
+
+    } catch (error) {
+      console.error("Error cloning pipeline:", error);
+      return {
+        url: null,
+        name: null
+      }
+    }
+  };


### PR DESCRIPTION
This PR adds a util function that will take a componentSpec, removes any status, then saves it to indexDB with a new name (if required) and returns the new name and url to that new pipeline. I've also added a button to the control component on the  run graph to use this functionality. 

If the name exists it will append (copy) or (copy N) to the end of it.

I've also made the control component slightly larger on this view only. 

I've also made the graph fit to view and made the nodes non-draggable.

<img width="68" alt="Screenshot 2025-03-21 at 10 19 35 AM" src="https://github.com/user-attachments/assets/5e7052c1-06b4-48eb-927a-fc317a57776c" />
