### PR TITLE
feat: Run list - Run names are now links that can be opened in new tab

### DIFF
--- a/src/components/AppMenu.tsx
+++ b/src/components/AppMenu.tsx
@@ -1,27 +1,21 @@
 import NewExperimentDialog from "@/components/NewExperiment";
-import { APP_ROUTES } from "@/utils/constants";
-import { useNavigate } from "@tanstack/react-router";
 
 import EditorMenu from "./EditorMenu";
 import ImportPipeline from "./ImportPipeline";
 import CloneRunButton from "./CloneRunButton";
+import { Link } from "@tanstack/react-router";
 const AppMenu = () => {
-  const navigate = useNavigate();
-
-  const handleLogoClick = () => {
-    navigate({ to: APP_ROUTES.HOME });
-  };
-
   return (
     <div className="w-full bg-stone-900 p-2">
       <div className="flex justify-between items-center w-3/4 mx-auto">
         <div className="flex flex-row gap-2 items-center">
-          <img
-            src="/beach.png"
-            alt="logo"
-            className="w-10 h-10 filter invert cursor-pointer"
-            onClick={handleLogoClick}
-          />
+          <Link to="/">
+            <img
+              src="/beach.png"
+              alt="logo"
+              className="w-10 h-10 filter invert cursor-pointer"
+            />
+          </Link>
           <EditorMenu />
         </div>
         <div className="flex flex-row gap-2 items-center">

--- a/src/components/PipelineRow/index.tsx
+++ b/src/components/PipelineRow/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useNavigate } from "@tanstack/react-router";
+import { Link, useNavigate } from "@tanstack/react-router";
 
 import { downloadDataWithCache, loadObjectFromYamlData } from "@/cacheUtils";
 import { EDITOR_PATH } from "@/utils/constants";
@@ -136,7 +136,16 @@ const PipelineRow = ({ url, componentRef, name }: PipelineRowProps) => {
     const isAccordionClick =
       (e.target as HTMLElement).closest("[data-popover-trigger]") !== null;
     if (!isAccordionClick) {
-      navigate({ to: `${EDITOR_PATH}/${name}` });
+      if (e.metaKey || e.ctrlKey) {
+        // Open in new tab using window.open instead of navigate with target
+        const safeName = name || "unnamed";
+        window.open(
+          `${window.location.origin}${EDITOR_PATH}/${encodeURIComponent(safeName)}`,
+          "_blank",
+        );
+      } else {
+        navigate({ to: `${EDITOR_PATH}/${name}` });
+      }
     }
   };
 
@@ -146,9 +155,20 @@ const PipelineRow = ({ url, componentRef, name }: PipelineRowProps) => {
   const pipelineSpec = componentRef?.spec || rowData;
   const displayName = name || pipelineSpec?.name || "Unnamed Pipeline";
 
+  const LinkProps = {
+    to: `${EDITOR_PATH}/${encodeURIComponent(name || "")}`,
+    className: "underline hover:text-blue-500",
+    onClick: (e: React.MouseEvent) => {
+      e.stopPropagation(); // Prevent triggering the row click handler
+    },
+  };
+
   return (
     <TableRow onClick={handleOpenInEditor} className="cursor-pointer">
-      <TableCell className="text-sm">{displayName}</TableCell>
+      <TableCell className="text-sm">
+        <Link {...LinkProps}>{displayName}</Link>
+      </TableCell>
+
       <TableCell>
         {latestRun && runTaskStatuses[latestRun.id] && (
           <StatusIcon status={latestRun.status} />


### PR DESCRIPTION
Closes: https://github.com/Cloud-Pipelines/pipeline-studio-app/pull/87

You can now right click the app logo to open a link context menu or command click to open in a new window. You can also command click anywhere on the row for a pipeline to open it in a new window or you can right click the title to open in a new window from the context menu