### PR TITLE
Fix Large list of options is too long, and not scrollable

### DIFF
--- a/src/DragNDrop/ArgumentsEditor.tsx
+++ b/src/DragNDrop/ArgumentsEditor.tsx
@@ -90,11 +90,16 @@ const ArgumentInput = ({
   };
 
   return (
-    <div className="flex w-full items-center gap-2">
-      <Label htmlFor={input.name} className="w-[200px] min-w-[200px] text-sm">
-        {input.name} (
-        {typeSpecToString(input.type) + (!input.optional ? "*" : "")})
-      </Label>
+    <div className="flex w-full items-center gap-2 py-1">
+      <div className="w-[300px] min-w-[300px] flex flex-col">
+        <Label htmlFor={input.name} className="text-sm break-words">
+          {input.name.replace(/_/g, " ")}
+        </Label>
+        <span className="text-xs text-gray-500 truncate" title={typeSpecToString(input.type)}>
+          ({typeSpecToString(input.type)}
+          {!input.optional ? "*" : ""})
+        </span>
+      </div>
       <Input
         id={input.name}
         value={inputValue}
@@ -132,7 +137,7 @@ const ArgumentsEditor = ({
   };
 
   return (
-    <div className="h-auto w-[550px] flex flex-col gap-2">
+    <div className="h-auto w-[650px] flex flex-col gap-2 max-h-[60vh] overflow-y-auto pr-4">
       {inputs.map((input) => {
         return (
           <ArgumentInput


### PR DESCRIPTION
closes: https://github.com/Shopify/oasis-frontend/issues/17
This PR makes argument editors scrollable, the labels break, the labels remove `_`, and the types get truncated if they are too long and have a hover

<img width="742" alt="Screenshot 2025-03-28 at 10 40 47 AM" src="https://github.com/user-attachments/assets/bd619ef3-990b-47c0-b00f-7410b3469f40" />
<img width="744" alt="Screenshot 2025-03-28 at 10 42 25 AM" src="https://github.com/user-attachments/assets/b0e5f5e8-c867-4d15-bc75-c3ad4061cfaa" />
<img width="738" alt="Screenshot 2025-03-28 at 10 43 02 AM" src="https://github.com/user-attachments/assets/45875e23-ed2a-4808-b046-54b3136a647c" />
