### PR TITLE
Improve display of run data on PipelineRow and RunList

### DIFF
--- a/src/components/PipelineRow/RunListItem.tsx
+++ b/src/components/PipelineRow/RunListItem.tsx
@@ -116,21 +116,29 @@ const RunListItem = ({ runId }: { runId: number }) => {
               {" "}
               {statusCounts.succeeded} succeeded
             </span>
-            ,
             {statusCounts.failed > 0 && (
               <span className="text-red-500">
-                {" "}
-                {statusCounts.failed} failed
+                <span className="text-black">,</span> {statusCounts.failed}{" "}
+                failed
               </span>
             )}
             {statusCounts.running > 0 && (
               <span className="text-blue-500">
-                {" "}
-                {statusCounts.running} running
+                <span className="text-black">,</span> {statusCounts.running}{" "}
+                running
               </span>
             )}
-            {statusCounts.pending > 0 && (
-              <span> {statusCounts.pending} pending</span>
+            {statusCounts.skipped > 0 && (
+              <span className="text-gray-800">
+                <span className="text-black">,</span> {statusCounts.skipped}{" "}
+                skipped
+              </span>
+            )}
+            {statusCounts.waiting > 0 && (
+              <span className="text-gray-500">
+                <span className="text-black">,</span> {statusCounts.waiting}{" "}
+                waiting
+              </span>
             )}
           </div>
         )}

--- a/src/components/PipelineRow/StatusIcon.tsx
+++ b/src/components/PipelineRow/StatusIcon.tsx
@@ -1,4 +1,4 @@
-import { CircleAlert, CircleCheck, RefreshCcw } from "lucide-react";
+import { CircleAlert, CircleCheck, CircleHelp, RefreshCcw } from "lucide-react";
 
 const StatusIcon = ({ status }: { status?: string }) => {
   switch (status) {
@@ -15,7 +15,7 @@ const StatusIcon = ({ status }: { status?: string }) => {
     case "CANCELLING":
       return <RefreshCcw className="w-4 h-4 text-blue-500 animate-spin" />;
     default:
-      return <RefreshCcw className="w-4 h-4 text-blue-500 animate-spin" />;
+      return <CircleHelp className="w-4 h-4 text-orange-500" />;
   }
 };
 

--- a/src/components/PipelineRow/StatusIcon.tsx
+++ b/src/components/PipelineRow/StatusIcon.tsx
@@ -1,4 +1,10 @@
-import { CircleAlert, CircleCheck, CircleHelp, RefreshCcw } from "lucide-react";
+import {
+  CircleAlert,
+  CircleCheck,
+  CircleEllipsis,
+  CircleHelp,
+  RefreshCcw,
+} from "lucide-react";
 
 const StatusIcon = ({ status }: { status?: string }) => {
   switch (status) {
@@ -14,6 +20,8 @@ const StatusIcon = ({ status }: { status?: string }) => {
     case "STARTING":
     case "CANCELLING":
       return <RefreshCcw className="w-4 h-4 text-blue-500 animate-spin" />;
+    case "WAITING":
+      return <CircleEllipsis className="w-4 h-4 text-gray-500" />;
     default:
       return <CircleHelp className="w-4 h-4 text-orange-500" />;
   }

--- a/src/components/PipelineRow/TaskStatusBar.tsx
+++ b/src/components/PipelineRow/TaskStatusBar.tsx
@@ -11,13 +11,14 @@ const TaskStatusBar = ({
     );
   }
 
-  const { total, succeeded, failed, running, pending } = statusCounts;
+  const { total, succeeded, failed, running, waiting, skipped } = statusCounts;
 
   // Calculate percentages for each segment
   const successWidth = `${(succeeded / total) * 100}%`;
   const failedWidth = `${(failed / total) * 100}%`;
   const runningWidth = `${(running / total) * 100}%`;
-  const pendingWidth = `${(pending / total) * 100}%`;
+  const waitingWidth = `${(waiting / total) * 100}%`;
+  const skippedWidth = `${(skipped / total) * 100}%`;
 
   return (
     <div className="flex h-2 w-full rounded overflow-hidden bg-gray-200">
@@ -30,8 +31,11 @@ const TaskStatusBar = ({
       {running > 0 && (
         <div className="bg-blue-500" style={{ width: runningWidth }}></div>
       )}
-      {pending > 0 && (
-        <div className="bg-gray-200" style={{ width: pendingWidth }}></div>
+      {waiting > 0 && (
+        <div className="bg-gray-200" style={{ width: waitingWidth }}></div>
+      )}
+      {skipped > 0 && (
+        <div className="bg-gray-800" style={{ width: skippedWidth }}></div>
       )}
     </div>
   );

--- a/src/components/PipelineRow/index.tsx
+++ b/src/components/PipelineRow/index.tsx
@@ -20,7 +20,7 @@ import {
   type PipelineRun,
   type TaskStatusCounts,
 } from "./types";
-import { countTaskStatuses } from "./utils";
+import { countTaskStatuses, formatDate, getRunStatus } from "./utils";
 
 const PipelineRow = ({ url, componentRef, name }: PipelineRowProps) => {
   const [rowData, setRowData] = useState<any>(null);
@@ -177,20 +177,30 @@ const PipelineRow = ({ url, componentRef, name }: PipelineRowProps) => {
     },
   };
 
+  if (latestRun) {
+    const statusData = runTaskStatuses[latestRun.id];
+    if (statusData) {
+      latestRun.status = getRunStatus(statusData);
+    }
+  }
+
   return (
     <TableRow onClick={handleOpenInEditor} className="cursor-pointer">
       <TableCell className="text-sm">
         <Link {...LinkProps}>{displayName}</Link>
       </TableCell>
-
-      <TableCell>
-        {latestRun && runTaskStatuses[latestRun.id] && (
-          <StatusIcon status={latestRun.status} />
-        )}
-      </TableCell>
-      <TableCell className="text-gray-500 text-xs">0:12:38</TableCell>
       <TableCell className="text-gray-500 text-xs">
-        3/20/2025 12:00:00
+        {latestRun ? (
+          <div className="flex items-center gap-1">
+            {latestRun && runTaskStatuses[latestRun.id] && (
+              <StatusIcon status={latestRun.status} />
+            )}
+            <p>{formatDate(latestRun.created_at)}</p>
+            {/* <p>{`(ran for 0h:12m:38s)`}</p> */}
+          </div>
+        ) : (
+          "None"
+        )}
       </TableCell>
       <TableCell>
         {pipelineRuns.length > 0 && (

--- a/src/components/PipelineRow/types.ts
+++ b/src/components/PipelineRow/types.ts
@@ -1,12 +1,3 @@
-export interface PipelineRun {
-  id: number;
-  root_execution_id: number;
-  created_at: string;
-  pipeline_name: string;
-  pipeline_digest?: string;
-  status?: string;
-}
-
 export interface TaskStatusCounts {
   total: number;
   succeeded: number;

--- a/src/components/PipelineRow/types.ts
+++ b/src/components/PipelineRow/types.ts
@@ -3,7 +3,8 @@ export interface TaskStatusCounts {
   succeeded: number;
   failed: number;
   running: number;
-  pending: number;
+  waiting: number;
+  skipped: number;
 }
 
 export interface PipelineRowProps {

--- a/src/components/PipelineRow/utils.ts
+++ b/src/components/PipelineRow/utils.ts
@@ -10,7 +10,7 @@ import { type TaskStatusCounts } from "./types";
  */
 export const countTaskStatuses = (
   details: GetExecutionInfoResponse,
-  stateData: GetGraphExecutionStateResponse,
+  stateData: GetGraphExecutionStateResponse
 ): TaskStatusCounts => {
   let succeeded = 0,
     failed = 0,
@@ -54,6 +54,25 @@ export const countTaskStatuses = (
 
   const total = succeeded + failed + running + pending;
   return { total, succeeded, failed, running, pending };
+};
+
+/**
+ * Determine the overall run status based on the task statuses.
+ */
+export const getRunStatus = (statusData: TaskStatusCounts) => {
+  if (statusData.failed > 0) {
+    return "FAILED";
+  }
+  if (statusData.running > 0) {
+    return "RUNNING";
+  }
+  if (statusData.pending > 0) {
+    return "PENDING";
+  }
+  if (statusData.succeeded > 0) {
+    return "SUCCEEDED";
+  }
+  return "UNKNOWN";
 };
 
 /**

--- a/src/components/PipelineRow/utils.ts
+++ b/src/components/PipelineRow/utils.ts
@@ -10,7 +10,7 @@ import { type TaskStatusCounts } from "./types";
  */
 export const countTaskStatuses = (
   details: GetExecutionInfoResponse,
-  stateData: GetGraphExecutionStateResponse
+  stateData: GetGraphExecutionStateResponse,
 ): TaskStatusCounts => {
   let succeeded = 0,
     failed = 0,
@@ -59,20 +59,28 @@ export const countTaskStatuses = (
 /**
  * Determine the overall run status based on the task statuses.
  */
+const STATUS = {
+  FAILED: "FAILED",
+  RUNNING: "RUNNING",
+  SUCCEEDED: "SUCCEEDED",
+  PENDING: "PENDING",
+  UNKNOWN: "UNKNOWN",
+} as const;
+
 export const getRunStatus = (statusData: TaskStatusCounts) => {
   if (statusData.failed > 0) {
-    return "FAILED";
+    return STATUS.FAILED;
   }
   if (statusData.running > 0) {
-    return "RUNNING";
+    return STATUS.RUNNING;
   }
   if (statusData.pending > 0) {
-    return "PENDING";
+    return STATUS.PENDING;
   }
   if (statusData.succeeded > 0) {
-    return "SUCCEEDED";
+    return STATUS.SUCCEEDED;
   }
-  return "UNKNOWN";
+  return STATUS.UNKNOWN;
 };
 
 /**

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -108,8 +108,6 @@ const Home = () => {
               <TableHeader>
                 <TableRow className="text-xs">
                   <TableHead>Title</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead>Duration</TableHead>
                   <TableHead>Last run</TableHead>
                   <TableHead>Runs</TableHead>
                 </TableRow>

--- a/src/utils/fetchPipelineRuns.ts
+++ b/src/utils/fetchPipelineRuns.ts
@@ -1,0 +1,43 @@
+import localForage from "localforage";
+
+export interface PipelineRun {
+  id: number;
+  root_execution_id: number;
+  created_at: string;
+  pipeline_name: string;
+  pipeline_digest?: string;
+  status?: string;
+}
+
+export const fetchPipelineRuns = async (pipelineName: string) => {
+  try {
+    const pipelineRunsDb = localForage.createInstance({
+      name: "components",
+      storeName: "pipeline_runs",
+    });
+
+    const runs: PipelineRun[] = [];
+    let latestRun: PipelineRun | null = null;
+    let latestDate = new Date(0);
+
+    await pipelineRunsDb.iterate<PipelineRun, void>((run) => {
+      if (run.pipeline_name === pipelineName) {
+        runs.push(run);
+        const runDate = new Date(run.created_at);
+        if (runDate > latestDate) {
+          latestDate = runDate;
+          latestRun = run;
+        }
+      }
+    });
+
+    runs.sort(
+      (a, b) =>
+        new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+    );
+
+    return { runs, latestRun };
+  } catch (error) {
+    console.error("Error fetching pipeline runs:", error);
+  }
+};


### PR DESCRIPTION
Addresses items on https://github.com/Shopify/oasis-frontend/issues/9 and https://github.com/Cloud-Pipelines/pipeline-studio-app/issues/105

- Condenses the "latest run" on the Pipeline Row into one cell, adds the run creation date and hides the hardcoded placeholder run duration.
![image](https://github.com/user-attachments/assets/1fd596e6-2181-4553-84a0-63cb9992d4bc)

- Displays the run creation date on the run list
![image](https://github.com/user-attachments/assets/3aaa0ca6-a826-4485-aab9-8d42d64bc2c6)

- Replaces the loading spinner with a warning triangle on runs with no status
- A little bit of refactoring/reorganization to facilitate the above two items. (mostly moving shared methods and run status calculation to a new, shared, method)


