### PR TITLE
Improved UX for deleting components

### DIFF
--- a/src/DragNDrop/ComponentTaskNode.tsx
+++ b/src/DragNDrop/ComponentTaskNode.tsx
@@ -37,7 +37,7 @@ type InputOrOutputSpec = InputSpec | OutputSpec;
 const NODE_WIDTH_IN_PX = 200;
 
 export const isComponentTaskNode = (
-  node: Node,
+  node: Node
 ): node is Node<ComponentTaskNodeProps> =>
   node.type === "task" &&
   node.data !== undefined &&
@@ -49,7 +49,7 @@ function generateHandles(
   handleType: HandleType,
   position: Position,
   idPrefix: string,
-  inputsWithMissingArguments?: string[],
+  inputsWithMissingArguments?: string[]
 ): React.ReactElement[] {
   const handleComponents = [];
   const numHandles = ioSpecs.length;
@@ -92,7 +92,7 @@ function generateHandles(
         <div className={labelClasses} style={labelStyle}>
           {ioSpec.name}
         </div>
-      </Handle>,
+      </Handle>
     );
   }
   return handleComponents;
@@ -100,7 +100,7 @@ function generateHandles(
 
 function generateLabelStyle(
   position: Position,
-  numHandles: number,
+  numHandles: number
 ): [string, CSSProperties] {
   let maxLabelWidthPx = NODE_WIDTH_IN_PX;
   let labelClasses = "label";
@@ -125,25 +125,25 @@ function generateLabelStyle(
 
 function generateInputHandles(
   inputSpecs: InputSpec[],
-  inputsWithInvalidArguments?: string[],
+  inputsWithInvalidArguments?: string[]
 ): React.ReactElement[] {
   return generateHandles(
     inputSpecs,
     "target",
     inputHandlePosition,
     "input_",
-    inputsWithInvalidArguments,
+    inputsWithInvalidArguments
   );
 }
 
 function generateOutputHandles(
-  outputSpecs: OutputSpec[],
+  outputSpecs: OutputSpec[]
 ): React.ReactElement[] {
   return generateHandles(
     outputSpecs,
     "source",
     outputHandlePosition,
-    "output_",
+    "output_"
   );
 }
 
@@ -151,6 +151,7 @@ export interface ComponentTaskNodeProps extends Record<string, unknown> {
   taskSpec: TaskSpec;
   taskId: string;
   setArguments?: (args: Record<string, ArgumentType>) => void;
+  onDelete: () => void;
 }
 
 const getStatusIcon = (status: string) => {
@@ -224,12 +225,12 @@ const ComponentTaskNode = ({ data }: NodeProps) => {
       (inputSpec) =>
         inputSpec.optional !== true &&
         inputSpec.default === undefined &&
-        !(inputSpec.name in (taskSpec.arguments ?? {})),
+        !(inputSpec.name in (taskSpec.arguments ?? {}))
     )
     .map((inputSpec) => inputSpec.name);
   const inputHandles = generateInputHandles(
     componentSpec.inputs ?? [],
-    inputsWithInvalidArguments,
+    inputsWithInvalidArguments
   );
   const outputHandles = generateOutputHandles(componentSpec.outputs ?? []);
   const handleComponents = inputHandles.concat(outputHandles);
@@ -290,6 +291,11 @@ const ComponentTaskNode = ({ data }: NodeProps) => {
     }
   };
 
+  const handleDelete = () => {
+    typedData.onDelete();
+    closeArgumentsEditor();
+  };
+
   return (
     <>
       <div
@@ -337,6 +343,7 @@ const ComponentTaskNode = ({ data }: NodeProps) => {
           setArguments={typedData.setArguments}
           disabled={!!runStatus}
           initialPosition={getDialogPosition(nodeRef.current, 650)}
+          handleDelete={handleDelete}
         />
       )}
     </>

--- a/src/DragNDrop/ComponentTaskNode.tsx
+++ b/src/DragNDrop/ComponentTaskNode.tsx
@@ -37,7 +37,7 @@ type InputOrOutputSpec = InputSpec | OutputSpec;
 const NODE_WIDTH_IN_PX = 200;
 
 export const isComponentTaskNode = (
-  node: Node
+  node: Node,
 ): node is Node<ComponentTaskNodeProps> =>
   node.type === "task" &&
   node.data !== undefined &&
@@ -49,7 +49,7 @@ function generateHandles(
   handleType: HandleType,
   position: Position,
   idPrefix: string,
-  inputsWithMissingArguments?: string[]
+  inputsWithMissingArguments?: string[],
 ): React.ReactElement[] {
   const handleComponents = [];
   const numHandles = ioSpecs.length;
@@ -92,7 +92,7 @@ function generateHandles(
         <div className={labelClasses} style={labelStyle}>
           {ioSpec.name}
         </div>
-      </Handle>
+      </Handle>,
     );
   }
   return handleComponents;
@@ -100,7 +100,7 @@ function generateHandles(
 
 function generateLabelStyle(
   position: Position,
-  numHandles: number
+  numHandles: number,
 ): [string, CSSProperties] {
   let maxLabelWidthPx = NODE_WIDTH_IN_PX;
   let labelClasses = "label";
@@ -125,25 +125,25 @@ function generateLabelStyle(
 
 function generateInputHandles(
   inputSpecs: InputSpec[],
-  inputsWithInvalidArguments?: string[]
+  inputsWithInvalidArguments?: string[],
 ): React.ReactElement[] {
   return generateHandles(
     inputSpecs,
     "target",
     inputHandlePosition,
     "input_",
-    inputsWithInvalidArguments
+    inputsWithInvalidArguments,
   );
 }
 
 function generateOutputHandles(
-  outputSpecs: OutputSpec[]
+  outputSpecs: OutputSpec[],
 ): React.ReactElement[] {
   return generateHandles(
     outputSpecs,
     "source",
     outputHandlePosition,
-    "output_"
+    "output_",
   );
 }
 
@@ -225,12 +225,12 @@ const ComponentTaskNode = ({ data }: NodeProps) => {
       (inputSpec) =>
         inputSpec.optional !== true &&
         inputSpec.default === undefined &&
-        !(inputSpec.name in (taskSpec.arguments ?? {}))
+        !(inputSpec.name in (taskSpec.arguments ?? {})),
     )
     .map((inputSpec) => inputSpec.name);
   const inputHandles = generateInputHandles(
     componentSpec.inputs ?? [],
-    inputsWithInvalidArguments
+    inputsWithInvalidArguments,
   );
   const outputHandles = generateOutputHandles(componentSpec.outputs ?? []);
   const handleComponents = inputHandles.concat(outputHandles);

--- a/src/DragNDrop/DraggableComponent.tsx
+++ b/src/DragNDrop/DraggableComponent.tsx
@@ -6,9 +6,11 @@
  * @copyright 2021 Alexey Volkov <alexey.volkov+oss@ark-kun.com>
  */
 
-import type { DragEvent } from "react";
+import { CircleX } from "lucide-react";
+import { type DragEvent, type MouseEvent } from "react";
 
 import CondensedUrl from "@/components/CondensedUrl";
+import { Button } from "@/components/ui/button";
 
 import type { ComponentReference, TaskSpec } from "../componentSpec";
 
@@ -30,10 +32,12 @@ interface DraggableComponentProps
     HTMLDivElement
   > {
   componentReference: ComponentReference;
+  onDelete?: (e: MouseEvent) => void;
 }
 
 const DraggableComponent = ({
   componentReference,
+  onDelete,
   ...props
 }: DraggableComponentProps) => {
   let title = componentReference.spec?.name || "";
@@ -61,6 +65,7 @@ const DraggableComponent = ({
       min-h-10
       p-2
       text-center
+      relative
       "
       draggable
       onDragStart={(event: DragEvent) => {
@@ -81,6 +86,16 @@ const DraggableComponent = ({
           />
         )}
       </div>
+      {onDelete && (
+        <Button
+          onClick={onDelete}
+          variant="ghost"
+          className="absolute top-0.5 right-0.5 cursor-pointer"
+          size="min"
+        >
+          <CircleX />
+        </Button>
+      )}
     </div>
   );
 };

--- a/src/DragNDrop/DraggableComponent.tsx
+++ b/src/DragNDrop/DraggableComponent.tsx
@@ -7,9 +7,10 @@
  */
 
 import { CircleX } from "lucide-react";
-import { type DragEvent, type MouseEvent } from "react";
+import { type DragEvent, type MouseEvent, useState } from "react";
 
 import CondensedUrl from "@/components/CondensedUrl";
+import { ConfirmationDialog } from "@/components/custom/ConfirmationDialog";
 import { Button } from "@/components/ui/button";
 
 import type { ComponentReference, TaskSpec } from "../componentSpec";
@@ -40,6 +41,9 @@ const DraggableComponent = ({
   onDelete,
   ...props
 }: DraggableComponentProps) => {
+  const [isConfirmationDialogOpen, setIsConfirmationDialogOpen] =
+    useState(false);
+
   let title = componentReference.spec?.name || "";
   if (componentReference.url) {
     title += "\nUrl: " + componentReference.url;
@@ -50,9 +54,25 @@ const DraggableComponent = ({
   if (componentReference.spec?.description) {
     title += "\nDescription: " + componentReference.spec?.description;
   }
+
+  const name = componentReference.spec?.name ?? "Component";
+
+  const handleConfirm = (e?: MouseEvent) => {
+    if (e) {
+      onDelete?.(e);
+    }
+    setIsConfirmationDialogOpen(false);
+  };
+
+  const handleCancel = (e?: MouseEvent) => {
+    e?.stopPropagation();
+    setIsConfirmationDialogOpen(false);
+  };
+
   return (
-    <div
-      className="
+    <>
+      <div
+        className="
       react-flow__node
       react-flow__node-task
       sidebar-node
@@ -67,36 +87,47 @@ const DraggableComponent = ({
       text-center
       relative
       "
-      draggable
-      onDragStart={(event: DragEvent) => {
-        const taskSpec: TaskSpec = {
-          componentRef: componentReference,
-        };
-        return onDragStart(event, { task: taskSpec });
-      }}
-      title={title}
-      {...props}
-    >
-      <div className="flex flex-col items-center">
-        <p>{componentReference.spec?.name ?? "Component"}</p>
-        {componentReference.url && (
-          <CondensedUrl
-            url={componentReference.url}
-            className="text-[0.5625rem]"
-          />
+        draggable
+        onDragStart={(event: DragEvent) => {
+          const taskSpec: TaskSpec = {
+            componentRef: componentReference,
+          };
+          return onDragStart(event, { task: taskSpec });
+        }}
+        title={title}
+        {...props}
+      >
+        <div className="flex flex-col items-center">
+          <p>{name}</p>
+          {componentReference.url && (
+            <CondensedUrl
+              url={componentReference.url}
+              className="text-[0.5625rem]"
+            />
+          )}
+        </div>
+        {onDelete && (
+          <Button
+            onClick={(e) => {
+              e.preventDefault();
+              setIsConfirmationDialogOpen(true);
+            }}
+            variant="ghost"
+            className="absolute top-0.5 right-0.5 cursor-pointer"
+            size="min"
+          >
+            <CircleX />
+          </Button>
         )}
       </div>
-      {onDelete && (
-        <Button
-          onClick={onDelete}
-          variant="ghost"
-          className="absolute top-0.5 right-0.5 cursor-pointer"
-          size="min"
-        >
-          <CircleX />
-        </Button>
-      )}
-    </div>
+      <ConfirmationDialog
+        title={`Delete ${name}?`}
+        message={`'${name}' is a custom user component. This action cannot be undone.`}
+        isOpen={isConfirmationDialogOpen}
+        onConfirm={handleConfirm}
+        onCancel={handleCancel}
+      />
+    </>
   );
 };
 

--- a/src/DragNDrop/DraggableDialog.tsx
+++ b/src/DragNDrop/DraggableDialog.tsx
@@ -7,11 +7,11 @@
  */
 
 import { DndContext, type DragEndEvent, useDraggable } from "@dnd-kit/core";
-import { GripVertical } from "lucide-react";
+import { CircleX, GripVertical } from "lucide-react";
 import { type PropsWithChildren, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 
-import { Button } from "@/components/ui/button";
+import { Button, type ButtonProps } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -44,6 +44,7 @@ interface DraggableDialogProps extends PropsWithChildren {
   description: string;
   position?: { x: number; y: number };
   disabled?: boolean;
+  secondaryActions?: ButtonProps[];
   onClose: () => void;
   onConfirm?: () => void;
 }
@@ -54,6 +55,7 @@ const DraggableDialogPortal = ({
   description,
   position = { x: 100, y: 100 },
   disabled,
+  secondaryActions,
   onClose,
   onConfirm,
   children,
@@ -76,6 +78,7 @@ const DraggableDialogPortal = ({
         description={description}
         position={dialogPosition}
         disabled={disabled}
+        secondaryActions={secondaryActions}
         onClose={onClose}
         onConfirm={onConfirm}
       >
@@ -93,6 +96,7 @@ const DraggableDialog = ({
   description,
   position = { x: 100, y: 100 },
   disabled,
+  secondaryActions,
   onClose,
   onConfirm,
   children,
@@ -154,12 +158,22 @@ const DraggableDialog = ({
             {title}
           </CardTitle>
           <CardDescription>{description}</CardDescription>
+          <Button
+            onClick={onClose}
+            className="cursor-pointer absolute top-2 right-2"
+            variant="ghost"
+          >
+            <CircleX />
+          </Button>
         </CardHeader>
         <CardContent>{children}</CardContent>
         <CardFooter className="flex justify-between">
-          <Button onClick={onClose} className="cursor-pointer">
-            Close
-          </Button>
+          <div className="flex gap-2">
+            {secondaryActions &&
+              secondaryActions.map((action, index) => (
+                <Button key={index} {...action} />
+              ))}
+          </div>
           {onConfirm && (
             <Button
               onClick={onConfirm}

--- a/src/DragNDrop/GraphComponentSpecFlow.tsx
+++ b/src/DragNDrop/GraphComponentSpecFlow.tsx
@@ -61,9 +61,24 @@ const GraphComponentSpecFlow = ({
 }: GraphComponentSpecFlowProps) => {
   const [reactFlowInstance, setReactFlowInstance] =
     useState<ReactFlowInstance>();
+
+  const deleteNode = (nodeId: string) => {
+    const node = nodes.find((n) => n.id === nodeId);
+    if (node) {
+      removeNode(node);
+
+      // Ideally the graph spec would be updated from within the Node onDelete fcn itself.
+      setComponentSpec({
+        ...componentSpec,
+        implementation: { graph: graphSpec },
+      });
+    }
+  };
+
   const { nodes, onNodesChange } = useComponentSpecToNodes(
     componentSpec,
     setComponentSpec,
+    deleteNode,
   );
   const { edges, onEdgesChange } = useComponentSpecToEdges(componentSpec);
 

--- a/src/DragNDrop/ShopifyCloud.tsx
+++ b/src/DragNDrop/ShopifyCloud.tsx
@@ -159,9 +159,7 @@ const ShopifyCloudSubmitter = ({
             Submitting...
           </>
         ) : cooldownTime > 0 ? (
-          <>
-            Submit Run ({cooldownTime}s)
-          </>
+          <>Submit Run ({cooldownTime}s)</>
         ) : (
           "Submit Run"
         )}

--- a/src/DragNDrop/UserComponentLibrary.tsx
+++ b/src/DragNDrop/UserComponentLibrary.tsx
@@ -166,8 +166,10 @@ const UserComponentLibrary = () => {
               "Drag and drop component.yaml files or click to select files"}
           {Array.from(componentFiles.entries()).map(([fileName, fileEntry]) => (
             <div key={fileName} className="draggable-component">
-              <DraggableComponent componentReference={fileEntry.componentRef} />
-              <Button onClick={handleDelete(fileName)}>Delete</Button>
+              <DraggableComponent
+                componentReference={fileEntry.componentRef}
+                onDelete={handleDelete(fileName)}
+              />
             </div>
           ))}
         </div>

--- a/src/components/ArgumentsEditor/ArgumentsEditorDialog.tsx
+++ b/src/components/ArgumentsEditor/ArgumentsEditorDialog.tsx
@@ -78,7 +78,7 @@ const ArgumentsEditorDialog = ({
   if (componentSpec === undefined) {
     console.error(
       "ArgumentsEditor called with missing taskSpec.componentRef.spec",
-      taskSpec
+      taskSpec,
     );
     return null;
   }
@@ -88,7 +88,7 @@ const ArgumentsEditorDialog = ({
     const argumentValues = Object.fromEntries(
       currentArguments
         .filter(({ isRemoved }) => !isRemoved)
-        .map(({ key, value }) => [key, value])
+        .map(({ key, value }) => [key, value]),
     );
 
     setArguments?.(argumentValues);

--- a/src/components/ArgumentsEditor/ArgumentsEditorDialog.tsx
+++ b/src/components/ArgumentsEditor/ArgumentsEditorDialog.tsx
@@ -6,6 +6,7 @@
  * @copyright 2021 Alexey Volkov <alexey.volkov+oss@ark-kun.com>
  */
 
+import { Trash } from "lucide-react";
 import { useState } from "react";
 
 import DraggableDialog from "@/DragNDrop/DraggableDialog";
@@ -23,6 +24,7 @@ interface ArgumentsEditorDialogProps {
   closeEditor: () => void;
   setArguments?: (args: Record<string, ArgumentType>) => void;
   disabled?: boolean;
+  handleDelete: () => void;
 }
 
 const ArgumentsEditorDialog = ({
@@ -31,6 +33,7 @@ const ArgumentsEditorDialog = ({
   setArguments,
   disabled = false,
   initialPosition,
+  handleDelete,
 }: ArgumentsEditorDialogProps) => {
   const componentSpec = taskSpec.componentRef.spec;
 
@@ -75,7 +78,7 @@ const ArgumentsEditorDialog = ({
   if (componentSpec === undefined) {
     console.error(
       "ArgumentsEditor called with missing taskSpec.componentRef.spec",
-      taskSpec,
+      taskSpec
     );
     return null;
   }
@@ -85,7 +88,7 @@ const ArgumentsEditorDialog = ({
     const argumentValues = Object.fromEntries(
       currentArguments
         .filter(({ isRemoved }) => !isRemoved)
-        .map(({ key, value }) => [key, value]),
+        .map(({ key, value }) => [key, value])
     );
 
     setArguments?.(argumentValues);
@@ -101,6 +104,20 @@ const ArgumentsEditorDialog = ({
       onClose={closeEditor}
       onConfirm={handleApply}
       position={initialPosition}
+      secondaryActions={[
+        {
+          children: (
+            <div className="flex items-center gap-2">
+              <Trash />
+              Delete
+            </div>
+          ),
+          variant: "destructive",
+          className: "cursor-pointer",
+          disabled,
+          onClick: handleDelete,
+        },
+      ]}
     >
       <ArgumentsEditor
         argumentData={currentArguments}

--- a/src/components/custom/ConfirmationDialog.tsx
+++ b/src/components/custom/ConfirmationDialog.tsx
@@ -1,0 +1,50 @@
+import type { MouseEvent } from "react";
+
+import { Button } from "../ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../ui/dialog";
+
+interface ConfirmationDialogProps {
+  isOpen: boolean;
+  title: string;
+  message?: string;
+  confirmButtonText?: string;
+  cancelButtonText?: string;
+  onConfirm: (e?: MouseEvent) => void;
+  onCancel: (e?: MouseEvent) => void;
+}
+
+export const ConfirmationDialog = ({
+  isOpen,
+  title,
+  message = "Are you sure?",
+  confirmButtonText = "Confirm",
+  cancelButtonText = "Cancel",
+  onConfirm,
+  onCancel,
+}: ConfirmationDialogProps) => {
+  return (
+    <Dialog open={isOpen} onOpenChange={() => onCancel()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        <DialogDescription>{message}</DialogDescription>
+        <DialogFooter>
+          <Button variant="secondary" onClick={onCancel}>
+            {cancelButtonText}
+          </Button>
+          <Button variant="destructive" onClick={onConfirm}>
+            {confirmButtonText}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -25,14 +25,21 @@ const buttonVariants = cva(
         sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9",
+        min: "h-fit w-fit p-1 rounded-sm",
       },
     },
     defaultVariants: {
       variant: "default",
       size: "default",
     },
-  },
+  }
 );
+
+interface ButtonProps
+  extends React.ComponentProps<"button">,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
 
 function Button({
   className,
@@ -40,10 +47,7 @@ function Button({
   size,
   asChild = false,
   ...props
-}: React.ComponentProps<"button"> &
-  VariantProps<typeof buttonVariants> & {
-    asChild?: boolean;
-  }) {
+}: ButtonProps) {
   const Comp = asChild ? Slot : "button";
 
   return (
@@ -56,3 +60,4 @@ function Button({
 }
 
 export { Button, buttonVariants };
+export type { ButtonProps };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -32,7 +32,7 @@ const buttonVariants = cva(
       variant: "default",
       size: "default",
     },
-  }
+  },
 );
 
 interface ButtonProps

--- a/src/hooks/useComponentSpecToNodes.test.tsx
+++ b/src/hooks/useComponentSpecToNodes.test.tsx
@@ -13,6 +13,8 @@ describe("useComponentSpecToNodes", () => {
     outputs: [],
   });
 
+  const onDelete = vi.fn();
+
   const mockSetComponentSpec = vi.fn();
 
   beforeEach(() => {
@@ -25,7 +27,7 @@ describe("useComponentSpecToNodes", () => {
     });
 
     const { result } = renderHook(() =>
-      useComponentSpecToNodes(componentSpec, mockSetComponentSpec),
+      useComponentSpecToNodes(componentSpec, mockSetComponentSpec, onDelete),
     );
 
     expect(result.current.nodes).toEqual([]);
@@ -51,7 +53,7 @@ describe("useComponentSpecToNodes", () => {
     }
 
     const { result } = renderHook(() =>
-      useComponentSpecToNodes(componentSpec, mockSetComponentSpec),
+      useComponentSpecToNodes(componentSpec, mockSetComponentSpec, onDelete),
     );
 
     expect(result.current.nodes).toContainEqual(
@@ -81,7 +83,7 @@ describe("useComponentSpecToNodes", () => {
     };
 
     const { result } = renderHook(() =>
-      useComponentSpecToNodes(componentSpec, mockSetComponentSpec),
+      useComponentSpecToNodes(componentSpec, mockSetComponentSpec, onDelete),
     );
 
     expect(result.current.nodes).toContainEqual({
@@ -108,7 +110,7 @@ describe("useComponentSpecToNodes", () => {
     };
 
     const { result } = renderHook(() =>
-      useComponentSpecToNodes(componentSpec, mockSetComponentSpec),
+      useComponentSpecToNodes(componentSpec, mockSetComponentSpec, onDelete),
     );
 
     expect(result.current.nodes).toContainEqual({
@@ -137,7 +139,7 @@ describe("useComponentSpecToNodes", () => {
     };
 
     const { result } = renderHook(() =>
-      useComponentSpecToNodes(componentSpec, mockSetComponentSpec),
+      useComponentSpecToNodes(componentSpec, mockSetComponentSpec, onDelete),
     );
     const defaultPosition = { x: 0, y: 0 };
 
@@ -175,7 +177,7 @@ describe("useComponentSpecToNodes", () => {
     });
 
     const { result } = renderHook(() =>
-      useComponentSpecToNodes(componentSpec, mockSetComponentSpec),
+      useComponentSpecToNodes(componentSpec, mockSetComponentSpec, onDelete),
     );
     const taskNode = result.current.nodes.find(
       (node) => node.id === "task_task1",


### PR DESCRIPTION
Addresses some of the items in https://github.com/Cloud-Pipelines/pipeline-studio-app/issues/131

- Moves the UserComponent Delete Button to a small X in the top right.
![image](https://github.com/user-attachments/assets/4329960a-a0f2-4671-8744-c59a3161ffdd)

- Adds a delete button for the component on the argument editor
![image](https://github.com/user-attachments/assets/819cbe86-a3e8-494d-947a-92bf0e68d6df)

- Moves the close button in the argument editor to a small X in the top right
- Changes the 'clear argument' button in the argument editor to a delete icon.
- Adds a Confirmation Dialog before anything on the graph is deleted
![image](https://github.com/user-attachments/assets/0e0501d2-4faa-437b-990f-ea42b5bc5359)
![image](https://github.com/user-attachments/assets/a74c2566-2309-4e4f-9562-d9a367628684)




