### PR TITLE
feat: Run submitter - Added submission error indication

### DIFF
--- a/src/DragNDrop/ShopifyCloud.tsx
+++ b/src/DragNDrop/ShopifyCloud.tsx
@@ -81,6 +81,11 @@ const ShopifyCloudSubmitter = ({
 
       setRunId(responseData.root_execution_id);
     },
+    onError: (error) => {
+      console.error("Error submitting pipeline:", error);
+      setErrorMessage("Failed to submit pipeline");
+      setSubmitSuccess(false);
+    },
   });
 
   const handleViewRun = () => {


### PR DESCRIPTION
When a user submits a pipeline and it fails, we now display a message:

<img width="288" alt="Screenshot 2025-03-23 at 10 21 05 PM" src="https://github.com/user-attachments/assets/771351fc-fe91-4e05-876f-1d7837ead743" />

closes https://github.com/Cloud-Pipelines/pipeline-studio-app/issues/80
