### PR TITLE
Fix status count crowding on run row

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@emotion/styled": "^11.14.0",
         "@radix-ui/react-accordion": "^1.2.3",
         "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-hover-card": "^1.1.6",
         "@radix-ui/react-label": "^2.1.2",
         "@radix-ui/react-popover": "^1.1.6",
         "@radix-ui/react-scroll-area": "^1.2.3",
@@ -1791,6 +1792,37 @@
         "@radix-ui/react-compose-refs": "1.1.1",
         "@radix-ui/react-primitive": "2.0.2",
         "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.6.tgz",
+      "integrity": "sha512-E4ozl35jq0VRlrdc4dhHrNSV0JqBb4Jy73WAhBEK7JoYnQ83ED5r0Rb/XdVKw89ReAJN38N492BAPBZQ57VmqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.5",
+        "@radix-ui/react-popper": "1.2.2",
+        "@radix-ui/react-portal": "1.1.4",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@emotion/styled": "^11.14.0",
     "@radix-ui/react-accordion": "^1.2.3",
     "@radix-ui/react-dialog": "^1.1.6",
+    "@radix-ui/react-hover-card": "^1.1.6",
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-popover": "^1.1.6",
     "@radix-ui/react-scroll-area": "^1.2.3",

--- a/src/components/PipelineRow/RunListItem.tsx
+++ b/src/components/PipelineRow/RunListItem.tsx
@@ -24,8 +24,6 @@ const RunListItem = ({ run }: { run: PipelineRun }) => {
   const { data, isLoading, error } = fetchExecutionInfo(executionId);
   const { details, state } = data;
 
-  const name = details?.task_spec?.componentRef?.spec?.name;
-
   useEffect(() => {
     const fetchData = async () => {
       const res = await fetchPipelineRunById(`${run.id}`);
@@ -65,18 +63,16 @@ const RunListItem = ({ run }: { run: PipelineRun }) => {
       className="flex flex-col p-2 text-sm hover:bg-gray-50 cursor-pointer"
     >
       <div className="flex items-center justify-between mb-1">
-        <div className="flex items-center gap-2">
-          <StatusIcon status={getRunStatus(statusCounts)} />
-          <span>{name}</span>
-          <span className="text-gray-500 text-xs">{`#${executionId}`}</span>
+        <div className="flex items-center gap-1 w-full justify-between">
+          <div className="flex items-center gap-3">
+            <StatusIcon status={getRunStatus(statusCounts)} />
+            <div className="text-xs">{`#${executionId}`}</div>
+          </div>
           {metadata && (
-            <>
-              <span>•</span>
-              <span className="text-gray-500 text-xs">{`${formatDate(metadata.created_at)}`}</span>
-            </>
+            <span className="text-gray-500 text-xs">{`${formatDate(metadata.created_at)}`}</span>
           )}
+          <StatusText statusCounts={statusCounts} shorthand />
         </div>
-        <StatusText statusCounts={statusCounts} shorthand />
       </div>
 
       <TaskStatusBar statusCounts={statusCounts} />

--- a/src/components/PipelineRow/StatusText.tsx
+++ b/src/components/PipelineRow/StatusText.tsx
@@ -9,7 +9,7 @@ const StatusText = ({
 }) => {
   return (
     <div className="text-xs text-gray-500 mt-1">
-      {Object.entries(statusCounts).map(([key, count], index, array) => {
+      {Object.entries(statusCounts).map(([key, count]) => {
         if (key === "total") return;
 
         if (count === 0) return;
@@ -25,20 +25,24 @@ const StatusText = ({
           ? `${key[0]}`
           : `${key}${count > 1 ? " " : ""}`;
 
-        const isLastVisibleItem = array
-          .slice(index + 1)
-          .some(([nextKey, nextCount]) => nextKey !== "total" && nextCount > 0);
+        const statusColor = statusColors[key];
 
-        return (
-          <span key={key}>
-            <span className={statusColors[key]}>
-              {count}
-              {shorthand ? statusText : ` ${statusText.trim()}`}
+        if (shorthand) {
+          return (
+            <span key={key} className="group">
+              <span className={statusColor}>
+                {count}
+                {statusText}
+              </span>
+              <span className="group-last:hidden"> • </span>
             </span>
-            {!shorthand && isLastVisibleItem && (
-              <span className="text-black">, </span>
-            )}
-            {shorthand && <span> </span>}
+          );
+        }
+        return (
+          <span key={key} className="flex items-center gap-1">
+            <span className={statusColor}>
+              {count} {statusText.trim()}
+            </span>
           </span>
         );
       })}

--- a/src/components/PipelineRow/index.tsx
+++ b/src/components/PipelineRow/index.tsx
@@ -80,32 +80,30 @@ const PipelineRow = ({ name, modificationTime }: PipelineRowProps) => {
           "-"
         )}
       </TableCell>
-      <TableCell className="text-muted-foreground text-xs">
-        <div className="flex items-center gap-2">
-          <span>
-            {pipelineRuns.length > 0 ? `${pipelineRuns.length} runs` : "-"}
-          </span>
-          {pipelineRuns.length > 0 && (
-            <Popover>
-              <PopoverTrigger data-popover-trigger asChild>
-                <Button
-                  className="hover:bg-muted p-1 rounded cursor-pointer"
-                  variant="ghost"
-                >
-                  <List className="h-4 w-4" />
-                </Button>
-              </PopoverTrigger>
-              <PopoverContent className="w-[500px]">
-                <div className="text-sm mb-2">Runs - {pipelineRuns.length}</div>
-                <ScrollArea className="h-[300px]">
-                  {pipelineRuns.map((run) => (
-                    <RunListItem key={run.id} run={run} />
-                  ))}
-                </ScrollArea>
-              </PopoverContent>
-            </Popover>
-          )}
-        </div>
+      <TableCell>
+        {pipelineRuns.length > 0 && (
+          <Popover>
+            <PopoverTrigger
+              data-popover-trigger
+              className="cursor-pointer text-gray-500 border border-gray-200 rounded-md p-1 hover:bg-gray-200"
+            >
+              <List className="w-4 h-4" />
+            </PopoverTrigger>
+            <PopoverContent className="w-[500px]">
+              <div className="text-sm mb-2">
+                <span className="font-bold">
+                  {pipelineRuns[0].pipeline_name}
+                </span>{" "}
+                - {pipelineRuns.length} runs
+              </div>
+              <ScrollArea className="h-[300px]">
+                {pipelineRuns.map((run) => (
+                  <RunListItem key={run.id} run={run} />
+                ))}
+              </ScrollArea>
+            </PopoverContent>
+          </Popover>
+        )}
       </TableCell>
     </TableRow>
   );

--- a/src/components/RunSection/RunRow.tsx
+++ b/src/components/RunSection/RunRow.tsx
@@ -13,6 +13,11 @@ import {
   formatDate,
   getRunStatus,
 } from "../PipelineRow/utils";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "../ui/hover-card";
 
 const RunRow = ({ run }: { run: PipelineRunResponse }) => {
   const navigate = useNavigate();
@@ -72,14 +77,19 @@ const RunRow = ({ run }: { run: PipelineRunResponse }) => {
         <span>{`#${executionId}`}</span>
       </TableCell>
       <TableCell>
-        <div className="flex items-center gap-2">
-          <div className="w-1/2">
-            <TaskStatusBar statusCounts={statusCounts} />
-          </div>
-          <div className="w-1/2">
-            {statusCounts && <StatusText statusCounts={statusCounts} />}
-          </div>
-        </div>
+        <HoverCard openDelay={100}>
+          <HoverCardTrigger>
+            <div className="w-2/3">
+              <TaskStatusBar statusCounts={statusCounts} />
+            </div>
+          </HoverCardTrigger>
+          <HoverCardContent>
+            <div className="flex flex-col gap-2">
+              <div className="text-sm font-bold">Status</div>
+              <StatusText statusCounts={statusCounts} />
+            </div>
+          </HoverCardContent>
+        </HoverCard>
       </TableCell>
       <TableCell>
         {run.created_at ? `${formatDate(run.created_at)}` : "Data not found..."}

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -1,0 +1,42 @@
+import * as HoverCardPrimitive from "@radix-ui/react-hover-card";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function HoverCard({
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Root>) {
+  return <HoverCardPrimitive.Root data-slot="hover-card" {...props} />;
+}
+
+function HoverCardTrigger({
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Trigger>) {
+  return (
+    <HoverCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />
+  );
+}
+
+function HoverCardContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Content>) {
+  return (
+    <HoverCardPrimitive.Portal data-slot="hover-card-portal">
+      <HoverCardPrimitive.Content
+        data-slot="hover-card-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className,
+        )}
+        {...props}
+      />
+    </HoverCardPrimitive.Portal>
+  );
+}
+
+export { HoverCard, HoverCardContent, HoverCardTrigger };


### PR DESCRIPTION
closes https://github.com/Shopify/oasis-frontend/issues/21
# Improve Pipeline Run UI Readability

## Problem
- Status information was overcrowded when displaying multiple states (successful, running, errors, skipped)
- Pipeline run list items became cluttered after switching to UUID format
- Status count information took up unnecessary space in the main view

## Solution
- Implemented a card popover that appears when hovering over the status bar
- Moved detailed status counts to the hover popover
- Retained the progress bar as the primary visual indicator
- Simplified the main UI while keeping detailed information easily accessible

## Details
- Status counts are now available on-demand via hover interaction
- Progress bar continues to provide visual feedback of overall pipeline status
- Improved space efficiency in pipeline run list items
- Better handling of UUID display in list view

This change maintains all necessary information while creating a cleaner, more user-friendly interface.

Before:

<img width="393" alt="Screenshot 2025-03-31 at 2 09 16 PM" src="https://github.com/user-attachments/assets/f9539a35-46df-4b2b-a028-a40c64c272c5" />
<img width="513" alt="Screenshot 2025-03-31 at 2 09 42 PM" src="https://github.com/user-attachments/assets/a2ec4185-6b20-4e0f-a7b6-c222f4884db7" />

After:

<img width="415" alt="Screenshot 2025-03-31 at 2 10 32 PM" src="https://github.com/user-attachments/assets/327cc51a-860b-43d7-a2e0-f4f621db7a67" />

<img width="520" alt="Screenshot 2025-03-31 at 2 12 40 PM" src="https://github.com/user-attachments/assets/9ba1d3c4-379a-44a9-a909-90f80ee926c2" />

