### PR TITLE
chore: Dev - Added simple-import-sort for sorting import statements

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,8 @@
-import globals from "globals";
 import pluginJs from "@eslint/js";
-import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
+import simpleImportSort from "eslint-plugin-simple-import-sort";
+import globals from "globals";
+import tseslint from "typescript-eslint";
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
@@ -25,6 +26,11 @@ export default [
           varsIgnorePattern: "^_",
         },
       ],
+      "simple-import-sort/imports": "error",
+      "simple-import-sort/exports": "error",
+    },
+    plugins: {
+      "simple-import-sort": simpleImportSort,
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@xyflow/react": "^12.4.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "eslint-plugin-simple-import-sort": "^12.1.1",
         "gh-pages": "^6.3.0",
         "js-yaml": "^4.1.0",
         "localforage": "^1.10.0",
@@ -1120,7 +1121,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
       "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
@@ -1139,7 +1139,6 @@
       "version": "4.12.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
       "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -1149,7 +1148,6 @@
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.2.tgz",
       "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^2.1.6",
@@ -1164,7 +1162,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1175,7 +1172,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -1188,7 +1184,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
       "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
@@ -1201,7 +1196,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.0.tgz",
       "integrity": "sha512-yaVPAiNAalnCZedKLdR21GOGILMLKPyqSLWaAjQFvYA2i/ciDi8ArYVr69Anohb6cH2Ukhqti4aFnYyPm8wdwQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
@@ -1225,7 +1219,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1236,7 +1229,6 @@
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
       "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1249,7 +1241,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -1262,7 +1253,6 @@
       "version": "9.21.0",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.21.0.tgz",
       "integrity": "sha512-BqStZ3HX8Yz6LvsF5ByXYrtigrV5AXADWLAGc7PH/1SxOb7/FIYYMszZZWiUou/GB9P2lXWk2SV4d+Z8h0nknw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1272,7 +1262,6 @@
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
       "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1282,7 +1271,6 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.7.tgz",
       "integrity": "sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^0.12.0",
@@ -1334,7 +1322,6 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
@@ -1344,7 +1331,6 @@
       "version": "0.16.6",
       "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
       "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@humanfs/core": "^0.19.1",
@@ -1358,7 +1344,6 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
       "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
@@ -1372,7 +1357,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
@@ -1386,7 +1370,6 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
       "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
@@ -3175,7 +3158,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -3620,7 +3602,6 @@
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "devOptional": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -3633,7 +3614,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -3653,7 +3633,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -3680,7 +3659,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3943,7 +3921,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bippy": {
@@ -4116,7 +4093,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -4170,7 +4146,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4183,7 +4158,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -4218,7 +4192,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/convert-source-map": {
@@ -4256,7 +4229,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4498,7 +4470,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/define-data-property": {
@@ -4931,7 +4902,6 @@
       "version": "9.21.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.21.0.tgz",
       "integrity": "sha512-KjeihdFqTPhOMXTt7StsDxriV4n66ueuF/jfPNC3j/lduHwr/ijDwJMsF+wyMJethgiKi5wniIE243vi07d3pg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
@@ -5062,11 +5032,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
+      "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
       "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -5083,7 +5061,6 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -5096,7 +5073,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -5107,7 +5083,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
       "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5120,7 +5095,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -5137,7 +5111,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -5150,7 +5123,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -5166,7 +5138,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -5179,7 +5150,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -5195,7 +5165,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -5211,7 +5180,6 @@
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
       "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.14.0",
@@ -5229,7 +5197,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
       "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5242,7 +5209,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
       "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -5255,7 +5221,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -5268,7 +5233,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -5287,7 +5251,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -5307,7 +5270,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -5330,14 +5292,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fastq": {
@@ -5353,7 +5313,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^4.0.0"
@@ -5452,7 +5411,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
@@ -5466,7 +5424,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/for-each": {
@@ -5830,7 +5787,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6017,7 +5973,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -6446,7 +6401,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -6650,7 +6604,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
@@ -6663,14 +6616,12 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
@@ -6717,7 +6668,6 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -6736,7 +6686,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -7014,7 +6963,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/loose-envify": {
@@ -7232,7 +7180,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-releases": {
@@ -7358,7 +7305,6 @@
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
@@ -7489,7 +7435,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7677,7 +7622,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
@@ -7750,7 +7694,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8293,7 +8236,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -8306,7 +8248,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8654,7 +8595,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8694,7 +8634,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -9388,7 +9327,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -9595,7 +9533,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -9908,7 +9845,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -10029,7 +9965,6 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10183,7 +10118,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@xyflow/react": "^12.4.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
     "gh-pages": "^6.3.0",
     "js-yaml": "^4.1.0",
     "localforage": "^1.10.0",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,5 +1,6 @@
-import { describe, expect, test } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
 import App from "./App.tsx";
 
 describe("App", () => {

--- a/src/DragNDrop/AppSettingsDialog.tsx
+++ b/src/DragNDrop/AppSettingsDialog.tsx
@@ -6,8 +6,9 @@
  * @copyright 2022 Alexey Volkov <alexey.volkov+oss@ark-kun.com>
  */
 
-import { Input } from "@/components/ui/input";
+import { useState } from "react";
 
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -16,11 +17,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
-import { useState } from "react";
-import { getMutableAppSettings } from "../appSettings";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+
+import { getMutableAppSettings } from "../appSettings";
 
 type AppSettingsDialogProps = {
   isOpen: boolean;

--- a/src/DragNDrop/ArgumentsEditor.tsx
+++ b/src/DragNDrop/ArgumentsEditor.tsx
@@ -6,11 +6,13 @@
  * @copyright 2021 Alexey Volkov <alexey.volkov+oss@ark-kun.com>
  */
 
-import type { ArgumentType, InputSpec, TypeSpecType } from "../componentSpec";
-import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
-import { Input } from "@/components/ui/input";
 import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+import type { ArgumentType, InputSpec, TypeSpecType } from "../componentSpec";
 
 interface ArgumentsEditorProps {
   inputs: InputSpec[];

--- a/src/DragNDrop/ArgumentsEditorDialog.tsx
+++ b/src/DragNDrop/ArgumentsEditorDialog.tsx
@@ -6,10 +6,11 @@
  * @copyright 2021 Alexey Volkov <alexey.volkov+oss@ark-kun.com>
  */
 
+import { DndContext, type DragEndEvent, useDraggable } from "@dnd-kit/core";
+import { GripVertical } from "lucide-react";
 import { useState } from "react";
 import { createPortal } from "react-dom";
-import type { ArgumentType, ComponentSpec, TaskSpec } from "../componentSpec";
-import ArgumentsEditor from "./ArgumentsEditor";
+
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -19,8 +20,9 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { DndContext, useDraggable, type DragEndEvent } from "@dnd-kit/core";
-import { GripVertical } from "lucide-react";
+
+import type { ArgumentType, ComponentSpec, TaskSpec } from "../componentSpec";
+import ArgumentsEditor from "./ArgumentsEditor";
 
 // Global counter for z-index management
 let globalZIndexCounter = 1000;

--- a/src/DragNDrop/ComponentLibrary.tsx
+++ b/src/DragNDrop/ComponentLibrary.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useEffect, useState } from "react";
+
 import type { DownloadDataType } from "../cacheUtils";
 import { downloadDataWithCache, loadObjectFromYamlData } from "../cacheUtils";
 import type { ComponentReference } from "../componentSpec";

--- a/src/DragNDrop/ComponentSearch.tsx
+++ b/src/DragNDrop/ComponentSearch.tsx
@@ -7,8 +7,10 @@
  */
 
 import { useState } from "react";
-import { Input } from "@/components/ui/input";
+
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
 import type { DownloadDataType } from "../cacheUtils";
 import { downloadDataWithCache } from "../cacheUtils";
 import type { ComponentReference } from "../componentSpec";

--- a/src/DragNDrop/ComponentTaskNode.tsx
+++ b/src/DragNDrop/ComponentTaskNode.tsx
@@ -6,7 +6,20 @@
  * @copyright 2021 Alexey Volkov <alexey.volkov+oss@ark-kun.com>
  */
 
+import type { HandleType, Node, NodeProps } from "@xyflow/react";
+import { Handle, Position } from "@xyflow/react";
+import {
+  CircleAlert,
+  CircleCheck,
+  CircleDashed,
+  EyeIcon,
+  RefreshCcw,
+  SettingsIcon,
+} from "lucide-react";
 import { type CSSProperties, memo, useState } from "react";
+
+import ExecutionDetailsSheet from "@/components/ExecutionDetailsSheet";
+import { Button } from "@/components/ui/button";
 
 import type {
   ArgumentType,
@@ -14,21 +27,8 @@ import type {
   OutputSpec,
   TaskSpec,
 } from "../componentSpec";
-
-import { Handle, Position } from "@xyflow/react";
-import type { Node, NodeProps, HandleType } from "@xyflow/react";
-import {
-  CircleCheck,
-  CircleAlert,
-  RefreshCcw,
-  EyeIcon,
-  CircleDashed,
-  SettingsIcon,
-} from "lucide-react";
-
 import ArgumentsEditorDialog from "./ArgumentsEditorDialog";
-import { Button } from "@/components/ui/button";
-import ExecutionDetailsSheet from "@/components/ExecutionDetailsSheet";
+
 const inputHandlePosition = Position.Top;
 const outputHandlePosition = Position.Bottom;
 
@@ -315,7 +315,7 @@ const ComponentTaskNode = ({ data }: NodeProps) => {
               <ExecutionDetailsSheet
                 taskSpec={taskSpec}
                 taskId={typedData.taskId}
-              runStatus={runStatus}
+                runStatus={runStatus}
               />
             )}
             {runStatus && (

--- a/src/DragNDrop/GoogleCloud.tsx
+++ b/src/DragNDrop/GoogleCloud.tsx
@@ -10,12 +10,14 @@
 /* global gapi */
 
 import { useEffect, useState } from "react";
+
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import type { ComponentSpec } from "../componentSpec";
+
 import { buildVertexPipelineJobFromGraphComponent } from "../compilers/GoogleCloudVertexAIPipelines/vertexAiCompiler";
 import type { PipelineJob } from "../compilers/GoogleCloudVertexAIPipelines/vertexPipelineSpec";
+import type { ComponentSpec } from "../componentSpec";
 
 const LOCAL_STORAGE_GCS_OUTPUT_DIRECTORY_KEY =
   "GoogleCloudSubmitter/gcsOutputDirectory";

--- a/src/DragNDrop/GraphComponentExporter.tsx
+++ b/src/DragNDrop/GraphComponentExporter.tsx
@@ -9,7 +9,6 @@
 import { useStore } from "@xyflow/react";
 
 import type { ComponentSpec } from "../componentSpec";
-
 import { componentSpecToYaml } from "../componentStore";
 import { updateComponentSpecFromNodes } from "../utils/updateComponentSpecFromNodes";
 

--- a/src/DragNDrop/GraphComponentSpecFlow.tsx
+++ b/src/DragNDrop/GraphComponentSpecFlow.tsx
@@ -6,18 +6,16 @@
  * @copyright 2021 Alexey Volkov <alexey.volkov+oss@ark-kun.com>
  */
 
-import { useState } from "react";
-import type { DragEvent } from "react";
-
-import { ReactFlow, type OnInit } from "@xyflow/react";
-
 import type {
-  ReactFlowInstance,
   Edge,
   Node,
-  ReactFlowProps,
   NodeChange,
+  ReactFlowInstance,
+  ReactFlowProps,
 } from "@xyflow/react";
+import { type OnInit, ReactFlow } from "@xyflow/react";
+import type { DragEvent } from "react";
+import { useState } from "react";
 
 import type {
   ArgumentType,
@@ -25,19 +23,18 @@ import type {
   GraphSpec,
   TaskOutputArgument,
 } from "../componentSpec";
-
-import ComponentTaskNode from "./ComponentTaskNode";
-import useComponentSpecToNodes from "../hooks/useComponentSpecToNodes";
 import useComponentSpecToEdges from "../hooks/useComponentSpecToEdges";
-import onDropNode from "../utils/onDropNode";
-import { updateNodePositions } from "../utils/updateNodePosition";
-import replaceTaskArgumentsInGraphSpec from "../utils/replaceTaskArgumentsInGraphSpec";
+import useComponentSpecToNodes from "../hooks/useComponentSpecToNodes";
 import { useConnectionHandler } from "../hooks/useConnectionHandler";
 import {
   nodeIdToInputName,
   nodeIdToOutputName,
   nodeIdToTaskId,
 } from "../utils/nodeIdUtils";
+import onDropNode from "../utils/onDropNode";
+import replaceTaskArgumentsInGraphSpec from "../utils/replaceTaskArgumentsInGraphSpec";
+import { updateNodePositions } from "../utils/updateNodePosition";
+import ComponentTaskNode from "./ComponentTaskNode";
 
 export const EMPTY_GRAPH_COMPONENT_SPEC: ComponentSpec = {
   implementation: {

--- a/src/DragNDrop/KubeflowPipelinesSubmitter.tsx
+++ b/src/DragNDrop/KubeflowPipelinesSubmitter.tsx
@@ -7,10 +7,12 @@
  */
 
 import yaml from "js-yaml";
-import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
 import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
 import {
   buildArgoWorkflowFromGraphComponent,
   type Workflow,

--- a/src/DragNDrop/PipelineLibrary.tsx
+++ b/src/DragNDrop/PipelineLibrary.tsx
@@ -6,6 +6,11 @@
  * @copyright 2021 Alexey Volkov <alexey.volkov+oss@ark-kun.com>
  */
 
+import { useNavigate } from "@tanstack/react-router";
+import { useStore } from "@xyflow/react";
+import { useCallback, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -14,25 +19,22 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { useCallback, useState, useRef } from "react";
-import { useStore } from "@xyflow/react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { EDITOR_PATH, USER_PIPELINES_LIST_NAME } from "@/utils/constants";
+
 import type { DownloadDataType } from "../cacheUtils";
 import { downloadDataWithCache } from "../cacheUtils";
 import type { ComponentSpec } from "../componentSpec";
 import {
   type ComponentFileEntry,
   componentSpecToYaml,
-  writeComponentToFileListFromText,
   getComponentFileFromList,
+  writeComponentToFileListFromText,
 } from "../componentStore";
-import GraphComponentLink from "./GraphComponentLink";
-import { updateComponentSpecFromNodes } from "../utils/updateComponentSpecFromNodes";
 import { preloadComponentReferences } from "../componentStore";
-import { Label } from "@/components/ui/label";
-import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
-import { EDITOR_PATH, USER_PIPELINES_LIST_NAME } from "@/utils/constants";
-import { useNavigate } from "@tanstack/react-router";
+import { updateComponentSpecFromNodes } from "../utils/updateComponentSpecFromNodes";
+import GraphComponentLink from "./GraphComponentLink";
 
 interface PipelineLibraryProps {
   componentSpec?: ComponentSpec;

--- a/src/DragNDrop/PipelineSubmitter.tsx
+++ b/src/DragNDrop/PipelineSubmitter.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useEffect, useState } from "react";
+
 import type { ArgumentType, ComponentSpec } from "../componentSpec";
 import ArgumentsEditor from "./ArgumentsEditor";
 import GoogleCloudSubmitter from "./GoogleCloud";

--- a/src/DragNDrop/SamplePipelineLibrary.tsx
+++ b/src/DragNDrop/SamplePipelineLibrary.tsx
@@ -6,7 +6,10 @@
  * @copyright 2021 Alexey Volkov <alexey.volkov+oss@ark-kun.com>
  */
 
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+
 import {
   type DownloadDataType,
   downloadDataWithCache,
@@ -17,7 +20,6 @@ import {
   type ComponentReferenceWithSpec,
   fullyLoadComponentRefFromUrl,
 } from "../componentStore";
-import { Button } from "@/components/ui/button";
 
 type PipelineLibraryStruct = {
   annotations?: {

--- a/src/DragNDrop/ShopifyCloud.tsx
+++ b/src/DragNDrop/ShopifyCloud.tsx
@@ -1,12 +1,14 @@
-import { useState } from "react";
-import { Button } from "@/components/ui/button";
-import { Loader2, CheckCircle, AlertCircle } from "lucide-react";
-import { useNavigate } from "@tanstack/react-router";
-import { APP_ROUTES } from "@/utils/constants";
-import type { ComponentSpec } from "../componentSpec";
-import localForage from "localforage";
 import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import localForage from "localforage";
+import { AlertCircle, CheckCircle, Loader2 } from "lucide-react";
+import { useState } from "react";
+
 import type { BodyCreateApiPipelineRunsPost } from "@/api/types.gen";
+import { Button } from "@/components/ui/button";
+import { APP_ROUTES } from "@/utils/constants";
+
+import type { ComponentSpec } from "../componentSpec";
 
 interface ShopifyCloudSubmitterProps {
   componentSpec?: ComponentSpec;

--- a/src/DragNDrop/Sidebar.tsx
+++ b/src/DragNDrop/Sidebar.tsx
@@ -8,18 +8,19 @@
 
 import { type DragEvent, useState } from "react";
 
+import { Button } from "@/components/ui/button";
+
+import type { AppSettings } from "../appSettings";
+import { type DownloadDataType, downloadDataWithCache } from "../cacheUtils";
+import { type ComponentSpec } from "../componentSpec";
+import AppSettingsDialog from "./AppSettingsDialog";
 import ComponentLibrary from "./ComponentLibrary";
 import ComponentSearch from "./ComponentSearch";
 import GraphComponentExporter from "./GraphComponentExporter";
-import VertexAiExporter from "./VertexAiExporter";
-import { type ComponentSpec } from "../componentSpec";
-import UserComponentLibrary from "./UserComponentLibrary";
 import PipelineLibrary from "./PipelineLibrary";
-import type { AppSettings } from "../appSettings";
 import PipelineSubmitter from "./PipelineSubmitter";
-import AppSettingsDialog from "./AppSettingsDialog";
-import { type DownloadDataType, downloadDataWithCache } from "../cacheUtils";
-import { Button } from "@/components/ui/button";
+import UserComponentLibrary from "./UserComponentLibrary";
+import VertexAiExporter from "./VertexAiExporter";
 
 const onDragStart = (event: DragEvent, nodeData: object) => {
   event.dataTransfer.setData("application/reactflow", JSON.stringify(nodeData));

--- a/src/DragNDrop/UserComponentLibrary.tsx
+++ b/src/DragNDrop/UserComponentLibrary.tsx
@@ -6,8 +6,10 @@
  * @copyright 2021 Alexey Volkov <alexey.volkov+oss@ark-kun.com>
  */
 
-import { Input } from "@/components/ui/input";
+import { useCallback, useEffect, useState } from "react";
+import { useDropzone } from "react-dropzone";
 
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -16,16 +18,15 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Button } from "@/components/ui/button";
-import { useCallback, useState, useEffect } from "react";
-import { useDropzone } from "react-dropzone";
+
 import {
   addComponentToListByText,
-  deleteComponentFileFromList,
-  type ComponentFileEntry,
-  getAllComponentFilesFromList,
   addComponentToListByUrl,
+  type ComponentFileEntry,
+  deleteComponentFileFromList,
+  getAllComponentFilesFromList,
 } from "../componentStore";
 import DraggableComponent from "./DraggableComponent";
 

--- a/src/DragNDrop/VertexAiExporter.tsx
+++ b/src/DragNDrop/VertexAiExporter.tsx
@@ -8,9 +8,9 @@
 
 import { useStore } from "@xyflow/react";
 
+import { buildVertexPipelineSpecFromGraphComponentSpec } from "../compilers/GoogleCloudVertexAIPipelines/vertexAiCompiler";
 import type { ComponentSpec } from "../componentSpec";
 import { updateComponentSpecFromNodes } from "../utils/updateComponentSpecFromNodes";
-import { buildVertexPipelineSpecFromGraphComponentSpec } from "../compilers/GoogleCloudVertexAIPipelines/vertexAiCompiler";
 
 interface VertexAiExporterProps {
   componentSpec: ComponentSpec;

--- a/src/DragNDrop/index.tsx
+++ b/src/DragNDrop/index.tsx
@@ -6,27 +6,28 @@
  * @copyright 2021 Alexey Volkov <alexey.volkov+oss@ark-kun.com>
  */
 
-import { useEffect, useState } from "react";
-import {
-  ReactFlowProvider,
-  Controls,
-  Background,
-  MiniMap,
-} from "@xyflow/react";
-import { DndContext } from "@dnd-kit/core";
-
-import { downloadDataWithCache } from "../cacheUtils";
-import type { ComponentSpec } from "../componentSpec";
-import GraphComponentSpecFlow from "./GraphComponentSpecFlow";
-import Sidebar from "./Sidebar";
-import { getAppSettings } from "../appSettings";
-import { type ComponentReferenceWithSpec } from "../componentStore";
-import { PipelineAutoSaver } from "./PipelineAutoSaver";
-
 import "./dnd.css";
+
+import { DndContext } from "@dnd-kit/core";
+import { useLocation } from "@tanstack/react-router";
+import {
+  Background,
+  Controls,
+  MiniMap,
+  ReactFlowProvider,
+} from "@xyflow/react";
+import { useEffect, useState } from "react";
+
 import loadPipelineByName from "@/utils/loadPipelineByName";
 import { prepareComponentRefForEditor } from "@/utils/prepareComponentRefForEditor";
-import { useLocation } from "@tanstack/react-router";
+
+import { getAppSettings } from "../appSettings";
+import { downloadDataWithCache } from "../cacheUtils";
+import type { ComponentSpec } from "../componentSpec";
+import { type ComponentReferenceWithSpec } from "../componentStore";
+import GraphComponentSpecFlow from "./GraphComponentSpecFlow";
+import { PipelineAutoSaver } from "./PipelineAutoSaver";
+import Sidebar from "./Sidebar";
 
 const GRID_SIZE = 10;
 

--- a/src/compilers/Argo/argoCompiler.test.ts
+++ b/src/compilers/Argo/argoCompiler.test.ts
@@ -6,10 +6,11 @@
  * @copyright 2021 Alexey Volkov <alexey.volkov+oss@ark-kun.com>
  */
 
-import { test, expect } from "vitest";
 import fs from "fs";
 import yaml from "js-yaml";
 import path from "path";
+import { expect, test } from "vitest";
+
 import type { ComponentSpec } from "../../componentSpec";
 import { buildArgoWorkflowFromGraphComponent } from "./argoCompiler";
 

--- a/src/compilers/Argo/argoCompiler.ts
+++ b/src/compilers/Argo/argoCompiler.ts
@@ -9,14 +9,12 @@
 import {
   type ArgumentType,
   type ComponentSpec,
-  type StringOrPlaceholder,
+  type InputSpec,
   isContainerImplementation,
   isGraphImplementation,
-  type InputSpec,
+  type StringOrPlaceholder,
 } from "../../componentSpec";
-
 import { assertDefined, notUndefined } from "../../utils";
-
 import * as argo from "./argo-workflows/ui/src/models/workflows";
 
 export type {

--- a/src/compilers/GoogleCloudVertexAIPipelines/vertexAiCompiler.test.ts
+++ b/src/compilers/GoogleCloudVertexAIPipelines/vertexAiCompiler.test.ts
@@ -9,7 +9,8 @@
 import fs from "fs";
 import yaml from "js-yaml";
 import path from "path";
-import { test, expect } from "vitest";
+import { expect, test } from "vitest";
+
 import type { ComponentSpec } from "../../componentSpec";
 import { buildVertexPipelineJobFromGraphComponent } from "./vertexAiCompiler";
 

--- a/src/compilers/GoogleCloudVertexAIPipelines/vertexAiCompiler.ts
+++ b/src/compilers/GoogleCloudVertexAIPipelines/vertexAiCompiler.ts
@@ -9,13 +9,12 @@
 import {
   type ArgumentType,
   type ComponentSpec,
-  type StringOrPlaceholder,
-  type TypeSpecType,
+  type InputSpec,
   isContainerImplementation,
   isGraphImplementation,
-  type InputSpec,
+  type StringOrPlaceholder,
+  type TypeSpecType,
 } from "../../componentSpec";
-
 import * as vertex from "./vertexPipelineSpec";
 
 // # How to handle I/O:

--- a/src/componentStore.ts
+++ b/src/componentStore.ts
@@ -8,10 +8,10 @@
 
 import yaml from "js-yaml";
 import localForage from "localforage";
+
 import type { DownloadDataType } from "./cacheUtils";
 import { downloadDataWithCache } from "./cacheUtils";
-
-import type { ComponentSpec, ComponentReference } from "./componentSpec";
+import type { ComponentReference, ComponentSpec } from "./componentSpec";
 import { isValidComponentSpec } from "./componentSpec";
 
 // IndexedDB: DB and table names

--- a/src/components/AppMenu.tsx
+++ b/src/components/AppMenu.tsx
@@ -1,9 +1,11 @@
+import { Link } from "@tanstack/react-router";
+
 import NewExperimentDialog from "@/components/NewExperiment";
 
+import CloneRunButton from "./CloneRunButton";
 import EditorMenu from "./EditorMenu";
 import ImportPipeline from "./ImportPipeline";
-import CloneRunButton from "./CloneRunButton";
-import { Link } from "@tanstack/react-router";
+
 const AppMenu = () => {
   return (
     <div className="w-full bg-stone-900 p-2">

--- a/src/components/CloneRunButton.tsx
+++ b/src/components/CloneRunButton.tsx
@@ -1,10 +1,12 @@
-import { useLoadComponentSpecAndDetailsFromId } from "@/hooks/useLoadComponentSpecDetailsFromId";
-import { runDetailRoute, type RunDetailParams } from "@/router";
-import { copyRunToPipeline } from "@/utils/copyRunToPipeline";
-import { useNavigate, useLocation } from "@tanstack/react-router";
+import { useLocation, useNavigate } from "@tanstack/react-router";
 import { CopyIcon, Loader2 } from "lucide-react";
-import { Button } from "./ui/button";
+
+import { useLoadComponentSpecAndDetailsFromId } from "@/hooks/useLoadComponentSpecDetailsFromId";
+import { type RunDetailParams, runDetailRoute } from "@/router";
 import { RUNS_BASE_PATH } from "@/utils/constants";
+import { copyRunToPipeline } from "@/utils/copyRunToPipeline";
+
+import { Button } from "./ui/button";
 
 const CloneRunButtonInner = () => {
   const { id } = runDetailRoute.useParams() as RunDetailParams;

--- a/src/components/EditorMenu.tsx
+++ b/src/components/EditorMenu.tsx
@@ -1,5 +1,6 @@
-import { EDITOR_PATH } from "@/utils/constants";
 import { useLocation } from "@tanstack/react-router";
+
+import { EDITOR_PATH } from "@/utils/constants";
 
 const EditorMenu = () => {
   const location = useLocation();

--- a/src/components/ExecutionDetailsSheet.tsx
+++ b/src/components/ExecutionDetailsSheet.tsx
@@ -1,9 +1,10 @@
-import { InfoIcon, Terminal, ArrowDownToLine } from "lucide-react";
+import { ArrowDownToLine, InfoIcon, Terminal } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { TaskSpec } from "@/componentSpec";
+
 import {
   Sheet,
   SheetContent,
@@ -35,8 +36,7 @@ const ExecutionDetailsSheet = ({
           <InfoIcon className="w-3 h-3" />
         </Button>
       </SheetTrigger>
-      <SheetContent
-        className="!max-w-none !w-[33.333333%] overflow-y-auto">
+      <SheetContent className="!max-w-none !w-[33.333333%] overflow-y-auto">
         <SheetHeader>
           <SheetTitle>Execution Details - {taskId}</SheetTitle>
         </SheetHeader>
@@ -171,7 +171,6 @@ const ExecutionDetailsSheet = ({
             <TabsContent value="logs">
               <ScrollArea className="h-[500px]">
                 <div className="font-mono text-sm whitespace-pre-wrap bg-gray-50 p-4 rounded-lg">
-
                   Fetching logs... TBD IN ANOTHER PR
                 </div>
               </ScrollArea>

--- a/src/components/ImportExperiment.tsx
+++ b/src/components/ImportExperiment.tsx
@@ -1,3 +1,6 @@
+import { useCallback } from "react";
+import { useRef } from "react";
+
 import { downloadData } from "@/cacheUtils";
 import { isGraphImplementation } from "@/componentSpec";
 import {
@@ -6,11 +9,9 @@ import {
   preloadComponentReferences,
 } from "@/componentStore";
 import { USER_PIPELINES_LIST_NAME } from "@/utils/constants";
-import { useCallback } from "react";
 
-import { useRef } from "react";
-import { Input } from "./ui/input";
 import { Button } from "./ui/button";
+import { Input } from "./ui/input";
 
 const removeSuffixes = (s: string, suffixes: string[]) => {
   for (const suffix of suffixes) {

--- a/src/components/ImportPipeline.tsx
+++ b/src/components/ImportPipeline.tsx
@@ -1,23 +1,25 @@
-import { useState, useRef } from "react";
+import { useNavigate } from "@tanstack/react-router";
 import type { ChangeEvent } from "react";
+import { useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { EDITOR_PATH } from "@/utils/constants";
 import {
   importPipelineFromFile,
   importPipelineFromYaml,
 } from "@/utils/importPipeline";
-import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
-import { Label } from "@/components/ui/label";
-import { Input } from "@/components/ui/input";
-import { useNavigate } from "@tanstack/react-router";
-import { EDITOR_PATH } from "@/utils/constants";
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-} from "@/components/ui/dialog";
+
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
 
 export default function ImportPipeline() {

--- a/src/components/NewExperiment.tsx
+++ b/src/components/NewExperiment.tsx
@@ -1,3 +1,8 @@
+import { useNavigate } from "@tanstack/react-router";
+import { AlertCircle, InfoIcon } from "lucide-react";
+import { generate } from "random-words";
+import { useEffect, useState } from "react";
+
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -11,21 +16,18 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import {
+  type ComponentFileEntry,
   getAllComponentFilesFromList,
   writeComponentToFileListFromText,
-  type ComponentFileEntry,
 } from "@/componentStore";
 import { replaceLocalStorageWithExperimentYaml } from "@/DragNDrop/PipelineAutoSaver";
-import { useNavigate } from "@tanstack/react-router";
 import {
   defaultPipelineYamlWithName,
   EDITOR_PATH,
   USER_PIPELINES_LIST_NAME,
 } from "@/utils/constants";
-import { generate } from "random-words";
-import { useEffect, useState } from "react";
+
 import { Alert, AlertDescription } from "./ui/alert";
-import { AlertCircle, InfoIcon } from "lucide-react";
 
 const VALID_NAME_REGEX = /^[a-zA-Z0-9\s]+$/;
 const VALID_NAME_MESSAGE =

--- a/src/components/PipelineRow/RunListItem.tsx
+++ b/src/components/PipelineRow/RunListItem.tsx
@@ -1,13 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
+
+import type {
+  GetExecutionInfoResponse,
+  GetGraphExecutionStateResponse,
+} from "@/api/types.gen";
+import { APP_ROUTES } from "@/utils/constants";
+
 import StatusIcon from "./StatusIcon";
 import TaskStatusBar from "./TaskStatusBar";
 import { countTaskStatuses } from "./utils";
-import { useQuery } from "@tanstack/react-query";
-import { APP_ROUTES } from "@/utils/constants";
-import type {
-  GetGraphExecutionStateResponse,
-  GetExecutionInfoResponse,
-} from "@/api/types.gen";
 
 const API_URL = import.meta.env.VITE_BACKEND_API_URL ?? "";
 

--- a/src/components/PipelineRow/index.tsx
+++ b/src/components/PipelineRow/index.tsx
@@ -1,27 +1,26 @@
-import { useState, useEffect } from "react";
 import { Link, useNavigate } from "@tanstack/react-router";
-
-import { downloadDataWithCache, loadObjectFromYamlData } from "@/cacheUtils";
-import { EDITOR_PATH } from "@/utils/constants";
 import localForage from "localforage";
+import { List } from "lucide-react";
+import { useEffect, useState } from "react";
 
+import type {
+  GetExecutionInfoResponse,
+  GetGraphExecutionStateResponse,
+} from "@/api/types.gen";
+import { downloadDataWithCache, loadObjectFromYamlData } from "@/cacheUtils";
+import { TableCell, TableRow } from "@/components/ui/table";
+import { EDITOR_PATH } from "@/utils/constants";
+
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
+import { ScrollArea } from "../ui/scroll-area";
+import RunListItem from "./RunListItem";
+import StatusIcon from "./StatusIcon";
 import {
   type PipelineRowProps,
   type PipelineRun,
   type TaskStatusCounts,
 } from "./types";
 import { countTaskStatuses } from "./utils";
-import StatusIcon from "./StatusIcon";
-import RunListItem from "./RunListItem";
-
-import { TableCell, TableRow } from "@/components/ui/table";
-import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
-import { ScrollArea } from "../ui/scroll-area";
-import { List } from "lucide-react";
-import type {
-  GetExecutionInfoResponse,
-  GetGraphExecutionStateResponse,
-} from "@/api/types.gen";
 
 const API_URL = import.meta.env.VITE_BACKEND_API_URL ?? "";
 

--- a/src/components/PipelineRow/utils.ts
+++ b/src/components/PipelineRow/utils.ts
@@ -1,8 +1,9 @@
-import { type TaskStatusCounts } from "./types";
 import type {
-  GetGraphExecutionStateResponse,
   GetExecutionInfoResponse,
+  GetGraphExecutionStateResponse,
 } from "@/api/types.gen";
+
+import { type TaskStatusCounts } from "./types";
 
 /**
  * Count task statuses from API response

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
 import { ChevronDownIcon } from "lucide-react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -61,4 +61,4 @@ function AccordionContent({
   );
 }
 
-export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };
+export { Accordion, AccordionContent, AccordionItem, AccordionTrigger };

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -63,4 +63,4 @@ function AlertDescription({
   );
 }
 
-export { Alert, AlertTitle, AlertDescription };
+export { Alert, AlertDescription, AlertTitle };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -67,9 +67,9 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
 
 export {
   Card,
-  CardHeader,
-  CardFooter,
-  CardTitle,
-  CardDescription,
   CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
 };

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { XIcon } from "lucide-react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
 import * as LabelPrimitive from "@radix-ui/react-label";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -43,4 +43,4 @@ function PopoverAnchor({
   return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
 }
 
-export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };
+export { Popover, PopoverAnchor, PopoverContent, PopoverTrigger };

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
 import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
 import * as SelectPrimitive from "@radix-ui/react-select";
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
 import * as SheetPrimitive from "@radix-ui/react-dialog";
 import { XIcon } from "lucide-react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -127,13 +127,13 @@ function SheetDescription({
 
 export {
   Sheet,
-  SheetTrigger,
   SheetClose,
   SheetContent,
-  SheetHeader,
-  SheetFooter,
-  SheetTitle,
   SheetDescription,
-  SheetPortal,
+  SheetFooter,
+  SheetHeader,
   SheetOverlay,
+  SheetPortal,
+  SheetTitle,
+  SheetTrigger,
 };

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -104,11 +104,11 @@ function TableCaption({
 
 export {
   Table,
-  TableHeader,
   TableBody,
+  TableCaption,
+  TableCell,
   TableFooter,
   TableHead,
+  TableHeader,
   TableRow,
-  TableCell,
-  TableCaption,
 };

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
 import * as TabsPrimitive from "@radix-ui/react-tabs";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -61,4 +61,4 @@ function TabsContent({
   );
 }
 
-export { Tabs, TabsList, TabsTrigger, TabsContent };
+export { Tabs, TabsContent, TabsList, TabsTrigger };

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -56,4 +56,4 @@ function TooltipContent({
   );
 }
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };

--- a/src/github.ts
+++ b/src/github.ts
@@ -8,16 +8,17 @@
 
 import yaml from "js-yaml";
 import localForage from "localforage";
+
 import type { DownloadDataType } from "./cacheUtils";
 import {
   downloadData as defaultDownloadData,
   downloadDataWithCache,
-  loadObjectFromYamlData,
   loadObjectFromJsonData,
+  loadObjectFromYamlData,
 } from "./cacheUtils";
 import {
-  type ComponentSpec,
   type ComponentReference,
+  type ComponentSpec,
   isValidComponentSpec,
 } from "./componentSpec";
 import {

--- a/src/hooks/useComponentSpecToEdges.test.tsx
+++ b/src/hooks/useComponentSpecToEdges.test.tsx
@@ -1,8 +1,9 @@
-import { describe, it, expect } from "vitest";
 import { renderHook } from "@testing-library/react";
-import useComponentSpecToEdges from "./useComponentSpecToEdges";
 import { MarkerType } from "@xyflow/react";
+import { describe, expect, it } from "vitest";
+
 import type { ComponentSpec } from "../componentSpec";
+import useComponentSpecToEdges from "./useComponentSpecToEdges";
 
 describe("useComponentSpecToEdges", () => {
   const createBasicComponentSpec = (implementation: any): ComponentSpec => ({

--- a/src/hooks/useComponentSpecToEdges.tsx
+++ b/src/hooks/useComponentSpecToEdges.tsx
@@ -1,9 +1,10 @@
 import {
-  MarkerType,
-  useEdgesState,
   type Edge,
   type EdgeChange,
+  MarkerType,
+  useEdgesState,
 } from "@xyflow/react";
+import { useEffect } from "react";
 
 import type {
   ArgumentType,
@@ -18,7 +19,6 @@ import {
   outputNameToNodeId,
   taskIdToNodeId,
 } from "../utils/nodeIdUtils";
-import { useEffect } from "react";
 
 const useComponentSpecToEdges = (
   componentSpec: ComponentSpec,

--- a/src/hooks/useComponentSpecToNodes.test.tsx
+++ b/src/hooks/useComponentSpecToNodes.test.tsx
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook } from "@testing-library/react";
-import useComponentSpecToNodes from "./useComponentSpecToNodes";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
 import type { ComponentSpec } from "../componentSpec";
 import { isGraphImplementation } from "../componentSpec";
+import useComponentSpecToNodes from "./useComponentSpecToNodes";
 
 describe("useComponentSpecToNodes", () => {
   const createBasicComponentSpec = (implementation: any): ComponentSpec => ({

--- a/src/hooks/useComponentSpecToNodes.tsx
+++ b/src/hooks/useComponentSpecToNodes.tsx
@@ -1,13 +1,13 @@
 import {
-  useNodesState,
   type Node,
   type NodeChange,
+  useNodesState,
   type XYPosition,
 } from "@xyflow/react";
+import { useEffect } from "react";
 
 import type { ArgumentType, ComponentSpec, GraphSpec } from "../componentSpec";
 import replaceTaskArgumentsInGraphSpec from "../utils/replaceTaskArgumentsInGraphSpec";
-import { useEffect } from "react";
 
 type SetComponentSpec = (componentSpec: ComponentSpec) => void;
 

--- a/src/hooks/useConnectionHandler.test.tsx
+++ b/src/hooks/useConnectionHandler.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook } from "@testing-library/react";
-import { useConnectionHandler } from "./useConnectionHandler";
 import type { Connection } from "@xyflow/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useConnectionHandler } from "./useConnectionHandler";
 
 describe("useConnectionHandler", () => {
   const mockSetTaskArgument = vi.fn();

--- a/src/hooks/useConnectionHandler.tsx
+++ b/src/hooks/useConnectionHandler.tsx
@@ -1,5 +1,6 @@
-import { useCallback } from "react";
 import type { Connection, Edge } from "@xyflow/react";
+import { useCallback } from "react";
+
 import type {
   ArgumentType,
   GraphInputArgument,

--- a/src/hooks/useLoadComponentSpecDetailsFromId.ts
+++ b/src/hooks/useLoadComponentSpecDetailsFromId.ts
@@ -1,9 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+
+import type { GetExecutionInfoResponse } from "@/api/types.gen";
 import type { ComponentSpec } from "@/componentSpec";
 import type { ComponentReferenceWithSpec } from "@/componentStore";
 import { prepareComponentRefForEditor } from "@/utils/prepareComponentRefForEditor";
-import { useQuery } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
-import type { GetExecutionInfoResponse } from "@/api/types.gen";
 
 const API_URL = import.meta.env.VITE_BACKEND_API_URL ?? "";
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,13 +1,13 @@
-import { scan } from "react-scan";
-import { StrictMode } from "react";
-import ReactDOM from "react-dom/client";
-import { RouterProvider } from "@tanstack/react-router";
+import "./styles.css";
+import "@xyflow/react/dist/style.css";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import "./styles.css";
-import reportWebVitals from "./reportWebVitals.ts";
+import { RouterProvider } from "@tanstack/react-router";
+import { StrictMode } from "react";
+import ReactDOM from "react-dom/client";
+import { scan } from "react-scan";
 
-import "@xyflow/react/dist/style.css";
+import reportWebVitals from "./reportWebVitals.ts";
 import { router } from "./router.tsx";
 
 const queryClient = new QueryClient();

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { clsx, type ClassValue } from "clsx";
+import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -1,5 +1,5 @@
 import type { Metric } from "web-vitals";
-import { onCLS, onFID, onFCP, onLCP, onTTFB } from "web-vitals";
+import { onCLS, onFCP, onFID, onLCP, onTTFB } from "web-vitals";
 
 const reportWebVitals = (onPerfEntry?: (metric: Metric) => void) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -4,13 +4,14 @@ import {
   createRouter,
   Outlet,
 } from "@tanstack/react-router";
-import Editor from "./routes/Editor";
-import Home from "./routes/Home";
 import { TanStackRouterDevtools } from "@tanstack/router-devtools";
+
 import AppFooter from "./components/AppFooter";
 import AppMenu from "./components/AppMenu";
-import { APP_ROUTES } from "./utils/constants";
+import Editor from "./routes/Editor";
+import Home from "./routes/Home";
 import RunDetails from "./routes/RunDetails";
+import { APP_ROUTES } from "./utils/constants";
 
 declare module "@tanstack/react-router" {
   interface Register {

--- a/src/routes/Editor.tsx
+++ b/src/routes/Editor.tsx
@@ -1,5 +1,6 @@
-import DnDFlow from "../DragNDrop";
 import "@xyflow/react/dist/style.css";
+
+import DnDFlow from "../DragNDrop";
 
 function App() {
   return <DnDFlow />;

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -1,9 +1,12 @@
-import { useState, useEffect } from "react";
-import {
-  getAllComponentFilesFromList,
-  type ComponentFileEntry,
-} from "@/componentStore";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useQuery } from "@tanstack/react-query";
+import { Terminal } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import type { ListPipelineJobsResponse } from "@/api/types.gen";
+import PipelineRow from "@/components/PipelineRow";
+import RunListItem from "@/components/PipelineRow/RunListItem";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 import {
   Table,
   TableBody,
@@ -11,15 +14,12 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-
-import { Button } from "@/components/ui/button";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Terminal } from "lucide-react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  type ComponentFileEntry,
+  getAllComponentFilesFromList,
+} from "@/componentStore";
 import { USER_PIPELINES_LIST_NAME } from "@/utils/constants";
-import PipelineRow from "@/components/PipelineRow";
-import { useQuery } from "@tanstack/react-query";
-import RunListItem from "@/components/PipelineRow/RunListItem";
-import type { ListPipelineJobsResponse } from "@/api/types.gen";
 
 const API_URL = import.meta.env.VITE_BACKEND_API_URL ?? "";
 

--- a/src/routes/RunDetails.tsx
+++ b/src/routes/RunDetails.tsx
@@ -1,17 +1,18 @@
-import {
-  ReactFlowProvider,
-  Controls,
-  Background,
-  MiniMap,
-} from "@xyflow/react";
+import { DndContext } from "@dnd-kit/core";
 import { useQuery } from "@tanstack/react-query";
+import {
+  Background,
+  Controls,
+  MiniMap,
+  ReactFlowProvider,
+} from "@xyflow/react";
+
+import type { GetGraphExecutionStateResponse } from "@/api/types.gen";
+import { useLoadComponentSpecAndDetailsFromId } from "@/hooks/useLoadComponentSpecDetailsFromId";
+import { type RunDetailParams, runDetailRoute } from "@/router";
+
 import type { ComponentSpec } from "../componentSpec";
 import GraphComponentSpecFlow from "../DragNDrop/GraphComponentSpecFlow";
-import { DndContext } from "@dnd-kit/core";
-
-import { runDetailRoute, type RunDetailParams } from "@/router";
-import { useLoadComponentSpecAndDetailsFromId } from "@/hooks/useLoadComponentSpecDetailsFromId";
-import type { GetGraphExecutionStateResponse } from "@/api/types.gen";
 
 const GRID_SIZE = 10;
 const API_URL = import.meta.env.VITE_BACKEND_API_URL ?? "";

--- a/src/userDataMigration.ts
+++ b/src/userDataMigration.ts
@@ -7,6 +7,7 @@
  */
 
 import localForage from "localforage";
+
 import {
   type ComponentFileEntry,
   getAllComponentFilesFromList,

--- a/src/utils/copyRunToPipeline.ts
+++ b/src/utils/copyRunToPipeline.ts
@@ -4,6 +4,7 @@ import {
   getComponentFileFromList,
   writeComponentToFileListFromText,
 } from "@/componentStore";
+
 import { APP_ROUTES, USER_PIPELINES_LIST_NAME } from "./constants";
 
 export const copyRunToPipeline = async (componentSpec: ComponentSpec) => {

--- a/src/utils/importPipeline.test.ts
+++ b/src/utils/importPipeline.test.ts
@@ -1,8 +1,10 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { importPipelineFromYaml } from "./importPipeline";
-import * as componentStore from "@/componentStore";
-import { USER_PIPELINES_LIST_NAME } from "./constants";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
 import * as componentSpecModule from "@/componentSpec";
+import * as componentStore from "@/componentStore";
+
+import { USER_PIPELINES_LIST_NAME } from "./constants";
+import { importPipelineFromYaml } from "./importPipeline";
 
 vi.mock("@/componentStore", () => ({
   componentSpecToYaml: vi.fn(),

--- a/src/utils/importPipeline.ts
+++ b/src/utils/importPipeline.ts
@@ -1,12 +1,14 @@
 import yaml from "js-yaml";
-import { USER_PIPELINES_LIST_NAME } from "./constants";
+
+import type { ComponentSpec } from "@/componentSpec";
+import { isGraphImplementation } from "@/componentSpec";
 import {
   componentSpecToYaml,
   getComponentFileFromList,
   writeComponentToFileListFromText,
 } from "@/componentStore";
-import type { ComponentSpec } from "@/componentSpec";
-import { isGraphImplementation } from "@/componentSpec";
+
+import { USER_PIPELINES_LIST_NAME } from "./constants";
 
 interface ImportResult {
   name: string;

--- a/src/utils/loadPipelineByName.ts
+++ b/src/utils/loadPipelineByName.ts
@@ -1,10 +1,11 @@
+import { getAppSettings } from "@/appSettings";
 import { downloadDataWithCache, loadObjectFromYamlData } from "@/cacheUtils";
 import {
+  type ComponentFileEntry,
   fullyLoadComponentRefFromUrl,
   getAllComponentFilesFromList,
-  type ComponentFileEntry,
 } from "@/componentStore";
-import { getAppSettings } from "@/appSettings";
+
 import { USER_PIPELINES_LIST_NAME } from "./constants";
 
 interface PipelineLibrary {

--- a/src/utils/nodeIdUtils.test.ts
+++ b/src/utils/nodeIdUtils.test.ts
@@ -1,11 +1,12 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
+
 import {
-  nodeIdToTaskId,
+  inputNameToNodeId,
   nodeIdToInputName,
   nodeIdToOutputName,
-  taskIdToNodeId,
-  inputNameToNodeId,
+  nodeIdToTaskId,
   outputNameToNodeId,
+  taskIdToNodeId,
 } from "./nodeIdUtils";
 
 describe("nodeIdUtils", () => {

--- a/src/utils/onDropNode.test.ts
+++ b/src/utils/onDropNode.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import onDropNode from "./onDropNode";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
 import type { ComponentSpec, GraphSpec, TaskSpec } from "../componentSpec";
+import onDropNode from "./onDropNode";
 
 describe("onDropNode", () => {
   let mockEvent: any;

--- a/src/utils/onDropNode.ts
+++ b/src/utils/onDropNode.ts
@@ -1,5 +1,6 @@
-import type { DragEvent } from "react";
 import type { ReactFlowInstance } from "@xyflow/react";
+import type { DragEvent } from "react";
+
 import type {
   ComponentSpec,
   GraphSpec,

--- a/src/utils/prepareComponentRefForEditor.ts
+++ b/src/utils/prepareComponentRefForEditor.ts
@@ -1,9 +1,9 @@
 import { downloadDataWithCache } from "@/cacheUtils";
 import { isGraphImplementation } from "@/componentSpec";
 import {
+  type ComponentReferenceWithSpec,
   loadComponentAsRefFromText,
   preloadComponentReferences,
-  type ComponentReferenceWithSpec,
 } from "@/componentStore";
 
 const loadInlineComponentRefs = async (tasks: Record<string, any>) => {

--- a/src/utils/replaceTaskArgumentsInGraphSpec.test.ts
+++ b/src/utils/replaceTaskArgumentsInGraphSpec.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from "vitest";
-import replaceTaskArgumentsInGraphSpec from "./replaceTaskArgumentsInGraphSpec";
+import { describe, expect, it } from "vitest";
+
 import type { ArgumentType, GraphSpec } from "../componentSpec";
+import replaceTaskArgumentsInGraphSpec from "./replaceTaskArgumentsInGraphSpec";
 
 describe("replaceTaskArgumentsInGraphSpec", () => {
   it("should update task arguments for an existing task", () => {

--- a/src/utils/updateComponentSpecFromNodes.test.ts
+++ b/src/utils/updateComponentSpecFromNodes.test.ts
@@ -1,11 +1,12 @@
 import { type Node } from "@xyflow/react";
-import { describe, test, expect, vi, beforeEach, type Mock } from "vitest";
-import { updateComponentSpecFromNodes } from "./updateComponentSpecFromNodes";
+import { beforeEach, describe, expect, type Mock, test, vi } from "vitest";
+
 import {
-  isGraphImplementation,
   type ComponentSpec,
   type GraphImplementation,
+  isGraphImplementation,
 } from "../componentSpec";
+import { updateComponentSpecFromNodes } from "./updateComponentSpecFromNodes";
 
 vi.mock("../componentSpec", () => ({
   isGraphImplementation: vi.fn(),

--- a/src/utils/updateComponentSpecFromNodes.ts
+++ b/src/utils/updateComponentSpecFromNodes.ts
@@ -1,12 +1,13 @@
+import type { Node } from "@xyflow/react";
+
 import {
-  isGraphImplementation,
   type ComponentSpec,
   type GraphSpec,
   type InputSpec,
+  isGraphImplementation,
   type OutputSpec,
   type TaskSpec,
 } from "../componentSpec";
-import type { Node } from "@xyflow/react";
 import { isComponentTaskNode } from "../DragNDrop/ComponentTaskNode";
 import {
   nodeIdToInputName,

--- a/src/utils/updateNodePosition.test.ts
+++ b/src/utils/updateNodePosition.test.ts
@@ -1,7 +1,8 @@
-import { describe, test, expect, beforeEach, vi } from "vitest";
-import { updateNodePositions } from "./updateNodePosition";
 import type { Node } from "@xyflow/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
 import type { ComponentSpec } from "../componentSpec";
+import { updateNodePositions } from "./updateNodePosition";
 
 describe("updateNodePositions", () => {
   let mockSetComponentSpec: ReturnType<typeof vi.fn>;

--- a/src/utils/updateNodePosition.ts
+++ b/src/utils/updateNodePosition.ts
@@ -1,4 +1,5 @@
 import type { Node } from "@xyflow/react";
+
 import type { ComponentSpec } from "../componentSpec";
 
 const nodeIdToTaskId = (id: string) => id.replace(/^task_/, "");

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,8 @@
-import { defineConfig } from "vite";
-import viteReact from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import viteReact from "@vitejs/plugin-react";
 import path from "path";
 import { fileURLToPath } from "url";
+import { defineConfig } from "vite";
 
 // Create __dirname equivalent for ES modules
 const __filename = fileURLToPath(import.meta.url);


### PR DESCRIPTION
Adds a new ESLint plugin `simple-import-sort` for sorting JS import statements. This plugin will highlight unsorted import statements and will automatically sort them as part of our existing `npm run validate` script.

The sorting rules are given here:
https://github.com/lydell/eslint-plugin-simple-import-sort/?tab=readme-ov-file#sort-order

🎩 I have tophatted the app as best I can and nothing appears to have been broken by the resorted imports.