### PR TITLE
Add source maps so we can debug in production

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -16,6 +16,14 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  build: {
+    sourcemap: true,
+    rollupOptions: {
+      output: {
+        sourcemapExcludeSources: false,
+      },
+    },
+  },
   test: {
     globals: true,
     environment: "jsdom",


### PR DESCRIPTION
This PR should add source maps to the production code so we can debug in production a little easier.

Also, the repo is open source so it should be no problem to add source maps in production