### PR TITLE
chore: Dialogs - Added missing dialog titles, descriptions and onOpenChange handlers

### DIFF
--- a/src/DragNDrop/AppSettingsDialog.tsx
+++ b/src/DragNDrop/AppSettingsDialog.tsx
@@ -11,6 +11,7 @@ import { Input } from "@/components/ui/input";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -77,6 +78,10 @@ const AppSettingsDialog = ({ isOpen, handleClose }: AppSettingsDialogProps) => {
         <DialogHeader>
           <DialogTitle>Settings</DialogTitle>
         </DialogHeader>
+
+        <DialogDescription className="hidden">
+          Application settings.
+        </DialogDescription>
 
         <Label htmlFor="component_library_url">Component library URL</Label>
         <Input

--- a/src/DragNDrop/PipelineLibrary.tsx
+++ b/src/DragNDrop/PipelineLibrary.tsx
@@ -9,6 +9,7 @@
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -122,11 +123,14 @@ const OkCancelDialog = ({
   onCancel,
 }: OkCancelDialogProps) => {
   return (
-    <Dialog open={isOpen} aria-labelledby="alert-dialog-title">
+    <Dialog open={isOpen} onOpenChange={onCancel}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle id="alert-dialog-title">{title}</DialogTitle>
+          <DialogTitle>{title}</DialogTitle>
         </DialogHeader>
+        <DialogDescription className="hidden">
+          Confirm action.
+        </DialogDescription>
         <DialogFooter>
           <Button color="primary" onClick={onCancel}>
             {cancelButtonText}
@@ -164,11 +168,14 @@ const SaveAsDialog = ({
   };
 
   return (
-    <Dialog open={isOpen} aria-labelledby="alert-dialog-title">
+    <Dialog open={isOpen} onOpenChange={onCancel}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle id="alert-dialog-title">{"Save pipeline"}</DialogTitle>
+          <DialogTitle>{"Save pipeline"}</DialogTitle>
         </DialogHeader>
+        <DialogDescription className="hidden">
+          Enter pipeline name.
+        </DialogDescription>
         <Label htmlFor="name">{inputLabel}</Label>
         <Input
           id="name"

--- a/src/DragNDrop/UserComponentLibrary.tsx
+++ b/src/DragNDrop/UserComponentLibrary.tsx
@@ -11,6 +11,7 @@ import { Input } from "@/components/ui/input";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -198,11 +199,15 @@ const ImportComponentFromUrlDialog = ({
   };
 
   return (
-    <Dialog open={isOpen}>
+    <Dialog open={isOpen} onOpenChange={onCancel}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>{"Import component"}</DialogTitle>
         </DialogHeader>
+
+        <DialogDescription className="hidden">
+          Enter a component URL to import from.
+        </DialogDescription>
 
         <Label htmlFor="name">Component URL</Label>
         <Input


### PR DESCRIPTION
This PR addresses three items:

1. Fixes a couple instances of broken "x" (close) buttons on Dialog components.

2. Addresses instances of a Radix warning about missing Dialog aria-description by adding a hidden description field.
![image](https://github.com/user-attachments/assets/38c6fef4-4518-4900-b5b4-917e52b2b3b0)

3. Addresses instances of a Radix error about missing Dialog aria-title by removing manual `aria-labelledby` assignments (Radix takes care of this internally)
![image](https://github.com/user-attachments/assets/b2a4e861-3ca6-4272-9215-48267680ba4d)

No more Radix-Dialog errors or warnings in the console:
![image](https://github.com/user-attachments/assets/d5a64325-ecdd-4b43-886f-8b42718d88ae)


