### PR TITLE
We now prompt the user to rename their cloned pipeline

### DIFF
--- a/src/components/CloneRunButton.tsx
+++ b/src/components/CloneRunButton.tsx
@@ -6,6 +6,7 @@ import { type RunDetailParams, runDetailRoute } from "@/router";
 import { RUNS_BASE_PATH } from "@/utils/constants";
 import { copyRunToPipeline } from "@/utils/copyRunToPipeline";
 
+import { PipelineNameDialog } from "./shared/PipelineNameDialog";
 import { Button } from "./ui/button";
 
 const CloneRunButtonInner = () => {
@@ -14,13 +15,13 @@ const CloneRunButtonInner = () => {
     useLoadComponentSpecAndDetailsFromId(id);
   const navigate = useNavigate();
 
-  const handleClone = async () => {
+  const handleClone = async (name: string) => {
     if (!componentSpec) {
       console.error("No component spec found");
       return;
     }
 
-    const result = await copyRunToPipeline(componentSpec);
+    const result = await copyRunToPipeline(componentSpec, name);
     if (result?.url) {
       navigate({ to: result.url });
     } else {
@@ -36,10 +37,31 @@ const CloneRunButtonInner = () => {
     );
   }
 
+  const getInitialName = () => {
+    const dateTime = new Date().toISOString();
+    return componentSpec?.name
+      ? `${componentSpec.name} (${dateTime})`
+      : `Pipeline ${dateTime}`;
+  };
+
+  const isSubmitDisabled = (name: string) => {
+    return name === componentSpec?.name;
+  };
+
   return (
-    <Button variant="outline" onClick={handleClone} className="cursor-pointer">
-      <CopyIcon /> Clone Run
-    </Button>
+    <PipelineNameDialog
+      trigger={
+        <Button variant="outline" className="cursor-pointer">
+          Clone Pipeline
+        </Button>
+      }
+      title="Clone Pipeline"
+      initialName={getInitialName()}
+      onSubmit={handleClone}
+      submitButtonText="Clone Run"
+      submitButtonIcon={<CopyIcon />}
+      isSubmitDisabled={isSubmitDisabled}
+    />
   );
 };
 

--- a/src/components/NewExperiment.tsx
+++ b/src/components/NewExperiment.tsx
@@ -1,25 +1,8 @@
 import { useNavigate } from "@tanstack/react-router";
-import { AlertCircle, InfoIcon } from "lucide-react";
 import { generate } from "random-words";
-import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import {
-  type ComponentFileEntry,
-  getAllComponentFilesFromList,
-  writeComponentToFileListFromText,
-} from "@/componentStore";
+import { writeComponentToFileListFromText } from "@/componentStore";
 import { replaceLocalStorageWithExperimentYaml } from "@/DragNDrop/PipelineAutoSaver";
 import {
   defaultPipelineYamlWithName,
@@ -27,62 +10,14 @@ import {
   USER_PIPELINES_LIST_NAME,
 } from "@/utils/constants";
 
-import { Alert, AlertDescription } from "./ui/alert";
+import { PipelineNameDialog } from "./shared/PipelineNameDialog";
 
-const VALID_NAME_REGEX = /^[a-zA-Z0-9\s]+$/;
-const VALID_NAME_MESSAGE =
-  "Name must be unique and contain only alphanumeric characters and spaces";
 const randomName = () => (generate(4) as string[]).join(" ");
 
 const NewExperimentDialog = () => {
   const navigate = useNavigate();
 
-  const [userPipelines, setUserPipelines] = useState<
-    Map<string, ComponentFileEntry>
-  >(new Map());
-
-  const [error, setError] = useState<string | null>(null);
-
-  const [isLoadingUserPipelines, setIsLoadingUserPipelines] = useState(false);
-
-  const [name, setName] = useState(randomName());
-
-  useEffect(() => {
-    fetchUserPipelines();
-  }, []);
-
-  const fetchUserPipelines = async () => {
-    setIsLoadingUserPipelines(true);
-    try {
-      const pipelines = await getAllComponentFilesFromList(
-        USER_PIPELINES_LIST_NAME,
-      );
-      setUserPipelines(pipelines);
-    } catch (error) {
-      console.error("Failed to load user pipelines:", error);
-    } finally {
-      setIsLoadingUserPipelines(false);
-    }
-  };
-
-  const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newName = e.target.value;
-    const existingPipelineNames = new Set(
-      Array.from(userPipelines.keys()).map((name) => name.toLowerCase()),
-    );
-
-    if (!VALID_NAME_REGEX.test(newName)) {
-      setError(VALID_NAME_MESSAGE);
-    } else if (existingPipelineNames.has(newName.trim().toLowerCase())) {
-      setError("Name already exists");
-    } else {
-      setError(null);
-    }
-
-    setName(e.target.value);
-  };
-
-  const handleOnCreate = async () => {
+  const handleCreate = async (name: string) => {
     const componentText = defaultPipelineYamlWithName(name);
     await writeComponentToFileListFromText(
       USER_PIPELINES_LIST_NAME,
@@ -97,63 +32,19 @@ const NewExperimentDialog = () => {
       reloadDocument: true,
     });
   };
-  const handleOnOpenModal = () => {
-    setName(randomName());
-  };
-  const handleOnOpenChange = () => {
-    setError(null);
-  };
 
   return (
-    <Dialog onOpenChange={handleOnOpenChange}>
-      <DialogTrigger asChild>
-        <Button
-          variant="outline"
-          onClick={handleOnOpenModal}
-          className="cursor-pointer"
-          disabled={isLoadingUserPipelines}
-        >
+    <PipelineNameDialog
+      trigger={
+        <Button variant="outline" className="cursor-pointer">
           New Pipeline
         </Button>
-      </DialogTrigger>
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>New Pipeline</DialogTitle>
-          <DialogDescription>Please, name your pipeline.</DialogDescription>
-        </DialogHeader>
-        <div className="flex items-center space-x-2">
-          <div className="grid flex-1 gap-2 flex-col">
-            <Input value={name} onChange={handleOnChange} />
-            <Alert variant={error ? "destructive" : "default"}>
-              {error && <AlertCircle className="h-4 w-4" />}
-              {!error && <InfoIcon className="h-4 w-4" />}
-              {error && <AlertDescription>{error}</AlertDescription>}
-              {!error && (
-                <AlertDescription>{VALID_NAME_MESSAGE}</AlertDescription>
-              )}
-            </Alert>
-          </div>
-        </div>
-        <DialogFooter className="sm:justify-end">
-          <DialogClose asChild>
-            <Button type="button" variant="secondary">
-              Close
-            </Button>
-          </DialogClose>
-          <DialogClose asChild>
-            <Button
-              type="button"
-              size="sm"
-              className="px-3"
-              onClick={handleOnCreate}
-              disabled={isLoadingUserPipelines || error !== null}
-            >
-              Create
-            </Button>
-          </DialogClose>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+      }
+      title="New Pipeline"
+      initialName={randomName()}
+      onSubmit={handleCreate}
+      submitButtonText="Create"
+    />
   );
 };
 

--- a/src/components/shared/PipelineNameDialog.tsx
+++ b/src/components/shared/PipelineNameDialog.tsx
@@ -1,0 +1,125 @@
+import { AlertCircle, InfoIcon } from "lucide-react";
+import { useState } from "react";
+
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import useLoadUserPipelines from "@/hooks/useLoadUserPipelines";
+import { VALID_NAME_MESSAGE, VALID_NAME_REGEX } from "@/utils/constants";
+
+interface PipelineNameDialogProps {
+  trigger: React.ReactNode;
+  title: string;
+  description?: string;
+  initialName: string;
+  onSubmit: (name: string) => void;
+  submitButtonText: string;
+  submitButtonIcon?: React.ReactNode;
+  isSubmitDisabled?: (name: string, error: string | null) => boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export const PipelineNameDialog = ({
+  trigger,
+  title,
+  description = "Please, name your pipeline.",
+  initialName,
+  onSubmit,
+  submitButtonText,
+  submitButtonIcon,
+  isSubmitDisabled,
+  onOpenChange,
+}: PipelineNameDialogProps) => {
+  const [error, setError] = useState<string | null>(null);
+  const [name, setName] = useState(initialName);
+  const { userPipelines, isLoadingUserPipelines } = useLoadUserPipelines();
+
+  const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newName = e.target.value;
+    const existingPipelineNames = new Set(
+      Array.from(userPipelines.keys()).map((name) => name.toLowerCase()),
+    );
+
+    if (!VALID_NAME_REGEX.test(newName)) {
+      setError(VALID_NAME_MESSAGE);
+    } else if (existingPipelineNames.has(newName.trim().toLowerCase())) {
+      setError("Name already exists");
+    } else {
+      setError(null);
+    }
+
+    setName(e.target.value);
+  };
+
+  const handleDialogOpenChange = (open: boolean) => {
+    if (!open) {
+      setError(null);
+      setName(initialName);
+    }
+    onOpenChange?.(open);
+  };
+
+  const handleSubmit = () => {
+    onSubmit(name);
+  };
+
+  const isDisabled =
+    isLoadingUserPipelines ||
+    !!error ||
+    !name ||
+    (isSubmitDisabled ? isSubmitDisabled(name, error) : false);
+
+  return (
+    <Dialog onOpenChange={handleDialogOpenChange}>
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <div className="flex items-center space-x-2">
+          <div className="grid flex-1 gap-2 flex-col">
+            <Input value={name} onChange={handleOnChange} />
+            <Alert variant={error ? "destructive" : "default"}>
+              {error && <AlertCircle className="h-4 w-4" />}
+              {!error && <InfoIcon className="h-4 w-4" />}
+              {error && <AlertDescription>{error}</AlertDescription>}
+              {!error && (
+                <AlertDescription>{VALID_NAME_MESSAGE}</AlertDescription>
+              )}
+            </Alert>
+          </div>
+        </div>
+        <DialogFooter className="sm:justify-end">
+          <DialogClose asChild>
+            <Button type="button" variant="secondary">
+              Close
+            </Button>
+          </DialogClose>
+          <DialogClose asChild>
+            <Button
+              type="button"
+              size="sm"
+              className="px-3 cursor-pointer"
+              onClick={handleSubmit}
+              disabled={isDisabled}
+            >
+              {submitButtonIcon}
+              {submitButtonText}
+            </Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/hooks/useLoadUserPipelines.tsx
+++ b/src/hooks/useLoadUserPipelines.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+
+import {
+  type ComponentFileEntry,
+  getAllComponentFilesFromList,
+} from "@/componentStore";
+import { USER_PIPELINES_LIST_NAME } from "@/utils/constants";
+
+const useLoadUserPipelines = () => {
+  const [isLoadingUserPipelines, setIsLoadingUserPipelines] = useState(false);
+  const [userPipelines, setUserPipelines] = useState<
+    Map<string, ComponentFileEntry>
+  >(new Map());
+
+  const fetchUserPipelines = async () => {
+    setIsLoadingUserPipelines(true);
+    try {
+      const pipelines = await getAllComponentFilesFromList(
+        USER_PIPELINES_LIST_NAME,
+      );
+      setUserPipelines(pipelines);
+    } catch (error) {
+      console.error("Failed to load user pipelines:", error);
+    } finally {
+      setIsLoadingUserPipelines(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchUserPipelines();
+  }, []);
+
+  return { userPipelines, isLoadingUserPipelines };
+};
+
+export default useLoadUserPipelines;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -40,3 +40,7 @@ implementation:
     tasks: {}
     outputValues: {}
 `;
+
+export const VALID_NAME_REGEX = /^[a-zA-Z0-9\s]+$/;
+export const VALID_NAME_MESSAGE =
+  "Name must be unique and contain only alphanumeric characters and spaces";

--- a/src/utils/copyRunToPipeline.ts
+++ b/src/utils/copyRunToPipeline.ts
@@ -7,7 +7,10 @@ import {
 
 import { APP_ROUTES, USER_PIPELINES_LIST_NAME } from "./constants";
 
-export const copyRunToPipeline = async (componentSpec: ComponentSpec) => {
+export const copyRunToPipeline = async (
+  componentSpec: ComponentSpec,
+  name?: string,
+) => {
   if (!componentSpec) {
     console.error("No component spec found to copy");
     return {
@@ -31,7 +34,7 @@ export const copyRunToPipeline = async (componentSpec: ComponentSpec) => {
 
     // Generate a name for the copied pipeline
     const originalName = cleanComponentSpec.name || "Unnamed Pipeline";
-    let newName = originalName;
+    let newName = name || originalName;
 
     // Check if the name already exists and append a number if needed
     let nameExists = true;


### PR DESCRIPTION
When a user clones a run, we now prompt them to either accept the original name + date time (to keep unique) or add their own unique name.

New pipeline and clone run share some logic, so I've moved that logic into a hook

<img width="515" alt="Screenshot 2025-03-28 at 7 27 45 AM" src="https://github.com/user-attachments/assets/69d92fa4-be9c-48d5-84b3-a3c7c8965dde" />
