### PR TITLE
visual: Argument editor - Added a grip icon next to argument modal title to indicate that the dialog is draggable

### DIFF
--- a/src/DragNDrop/ArgumentsEditorDialog.tsx
+++ b/src/DragNDrop/ArgumentsEditorDialog.tsx
@@ -20,6 +20,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { DndContext, useDraggable, type DragEndEvent } from "@dnd-kit/core";
+import { GripVertical } from "lucide-react";
 
 // Global counter for z-index management
 let globalZIndexCounter = 1000;
@@ -128,8 +129,15 @@ const DraggableDialogContent = ({
       onMouseDown={bringToFront}
     >
       <Card>
-        <CardHeader {...attributes} {...listeners} className="cursor-grab">
-          <CardTitle>{componentSpec.name}</CardTitle>
+        <CardHeader>
+          <CardTitle
+            {...attributes}
+            {...listeners}
+            className="cursor-move flex items-center"
+          >
+            <GripVertical className="w-4 h-4 mr-2" />
+            {componentSpec.name}
+          </CardTitle>
           <CardDescription>
             Configure the component&apos;s input parameters.
           </CardDescription>


### PR DESCRIPTION
This PR adds a "Grip" icon to indicate to the user they can grab there and move the arguments box. I've also added a cursor icon of "move" when they hover.


<img width="641" alt="Screenshot 2025-03-23 at 9 24 12 PM" src="https://github.com/user-attachments/assets/bdd6e203-8ce6-4793-9a73-da28b13af45f" />
