### PR TITLE
Fix broken group Drag-n-Drop & Delete

### DIFF
--- a/src/DragNDrop/GraphComponentSpecFlow.tsx
+++ b/src/DragNDrop/GraphComponentSpecFlow.tsx
@@ -20,7 +20,6 @@ import { useState } from "react";
 import type {
   ArgumentType,
   ComponentSpec,
-  GraphSpec,
   TaskOutputArgument,
 } from "../componentSpec";
 import useComponentSpecToEdges from "../hooks/useComponentSpecToEdges";
@@ -194,17 +193,9 @@ const GraphComponentSpecFlow = ({
       ),
     );
 
-    // Step 4: Update the component spec with our changes
-    const newGraphSpec: GraphSpec = {
-      ...graphSpec,
-      tasks: newTasks,
-      outputValues: newGraphOutputValues,
-    };
-
-    setComponentSpec({
-      ...componentSpec,
-      implementation: { graph: newGraphSpec },
-    });
+    // Step 4: Update the graph spec with our changes
+    graphSpec.tasks = newTasks;
+    graphSpec.outputValues = newGraphOutputValues;
   };
 
   const removeNode = (node: Node) => {
@@ -253,6 +244,12 @@ const GraphComponentSpecFlow = ({
     for (const node of params.nodes) {
       removeNode(node);
     }
+
+    // Save the updated graph spec to the component spec
+    setComponentSpec({
+      ...componentSpec,
+      implementation: { graph: graphSpec },
+    });
   };
 
   const handleOnNodesChange = (changes: NodeChange[]) => {

--- a/src/utils/updateNodePosition.ts
+++ b/src/utils/updateNodePosition.ts
@@ -16,13 +16,18 @@ export const updateNodePositions = (
   if (!("graph" in componentSpec.implementation)) {
     throw new Error("Component spec is not a graph");
   }
-  const graphSpec = componentSpec.implementation.graph;
 
   for (const node of updatedNodes) {
     const positionAnnotation = JSON.stringify({
       x: node.position.x,
       y: node.position.y,
     });
+
+    if (!("graph" in newComponentSpec.implementation)) {
+      throw new Error("Implementation does not contain a graph");
+    }
+
+    const graphSpec = newComponentSpec.implementation.graph;
 
     if (node.type === "task") {
       const taskId = nodeIdToTaskId(node.id);


### PR DESCRIPTION
Closes https://github.com/Cloud-Pipelines/pipeline-studio-app/issues/98
Closes https://github.com/Cloud-Pipelines/pipeline-studio-app/issues/99

Fixes an issue where a selected group of tasks could not be moved or deleted as a group.

This was occurring due to the move & delete operations not updating the graph spec in real-time, and instead overwriting the updated graph spec with the original when a new task is operated upon. This resulted in only the final task being moved or deleted. In the case of the delete function this was a by-product of React's state update logic, which meant that the delete operations were running on old state as the component doesn't rerender until the current operations have finished.

The operations will now run on a graph spec that is updated after each previous operation, meaning any changes are carried over throughout the for-loop.

Note that the solution for the delete function is not tidy. It relies on directly updating the global graphSpec and then updating the componentSpec state once all operations are complete. This is a dangerous and untidy way of solving the problem. It is strongly recommended we come back and refactor this operation to tie-in to React's state more naturally once we have more time.