### PR TITLE
Removes replacing _ from pipeline name

### DIFF
--- a/src/components/PipelineSection/PipelineSection.tsx
+++ b/src/components/PipelineSection/PipelineSection.tsx
@@ -130,7 +130,7 @@ export const PipelineSection = () => {
               <PipelineRow
                 key={fileEntry.componentRef.digest}
                 componentRef={fileEntry.componentRef}
-                name={name.replace(/_/g, " ")}
+                name={name}
                 modificationTime={fileEntry.modificationTime}
               />
             ))}


### PR DESCRIPTION
closes: https://github.com/Shopify/oasis-frontend/issues/22
The pipeline section was removing "_" from pipeline names, causing links to not render out correctly. 

Fixes: https://github.com/Cloud-Pipelines/pipeline-studio-app/issues/158