### PR TITLE
Fix for 'save' button prompting an overwrite

### DIFF
--- a/src/DragNDrop/PipelineLibrary.tsx
+++ b/src/DragNDrop/PipelineLibrary.tsx
@@ -8,7 +8,7 @@
 
 import { useNavigate } from "@tanstack/react-router";
 import { useStore } from "@xyflow/react";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -244,28 +244,49 @@ const PipelineLibrary = ({
           throw Error(`File "${name}" already exists.`);
         }
       }
+
       if (!componentSpec) {
         return;
       }
+
       const graphComponent = updateComponentSpecFromNodes(
         componentSpec,
         nodes,
         false,
         true,
       );
+
       graphComponent.name = name;
+
       const componentText = componentSpecToYaml(graphComponent);
       const fileEntry = await writeComponentToFileListFromText(
         USER_PIPELINES_LIST_NAME,
         name,
         componentText,
       );
+
       await openPipelineFile(fileEntry);
 
       closeSaveAsDialog();
     },
     [componentSpec, closeSaveAsDialog, nodes, openPipelineFile],
   );
+
+  useEffect(() => {
+    const fetchFileEntry = async () => {
+      if (componentSpec?.name) {
+        const fileEntry = await getComponentFileFromList(
+          USER_PIPELINES_LIST_NAME,
+          componentSpec.name,
+        );
+        if (fileEntry) {
+          setPipelineFile(fileEntry);
+        }
+      }
+    };
+
+    fetchFileEntry();
+  }, [componentSpec]);
 
   const componentLink = useRef<HTMLAnchorElement>(null);
 

--- a/src/componentStore.ts
+++ b/src/componentStore.ts
@@ -122,15 +122,16 @@ export const preloadComponentReferences = async (
     )) {
       const componentUrl = taskSpec.componentRef.url;
       let taskComponentSpec = taskSpec.componentRef.spec;
+
       if (taskComponentSpec === undefined) {
         if (taskSpec.componentRef.text !== undefined) {
-          const taskComponentRef = await loadComponentFromUrlAsRef(
+          const taskComponentRef = await loadComponentAsRefFromText(
             taskSpec.componentRef.text,
-            downloadData,
           );
           taskComponentSpec = taskComponentRef.spec;
         } else if (componentUrl !== undefined) {
           taskComponentSpec = componentMap.get(componentUrl);
+
           if (taskComponentSpec === undefined) {
             const taskComponentRef = await loadComponentFromUrlAsRef(
               componentUrl,
@@ -140,6 +141,7 @@ export const preloadComponentReferences = async (
             componentMap.set(componentUrl, taskComponentSpec);
           }
         }
+
         if (taskComponentSpec === undefined) {
           // TODO: Print task name here
           console.error(


### PR DESCRIPTION
Closes https://github.com/Shopify/oasis-frontend/issues/8

Fixes an issue where the 'save' button was acting as a 'save as' action and prompting input and confirmation.

Also fixes a fetch error that occurs once saving has been completed.
