### PR TITLE
Convert Run List into Table

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,8 +26,8 @@ export default [
           varsIgnorePattern: "^_",
         },
       ],
-      "simple-import-sort/imports": "error",
-      "simple-import-sort/exports": "error",
+      "simple-import-sort/imports": "warn",
+      "simple-import-sort/exports": "warn",
     },
     plugins: {
       "simple-import-sort": simpleImportSort,

--- a/src/components/PipelineRow/RunListItem.tsx
+++ b/src/components/PipelineRow/RunListItem.tsx
@@ -26,11 +26,11 @@ const RunListItem = ({ runId }: { runId: number }) => {
     queryKey: ["pipeline-run-details", runId],
     queryFn: async () => {
       const response = await fetch(
-        `${API_URL}/api/executions/${runId}/details`,
+        `${API_URL}/api/executions/${runId}/details`
       );
       if (!response.ok) {
         throw new Error(
-          `Failed to fetch execution details: ${response.statusText}`,
+          `Failed to fetch execution details: ${response.statusText}`
         );
       }
       return response.json();
@@ -47,7 +47,7 @@ const RunListItem = ({ runId }: { runId: number }) => {
       const response = await fetch(`${API_URL}/api/executions/${runId}/state`);
       if (!response.ok) {
         throw new Error(
-          `Failed to fetch execution state: ${response.statusText}`,
+          `Failed to fetch execution state: ${response.statusText}`
         );
       }
       return response.json();
@@ -107,6 +107,12 @@ const RunListItem = ({ runId }: { runId: number }) => {
             <>
               <span>•</span>
               <span className="text-gray-500 text-xs">{`${formatDate(metadata.created_at)}`}</span>
+              {metadata.created_by && (
+                <>
+                  <span className="text-2xs">• Initated by</span>
+                  <span className="text-2xs">{`${metadata.created_by}`}</span>
+                </>
+              )}
             </>
           )}
         </div>

--- a/src/components/PipelineRow/RunListItem.tsx
+++ b/src/components/PipelineRow/RunListItem.tsx
@@ -26,11 +26,11 @@ const RunListItem = ({ runId }: { runId: number }) => {
     queryKey: ["pipeline-run-details", runId],
     queryFn: async () => {
       const response = await fetch(
-        `${API_URL}/api/executions/${runId}/details`
+        `${API_URL}/api/executions/${runId}/details`,
       );
       if (!response.ok) {
         throw new Error(
-          `Failed to fetch execution details: ${response.statusText}`
+          `Failed to fetch execution details: ${response.statusText}`,
         );
       }
       return response.json();
@@ -47,7 +47,7 @@ const RunListItem = ({ runId }: { runId: number }) => {
       const response = await fetch(`${API_URL}/api/executions/${runId}/state`);
       if (!response.ok) {
         throw new Error(
-          `Failed to fetch execution state: ${response.statusText}`
+          `Failed to fetch execution state: ${response.statusText}`,
         );
       }
       return response.json();

--- a/src/components/PipelineRow/StatusText.tsx
+++ b/src/components/PipelineRow/StatusText.tsx
@@ -1,0 +1,46 @@
+import type { TaskStatusCounts } from "./types";
+
+const StatusText = ({
+  statusCounts,
+  shorthand,
+}: {
+  statusCounts: TaskStatusCounts;
+  shorthand?: boolean;
+}) => {
+  return (
+    <div className="text-xs text-gray-500 mt-1">
+      {Object.entries(statusCounts).map(([key, count]) => {
+        if (key === "total") return;
+
+        if (count > 0) {
+          const statusColors: Record<string, string> = {
+            succeeded: "text-green-500",
+            failed: "text-red-500",
+            running: "text-blue-500",
+            skipped: "text-gray-800",
+            waiting: "text-gray-500",
+          };
+          const statusText = shorthand
+            ? `${key[0]}`
+            : `${key}${count > 1 ? " " : ""}`;
+
+          return (
+            <span key={key}>
+              <span className={statusColors[key]}>
+                {count}
+                {shorthand ? statusText : ` ${statusText.trim()}`}
+              </span>
+              {!shorthand && count > 1 && (
+                <span className="text-black">, </span>
+              )}
+              {shorthand && <span> </span>}
+            </span>
+          );
+        }
+        return null;
+      })}
+    </div>
+  );
+};
+
+export default StatusText;

--- a/src/components/PipelineRow/index.tsx
+++ b/src/components/PipelineRow/index.tsx
@@ -188,7 +188,7 @@ const PipelineRow = ({ url, componentRef, name }: PipelineRowProps) => {
                 {pipelineRuns.map((run) => (
                   <RunListItem
                     key={run.root_execution_id}
-                    runId={run.root_execution_id}
+                    runId={`${run.root_execution_id}`}
                   />
                 ))}
               </ScrollArea>

--- a/src/components/PipelineSection/PipelineSection.tsx
+++ b/src/components/PipelineSection/PipelineSection.tsx
@@ -1,4 +1,5 @@
 import { Terminal } from "lucide-react";
+import { useEffect, useState } from "react";
 
 import NewExperimentDialog from "@/components/NewExperiment";
 import PipelineRow from "@/components/PipelineRow";
@@ -11,19 +12,42 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { type ComponentFileEntry } from "@/componentStore";
+import {
+  type ComponentFileEntry,
+  getAllComponentFilesFromList,
+} from "@/componentStore";
+import { USER_PIPELINES_LIST_NAME } from "@/utils/constants";
+
+import { Button } from "../ui/button";
 
 export type Pipelines = Map<string, ComponentFileEntry>;
 
-interface PipelineSectionProps {
-  pipelines: Pipelines;
-  isLoading?: boolean;
-}
+export const PipelineSection = () => {
+  const [pipelines, setPipelines] = useState<Pipelines>(new Map());
+  const [isLoading, setIsLoading] = useState(false);
 
-export const PipelineSection = ({
-  pipelines,
-  isLoading,
-}: PipelineSectionProps) => {
+  useEffect(() => {
+    fetchUserPipelines();
+  }, []);
+
+  const fetchUserPipelines = async () => {
+    setIsLoading(true);
+    try {
+      const pipelines = await getAllComponentFilesFromList(
+        USER_PIPELINES_LIST_NAME
+      );
+      setPipelines(pipelines);
+    } catch (error) {
+      console.error("Failed to load user pipelines:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const refreshAll = () => {
+    fetchUserPipelines();
+  };
+
   if (isLoading) {
     return (
       <div className="flex gap-2 items-center">
@@ -73,6 +97,10 @@ export const PipelineSection = ({
           </TableBody>
         </Table>
       )}
+
+      <Button onClick={refreshAll} className="mt-6 max-w-96">
+        Refresh
+      </Button>
     </div>
   );
 };

--- a/src/components/PipelineSection/PipelineSection.tsx
+++ b/src/components/PipelineSection/PipelineSection.tsx
@@ -34,7 +34,7 @@ export const PipelineSection = () => {
     setIsLoading(true);
     try {
       const pipelines = await getAllComponentFilesFromList(
-        USER_PIPELINES_LIST_NAME
+        USER_PIPELINES_LIST_NAME,
       );
       setPipelines(pipelines);
     } catch (error) {

--- a/src/components/PipelineSection/PipelineSection.tsx
+++ b/src/components/PipelineSection/PipelineSection.tsx
@@ -1,0 +1,78 @@
+import { Terminal } from "lucide-react";
+
+import NewExperimentDialog from "@/components/NewExperiment";
+import PipelineRow from "@/components/PipelineRow";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Table,
+  TableBody,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { type ComponentFileEntry } from "@/componentStore";
+
+export type Pipelines = Map<string, ComponentFileEntry>;
+
+interface PipelineSectionProps {
+  pipelines: Pipelines;
+  isLoading?: boolean;
+}
+
+export const PipelineSection = ({
+  pipelines,
+  isLoading,
+}: PipelineSectionProps) => {
+  if (isLoading) {
+    return (
+      <div className="flex gap-2 items-center">
+        <Spinner /> Loading...
+      </div>
+    );
+  }
+
+  if (pipelines.size === 0) {
+    return (
+      <div>
+        <p>No pipelines found.</p>
+        <NewExperimentDialog />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <Alert variant="destructive">
+        <Terminal className="h-4 w-4" />
+        <AlertTitle>Heads up!</AlertTitle>
+        <AlertDescription>
+          Your pipelines are stored in your browser&apos;s local storage.
+          Clearing your browser data or cookies will delete all saved pipelines.
+          Consider exporting important pipelines to files for backup.
+        </AlertDescription>
+      </Alert>
+
+      {pipelines.size > 0 && (
+        <Table>
+          <TableHeader>
+            <TableRow className="text-xs">
+              <TableHead>Title</TableHead>
+              <TableHead>Last run</TableHead>
+              <TableHead>Runs</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {Array.from(pipelines.entries()).map(([name, fileEntry]) => (
+              <PipelineRow
+                key={fileEntry.componentRef.digest}
+                componentRef={fileEntry.componentRef}
+                name={name.replace(/_/g, " ")}
+              />
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+};

--- a/src/components/PipelineSection/index.ts
+++ b/src/components/PipelineSection/index.ts
@@ -1,0 +1,1 @@
+export * from "./PipelineSection";

--- a/src/components/RunSection/RunRow.tsx
+++ b/src/components/RunSection/RunRow.tsx
@@ -76,17 +76,26 @@ const RunRow = ({ runId }: { runId: string }) => {
   }, [name]);
 
   if (isDetailsLoading || isStateLoading) {
-    return <div>Loading...</div>;
+    return (
+      <TableRow>
+        <TableCell colSpan={4}>Loading...</TableCell>
+      </TableRow>
+    );
   }
 
   if (detailsError || stateError || !details || !state) {
     return (
-      <div className="flex flex-col p-2 text-sm text-red-500">
-        <span>Error loading run details</span>
-        <span className="text-xs">
-          {detailsError?.message || stateError?.message}
-        </span>
-      </div>
+      <TableRow>
+        <TableCell
+          colSpan={4}
+          className="flex flex-col p-2 text-sm text-red-500"
+        >
+          <span>Error loading run details</span>
+          <span className="text-xs">
+            {detailsError?.message || stateError?.message}
+          </span>
+        </TableCell>
+      </TableRow>
     );
   }
 

--- a/src/components/RunSection/RunSection.tsx
+++ b/src/components/RunSection/RunSection.tsx
@@ -3,10 +3,18 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useState } from "react";
 
 import type { ListPipelineJobsResponse } from "@/api/types.gen";
-import RunListItem from "@/components/PipelineRow/RunListItem";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { API_URL } from "@/utils/constants";
+
+import {
+  Table,
+  TableBody,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../ui/table";
+import RunRow from "./RunRow";
 
 export const RunSection = () => {
   const [pageToken, setPageToken] = useState<string | undefined>();
@@ -59,14 +67,26 @@ export const RunSection = () => {
 
   return (
     <div>
-      {data?.pipeline_runs?.map((run) => (
-        <RunListItem
-          key={run.root_execution_id}
-          runId={run.root_execution_id}
-        />
-      ))}
+      <Table>
+        <TableHeader>
+          <TableRow className="text-xs">
+            <TableHead className="w-1/3">Name</TableHead>
+            <TableHead className="w-1/3">Status</TableHead>
+            <TableHead className="w-1/6">Date</TableHead>
+            <TableHead className="w-1/6">Initiated By</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {data.pipeline_runs?.map((run) => (
+            <RunRow
+              key={run.root_execution_id}
+              runId={`${run.root_execution_id}`}
+            />
+          ))}
+        </TableBody>
+      </Table>
 
-      {(data?.next_page_token || previousPageTokens.length > 0) && (
+      {(data.next_page_token || previousPageTokens.length > 0) && (
         <div className="flex justify-between items-center mt-4">
           <Button
             variant="outline"

--- a/src/components/RunSection/RunSection.tsx
+++ b/src/components/RunSection/RunSection.tsx
@@ -1,0 +1,91 @@
+import { useQuery } from "@tanstack/react-query";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useState } from "react";
+
+import type { ListPipelineJobsResponse } from "@/api/types.gen";
+import RunListItem from "@/components/PipelineRow/RunListItem";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { API_URL } from "@/utils/constants";
+
+export const RunSection = () => {
+  const [pageToken, setPageToken] = useState<string | undefined>();
+  const [previousPageTokens, setPreviousPageTokens] = useState<string[]>([]);
+
+  const { data, isLoading } = useQuery<ListPipelineJobsResponse>({
+    queryKey: ["runs", pageToken],
+    queryFn: async () => {
+      const pageTokenParam = pageToken ? `?page_token=${pageToken}` : "";
+      const url = `${API_URL}/api/pipeline_runs/${pageTokenParam}`;
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(
+          `Failed to fetch pipeline runs: ${response.statusText}`,
+        );
+      }
+
+      return response.json();
+    },
+  });
+
+  const handleNextPage = () => {
+    if (data?.next_page_token) {
+      setPreviousPageTokens([...previousPageTokens, pageToken || ""]);
+      setPageToken(data.next_page_token);
+    }
+  };
+
+  const handlePreviousPage = () => {
+    const previousToken = previousPageTokens[previousPageTokens.length - 1];
+    setPreviousPageTokens(previousPageTokens.slice(0, -1));
+    setPageToken(previousToken);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex gap-2 items-center">
+        <Spinner /> Loading...
+      </div>
+    );
+  }
+
+  if (!data) {
+    return <div>Failed to load runs.</div>;
+  }
+
+  if (!data?.pipeline_runs || data?.pipeline_runs?.length === 0) {
+    return <div>No runs found. Run a pipeline to see it here.</div>;
+  }
+
+  return (
+    <div>
+      {data?.pipeline_runs?.map((run) => (
+        <RunListItem
+          key={run.root_execution_id}
+          runId={run.root_execution_id}
+        />
+      ))}
+
+      {(data?.next_page_token || previousPageTokens.length > 0) && (
+        <div className="flex justify-between items-center mt-4">
+          <Button
+            variant="outline"
+            onClick={handlePreviousPage}
+            disabled={previousPageTokens.length === 0}
+          >
+            <ChevronLeft className="h-4 w-4 mr-2" />
+            Previous
+          </Button>
+          <Button
+            variant="outline"
+            onClick={handleNextPage}
+            disabled={!data?.next_page_token}
+          >
+            Next
+            <ChevronRight className="h-4 w-4 ml-2" />
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/RunSection/index.ts
+++ b/src/components/RunSection/index.ts
@@ -1,0 +1,1 @@
+export * from "./RunSection";

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -1,19 +1,16 @@
 import { useQuery } from "@tanstack/react-query";
 import { ChevronLeft, ChevronRight } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import type { ListPipelineJobsResponse } from "@/api/types.gen";
 import RunListItem from "@/components/PipelineRow/RunListItem";
-import { type Pipelines, PipelineSection } from "@/components/PipelineSection";
+import { PipelineSection } from "@/components/PipelineSection";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { getAllComponentFilesFromList } from "@/componentStore";
-import { API_URL, USER_PIPELINES_LIST_NAME } from "@/utils/constants";
+import { API_URL } from "@/utils/constants";
 
 const Home = () => {
-  const [userPipelines, setUserPipelines] = useState<Pipelines>(new Map());
-  const [isLoadingUserPipelines, setIsLoadingUserPipelines] = useState(false);
   const [pageToken, setPageToken] = useState<string | undefined>();
   const [previousPageTokens, setPreviousPageTokens] = useState<string[]>([]);
 
@@ -26,7 +23,7 @@ const Home = () => {
         const response = await fetch(url);
         if (!response.ok) {
           throw new Error(
-            `Failed to fetch pipeline runs: ${response.statusText}`,
+            `Failed to fetch pipeline runs: ${response.statusText}`
           );
         }
 
@@ -47,35 +44,10 @@ const Home = () => {
     setPageToken(previousToken);
   };
 
-  useEffect(() => {
-    fetchUserPipelines();
-  }, []);
-
-  const fetchUserPipelines = async () => {
-    setIsLoadingUserPipelines(true);
-    try {
-      const pipelines = await getAllComponentFilesFromList(
-        USER_PIPELINES_LIST_NAME,
-      );
-      setUserPipelines(pipelines);
-    } catch (error) {
-      console.error("Failed to load user pipelines:", error);
-    } finally {
-      setIsLoadingUserPipelines(false);
-    }
-  };
-
-  const refreshAll = () => {
-    fetchUserPipelines();
-  };
-
   return (
     <div className="container mx-auto w-3/4 p-4 flex flex-col gap-4">
       <div className="flex justify-between items-center">
         <h1 className="text-2xl font-bold">Pipelines</h1>
-        <Button onClick={refreshAll} className="mt-6 max-w-96">
-          Refresh
-        </Button>
       </div>
       <Tabs defaultValue="runs" className="w-full">
         <TabsList>
@@ -83,10 +55,7 @@ const Home = () => {
           <TabsTrigger value="pipelines">My pipelines</TabsTrigger>
         </TabsList>
         <TabsContent value="pipelines">
-          <PipelineSection
-            pipelines={userPipelines}
-            isLoading={isLoadingUserPipelines}
-          />
+          <PipelineSection />
         </TabsContent>
         <TabsContent value="runs" className="flex flex-col gap-1">
           {isLoadingUserRuns && (

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -1,49 +1,8 @@
-import { useQuery } from "@tanstack/react-query";
-import { ChevronLeft, ChevronRight } from "lucide-react";
-import { useState } from "react";
-
-import type { ListPipelineJobsResponse } from "@/api/types.gen";
-import RunListItem from "@/components/PipelineRow/RunListItem";
 import { PipelineSection } from "@/components/PipelineSection";
-import { Button } from "@/components/ui/button";
-import { Spinner } from "@/components/ui/spinner";
+import { RunSection } from "@/components/RunSection";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { API_URL } from "@/utils/constants";
 
 const Home = () => {
-  const [pageToken, setPageToken] = useState<string | undefined>();
-  const [previousPageTokens, setPreviousPageTokens] = useState<string[]>([]);
-
-  const { data, isLoading: isLoadingUserRuns } =
-    useQuery<ListPipelineJobsResponse>({
-      queryKey: ["runs", pageToken],
-      queryFn: async () => {
-        const pageTokenParam = pageToken ? `?page_token=${pageToken}` : "";
-        const url = `${API_URL}/api/pipeline_runs/${pageTokenParam}`;
-        const response = await fetch(url);
-        if (!response.ok) {
-          throw new Error(
-            `Failed to fetch pipeline runs: ${response.statusText}`
-          );
-        }
-
-        return response.json();
-      },
-    });
-
-  const handleNextPage = () => {
-    if (data?.next_page_token) {
-      setPreviousPageTokens([...previousPageTokens, pageToken || ""]);
-      setPageToken(data.next_page_token);
-    }
-  };
-
-  const handlePreviousPage = () => {
-    const previousToken = previousPageTokens[previousPageTokens.length - 1];
-    setPreviousPageTokens(previousPageTokens.slice(0, -1));
-    setPageToken(previousToken);
-  };
-
   return (
     <div className="container mx-auto w-3/4 p-4 flex flex-col gap-4">
       <div className="flex justify-between items-center">
@@ -58,44 +17,7 @@ const Home = () => {
           <PipelineSection />
         </TabsContent>
         <TabsContent value="runs" className="flex flex-col gap-1">
-          {isLoadingUserRuns && (
-            <div className="flex gap-2 items-center">
-              <Spinner /> Loading...
-            </div>
-          )}
-
-          {!isLoadingUserRuns &&
-            (!data?.pipeline_runs || data?.pipeline_runs?.length === 0) && (
-              <div>No runs found. Run a pipeline to see it here.</div>
-            )}
-
-          {data?.pipeline_runs?.map((run) => (
-            <RunListItem
-              key={run.root_execution_id}
-              runId={run.root_execution_id}
-            />
-          ))}
-
-          {(data?.next_page_token || previousPageTokens.length > 0) && (
-            <div className="flex justify-between items-center mt-4">
-              <Button
-                variant="outline"
-                onClick={handlePreviousPage}
-                disabled={previousPageTokens.length === 0}
-              >
-                <ChevronLeft className="h-4 w-4 mr-2" />
-                Previous
-              </Button>
-              <Button
-                variant="outline"
-                onClick={handleNextPage}
-                disabled={!data?.next_page_token}
-              >
-                Next
-                <ChevronRight className="h-4 w-4 ml-2" />
-              </Button>
-            </div>
-          )}
+          <RunSection />
         </TabsContent>
       </Tabs>
     </div>

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -1,32 +1,18 @@
 import { useQuery } from "@tanstack/react-query";
-import { ChevronLeft, ChevronRight, Terminal } from "lucide-react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import type { ListPipelineJobsResponse } from "@/api/types.gen";
-import NewExperimentDialog from "@/components/NewExperiment";
-import PipelineRow from "@/components/PipelineRow";
 import RunListItem from "@/components/PipelineRow/RunListItem";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { type Pipelines, PipelineSection } from "@/components/PipelineSection";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
-import {
-  Table,
-  TableBody,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import {
-  type ComponentFileEntry,
-  getAllComponentFilesFromList,
-} from "@/componentStore";
+import { getAllComponentFilesFromList } from "@/componentStore";
 import { API_URL, USER_PIPELINES_LIST_NAME } from "@/utils/constants";
 
 const Home = () => {
-  const [userPipelines, setUserPipelines] = useState<
-    Map<string, ComponentFileEntry>
-  >(new Map());
+  const [userPipelines, setUserPipelines] = useState<Pipelines>(new Map());
   const [isLoadingUserPipelines, setIsLoadingUserPipelines] = useState(false);
   const [pageToken, setPageToken] = useState<string | undefined>();
   const [previousPageTokens, setPreviousPageTokens] = useState<string[]>([]);
@@ -85,59 +71,22 @@ const Home = () => {
 
   return (
     <div className="container mx-auto w-3/4 p-4 flex flex-col gap-4">
-      <h1 className="text-2xl font-bold">Pipelines</h1>
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold">Pipelines</h1>
+        <Button onClick={refreshAll} className="mt-6 max-w-96">
+          Refresh
+        </Button>
+      </div>
       <Tabs defaultValue="runs" className="w-full">
         <TabsList>
           <TabsTrigger value="runs">All Runs</TabsTrigger>
           <TabsTrigger value="pipelines">My pipelines</TabsTrigger>
         </TabsList>
         <TabsContent value="pipelines">
-          <Alert variant="destructive">
-            <Terminal className="h-4 w-4" />
-            <AlertTitle>Heads up!</AlertTitle>
-            <AlertDescription>
-              Your pipelines are stored in your browser&apos;s local storage.
-              Clearing your browser data or cookies will delete all saved
-              pipelines. Consider exporting important pipelines to files for
-              backup.
-            </AlertDescription>
-          </Alert>
-
-          {isLoadingUserPipelines && (
-            <div className="flex gap-2 items-center">
-              <Spinner /> Loading...
-            </div>
-          )}
-
-          {!isLoadingUserPipelines && userPipelines.size === 0 && (
-            <div>
-              <p>No pipelines found.</p>
-              <NewExperimentDialog />
-            </div>
-          )}
-
-          {userPipelines.size > 0 && (
-            <Table>
-              <TableHeader>
-                <TableRow className="text-xs">
-                  <TableHead>Title</TableHead>
-                  <TableHead>Last run</TableHead>
-                  <TableHead>Runs</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {Array.from(userPipelines.entries()).map(
-                  ([name, fileEntry]) => (
-                    <PipelineRow
-                      key={fileEntry.componentRef.digest}
-                      componentRef={fileEntry.componentRef}
-                      name={name.replace(/_/g, " ")}
-                    />
-                  ),
-                )}
-              </TableBody>
-            </Table>
-          )}
+          <PipelineSection
+            pipelines={userPipelines}
+            isLoading={isLoadingUserPipelines}
+          />
         </TabsContent>
         <TabsContent value="runs" className="flex flex-col gap-1">
           {isLoadingUserRuns && (
@@ -180,10 +129,6 @@ const Home = () => {
           )}
         </TabsContent>
       </Tabs>
-
-      <Button onClick={refreshAll} className="mt-6 max-w-96">
-        Refresh
-      </Button>
     </div>
   );
 };

--- a/src/utils/fetchPipelineRuns.ts
+++ b/src/utils/fetchPipelineRuns.ts
@@ -4,6 +4,7 @@ export interface PipelineRun {
   id: number;
   root_execution_id: number;
   created_at: string;
+  created_by: string;
   pipeline_name: string;
   pipeline_digest?: string;
   status?: string;
@@ -33,7 +34,7 @@ export const fetchPipelineRuns = async (pipelineName: string) => {
 
     runs.sort(
       (a, b) =>
-        new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+        new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
     );
 
     return { runs, latestRun };

--- a/src/utils/fetchPipelineRuns.ts
+++ b/src/utils/fetchPipelineRuns.ts
@@ -34,7 +34,7 @@ export const fetchPipelineRuns = async (pipelineName: string) => {
 
     runs.sort(
       (a, b) =>
-        new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+        new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
     );
 
     return { runs, latestRun };


### PR DESCRIPTION
Closes https://github.com/Cloud-Pipelines/pipeline-studio-app/issues/105

Converts the Run list into a Table, and adds `created_by` info, if available.

This requires a bit of reorganization and refactoring of the Home page (+ separation of concerns).

- Pipeline Tab React code moved into its own PipelineSection, including supporting methods.
- Refresh button was only being used for Pipelines, so this is no longer available in the Run Tab.
- Run Tab React code moved into its own RunSection, including supporting methods.
- Run Tab now display information in a Table.
- Run Status bar is no longer the width of the entire screen.
- Shorthand variant added to Run StatusText, creating a more condensed string. This is now used in RunList which is now exclusively used in the Pipeline Section run list.

Tangentially related:

- RunId is now expected to be a string, not a number.
- Import sorting switched to "Warn" not "Error"