### PR TITLE
Move the clone button from graph to header

### DIFF
--- a/src/components/AppMenu.tsx
+++ b/src/components/AppMenu.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from "@tanstack/react-router";
 
 import EditorMenu from "./EditorMenu";
 import ImportPipeline from "./ImportPipeline";
-
+import CloneRunButton from "./CloneRunButton";
 const AppMenu = () => {
   const navigate = useNavigate();
 
@@ -25,6 +25,7 @@ const AppMenu = () => {
           <EditorMenu />
         </div>
         <div className="flex flex-row gap-2 items-center">
+          <CloneRunButton />
           <ImportPipeline />
           <NewExperimentDialog />
         </div>

--- a/src/components/CloneRunButton.tsx
+++ b/src/components/CloneRunButton.tsx
@@ -1,0 +1,55 @@
+import { useLoadComponentSpecAndDetailsFromId } from "@/hooks/useLoadComponentSpecDetailsFromId";
+import { runDetailRoute, type RunDetailParams } from "@/router";
+import { copyRunToPipeline } from "@/utils/copyRunToPipeline";
+import { useNavigate, useLocation } from "@tanstack/react-router";
+import { CopyIcon, Loader2 } from "lucide-react";
+import { Button } from "./ui/button";
+import { RUNS_BASE_PATH } from "@/utils/constants";
+
+const CloneRunButtonInner = () => {
+  const { id } = runDetailRoute.useParams() as RunDetailParams;
+  const { componentSpec, isLoading: detailsLoading } =
+    useLoadComponentSpecAndDetailsFromId(id);
+  const navigate = useNavigate();
+
+  const handleClone = async () => {
+    if (!componentSpec) {
+      console.error("No component spec found");
+      return;
+    }
+
+    const result = await copyRunToPipeline(componentSpec);
+    if (result?.url) {
+      navigate({ to: result.url });
+    } else {
+      console.error("Failed to copy run to pipeline");
+    }
+  };
+
+  if (detailsLoading) {
+    return (
+      <button>
+        <Loader2 className="w-4 h-4 animate-spin" />
+      </button>
+    );
+  }
+
+  return (
+    <Button variant="outline" onClick={handleClone} className="cursor-pointer">
+      <CopyIcon /> Clone Run
+    </Button>
+  );
+};
+
+const CloneRunButton = () => {
+  const location = useLocation();
+
+  const isRunDetailRoute = location.pathname.includes(RUNS_BASE_PATH);
+
+  if (!isRunDetailRoute) {
+    return null;
+  }
+  return <CloneRunButtonInner />;
+};
+
+export default CloneRunButton;

--- a/src/hooks/useLoadComponentSpecDetailsFromId.ts
+++ b/src/hooks/useLoadComponentSpecDetailsFromId.ts
@@ -1,0 +1,55 @@
+import type { ComponentSpec } from "@/componentSpec";
+import type { ComponentReferenceWithSpec } from "@/componentStore";
+import { prepareComponentRefForEditor } from "@/utils/prepareComponentRefForEditor";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+
+export const useLoadComponentSpecAndDetailsFromId = (id: string) => {
+  if (!id) {
+    return {
+      componentSpec: undefined,
+      detailsData: undefined,
+      isLoading: false,
+    };
+  }
+
+  const [componentSpec, setComponentSpec] = useState<
+    ComponentSpec | undefined
+  >();
+  const { data: detailsData, isLoading: detailsLoading } = useQuery({
+    queryKey: ["run_details", id],
+    queryFn: () =>
+      fetch(
+        `${import.meta.env.VITE_BACKEND_API_URL ?? ""}/api/executions/${id}/details`,
+      ).then((response) => response.json()),
+  });
+
+  useEffect(() => {
+    const loadPipeline = async () => {
+      if (detailsLoading || !detailsData?.task_spec?.componentRef) {
+        return;
+      }
+
+      try {
+        const componentRef: ComponentReferenceWithSpec = {
+          ...detailsData.task_spec.componentRef,
+          digest:
+            detailsData.task_spec.componentRef.spec?.metadata?.annotations
+              ?.digest || "unknown",
+        };
+
+        // Prepare the component for the editor
+        const preparedComponentRef =
+          await prepareComponentRefForEditor(componentRef);
+
+        setComponentSpec(preparedComponentRef);
+      } catch (error) {
+        console.error("Error preparing component for editor:", error);
+      }
+    };
+
+    loadPipeline();
+  }, [detailsData, detailsLoading]);
+
+  return { componentSpec, detailsData, isLoading: detailsLoading };
+};

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -36,7 +36,7 @@ const Home = () => {
           headers: {
             "Content-Type": "application/json",
           },
-        }
+        },
       );
       if (!response.ok) {
         throw response;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -4,11 +4,12 @@ export const GIVE_FEEDBACK_URL =
 export const PRIVACY_POLICY_URL = "https://cloud-pipelines.net/privacy_policy";
 
 export const EDITOR_PATH = "/editor";
+export const RUNS_BASE_PATH = "/runs";
 export const APP_ROUTES = {
   HOME: "/",
   PIPELINE_EDITOR: `${EDITOR_PATH}/$name`,
-  RUN_DETAIL: "/runs/$id",
-  RUNS: "/runs",
+  RUN_DETAIL: `${RUNS_BASE_PATH}/$id`,
+  RUNS: RUNS_BASE_PATH,
 };
 
 export const USER_PIPELINES_LIST_NAME = "user_pipelines";


### PR DESCRIPTION
This PR moves the clone button from the graph controls to the header. This has been achieved by creating a clone run button component that works by accepting an ID as a param. We can place this anywhere we have access to the ID now.

<img width="1197" alt="Screenshot 2025-03-23 at 8 16 44 PM" src="https://github.com/user-attachments/assets/82d69585-0636-473d-bba6-7db0aa7e8775" />
