### PR TITLE
Argument Editor Improvements

### DIFF
--- a/src/components/shared/Dialogs/ConfirmationDialog.tsx
+++ b/src/components/shared/Dialogs/ConfirmationDialog.tsx
@@ -58,7 +58,7 @@ const ConfirmationDialog = ({
           {trigger}
         </AlertDialogTrigger>
       )}
-      <AlertDialogContent>
+      <AlertDialogContent className="z-[9999]">
         <AlertDialogHeader>
           <AlertDialogTitle>{title}</AlertDialogTitle>
           <AlertDialogDescription>{description}</AlertDialogDescription>

--- a/src/components/shared/Dialogs/DraggableDialog.tsx
+++ b/src/components/shared/Dialogs/DraggableDialog.tsx
@@ -137,6 +137,19 @@ const DraggableDialog = ({
   const translateX = position.x + (transform?.x || 0);
   const translateY = position.y + (transform?.y || 0);
 
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose]);
+
   return (
     <div
       ref={setNodeRef}

--- a/src/components/shared/ReactFlow/FlowGraph/FlowGraph.tsx
+++ b/src/components/shared/ReactFlow/FlowGraph/FlowGraph.tsx
@@ -72,7 +72,7 @@ const FlowGraph = ({
       );
       updateGraphSpec(newGraphSpec);
     },
-    [],
+    [graphSpec],
   );
 
   const onDelete = useCallback(

--- a/src/components/shared/ReactFlow/FlowGraph/FlowGraph.tsx
+++ b/src/components/shared/ReactFlow/FlowGraph/FlowGraph.tsx
@@ -13,18 +13,16 @@ import type {
   ReactFlowInstance,
   ReactFlowProps,
 } from "@xyflow/react";
-import { type OnInit, ReactFlow } from "@xyflow/react";
+import { type OnInit, ReactFlow, useNodesState } from "@xyflow/react";
 import type { ComponentType, DragEvent } from "react";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { ConfirmationDialog } from "@/components/shared/Dialogs";
 import useComponentSpecToEdges from "@/hooks/useComponentSpecToEdges";
-import useComponentSpecToNodes, {
-  type NodeAndTaskId,
-} from "@/hooks/useComponentSpecToNodes";
 import { useConnectionHandler } from "@/hooks/useConnectionHandler";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import type { ArgumentType, TaskOutputArgument } from "@/utils/componentSpec";
+import { createNodes, type NodeAndTaskId } from "@/utils/nodes/createNodes";
 import {
   nodeIdToInputName,
   nodeIdToOutputName,
@@ -53,22 +51,16 @@ const FlowGraph = ({
   const { componentSpec, setComponentSpec, graphSpec, updateGraphSpec } =
     useComponentSpec();
 
-  const onDelete = useCallback(async (ids: NodeAndTaskId) => {
-    const nodeId = ids.nodeId;
-    const node = nodes.find((n) => n.id === nodeId);
-    if (node) {
-      const confirmed = await triggerConfirmationDialog({
-        nodes: [node],
-        edges: [],
-      });
-      if (confirmed) {
-        removeNode(node);
+  /* Initialize nodes with an empty array and sync with the ComponentSpec via useEffect to avoid infinite renders */
+  const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
 
-        // Ideally the graph spec would be updated from within the Node onDelete fcn itself.
-        updateGraphSpec(graphSpec);
-      }
-    }
-  }, []);
+  useEffect(() => {
+    const newNodes = createNodes(componentSpec, {
+      onDelete,
+      setArguments,
+    });
+    setNodes(newNodes);
+  }, [componentSpec]);
 
   const setArguments = useCallback(
     (ids: NodeAndTaskId, args: Record<string, ArgumentType>) => {
@@ -76,17 +68,33 @@ const FlowGraph = ({
       const newGraphSpec = replaceTaskArgumentsInGraphSpec(
         taskId,
         graphSpec,
-        args,
+        args
       );
       updateGraphSpec(newGraphSpec);
     },
-    [],
+    []
   );
 
-  const { nodes, onNodesChange } = useComponentSpecToNodes(componentSpec, {
-    onDelete,
-    setArguments,
-  });
+  const onDelete = useCallback(
+    async (ids: NodeAndTaskId) => {
+      const nodeId = ids.nodeId;
+      const node = nodes.find((n) => n.id === nodeId);
+
+      if (node) {
+        const confirmed = await triggerConfirmationDialog({
+          nodes: [node],
+          edges: [],
+        });
+        if (confirmed) {
+          removeNode(node);
+
+          // Ideally the graph spec would be updated from within the Node onDelete fcn itself.
+          updateGraphSpec(graphSpec);
+        }
+      }
+    },
+    [nodes]
+  );
 
   const { edges, onEdgesChange } = useComponentSpecToEdges(componentSpec);
 
@@ -102,7 +110,7 @@ const FlowGraph = ({
   const setTaskArgument = (
     taskId: string,
     inputName: string,
-    argument?: ArgumentType,
+    argument?: ArgumentType
   ) => {
     if (readOnly) {
       return;
@@ -120,7 +128,7 @@ const FlowGraph = ({
     const newGraphSpec = replaceTaskArgumentsInGraphSpec(
       taskId,
       graphSpec,
-      newTaskSpecArguments,
+      newTaskSpecArguments
     );
 
     updateGraphSpec(newGraphSpec);
@@ -128,7 +136,7 @@ const FlowGraph = ({
 
   const setGraphOutputValue = (
     outputName: string,
-    outputValue?: TaskOutputArgument,
+    outputValue?: TaskOutputArgument
   ) => {
     const nonNullOutputObject = outputValue
       ? { [outputName]: outputValue }
@@ -162,7 +170,7 @@ const FlowGraph = ({
     // Not really needed since react-flow sends the node's incoming and outcoming edges for deletion when a node is deleted
     for (const [taskId, taskSpec] of Object.entries(graphSpec.tasks)) {
       for (const [inputName, argument] of Object.entries(
-        taskSpec.arguments ?? {},
+        taskSpec.arguments ?? {}
       )) {
         if (typeof argument !== "string" && "graphInput" in argument) {
           if (argument.graphInput.inputName === inputNameToRemove) {
@@ -173,7 +181,7 @@ const FlowGraph = ({
     }
 
     const newInputs = (componentSpec.inputs ?? []).filter(
-      (inputSpec) => inputSpec.name !== inputNameToRemove,
+      (inputSpec) => inputSpec.name !== inputNameToRemove
     );
     setComponentSpec({ ...componentSpec, inputs: newInputs });
   };
@@ -182,7 +190,7 @@ const FlowGraph = ({
     setGraphOutputValue(outputNameToRemove);
     // Removing the output itself
     const newOutputs = (componentSpec.outputs ?? []).filter(
-      (outputSpec) => outputSpec.name !== outputNameToRemove,
+      (outputSpec) => outputSpec.name !== outputNameToRemove
     );
     setComponentSpec({ ...componentSpec, outputs: newOutputs });
   };
@@ -209,15 +217,15 @@ const FlowGraph = ({
     // Step 2: Remove any connections from this task to graph outputs
     const newGraphOutputValues = Object.fromEntries(
       Object.entries(graphSpec.outputValues ?? {}).filter(
-        ([_, argument]) => argument.taskOutput.taskId !== taskIdToRemove,
-      ),
+        ([_, argument]) => argument.taskOutput.taskId !== taskIdToRemove
+      )
     );
 
     // Step 3: Remove the task itself from the graph
     const newTasks = Object.fromEntries(
       Object.entries(graphSpec.tasks).filter(
-        ([taskId]) => taskId !== taskIdToRemove,
-      ),
+        ([taskId]) => taskId !== taskIdToRemove
+      )
     );
 
     // Step 4: Update the graph spec with our changes
@@ -264,7 +272,7 @@ const FlowGraph = ({
         reactFlowInstance,
         componentSpec,
         setComponentSpec,
-        graphSpec,
+        graphSpec
       );
     }
   };
@@ -315,7 +323,7 @@ const FlowGraph = ({
   const handleOnNodesChange = (changes: NodeChange[]) => {
     // Process position changes and update component spec
     const positionChanges = changes.filter(
-      (change) => change.type === "position" && change.dragging === false,
+      (change) => change.type === "position" && change.dragging === false
     );
 
     if (positionChanges.length > 0) {

--- a/src/components/shared/ReactFlow/FlowGraph/FlowGraph.tsx
+++ b/src/components/shared/ReactFlow/FlowGraph/FlowGraph.tsx
@@ -68,11 +68,11 @@ const FlowGraph = ({
       const newGraphSpec = replaceTaskArgumentsInGraphSpec(
         taskId,
         graphSpec,
-        args
+        args,
       );
       updateGraphSpec(newGraphSpec);
     },
-    []
+    [],
   );
 
   const onDelete = useCallback(
@@ -93,7 +93,7 @@ const FlowGraph = ({
         }
       }
     },
-    [nodes]
+    [nodes],
   );
 
   const { edges, onEdgesChange } = useComponentSpecToEdges(componentSpec);
@@ -110,7 +110,7 @@ const FlowGraph = ({
   const setTaskArgument = (
     taskId: string,
     inputName: string,
-    argument?: ArgumentType
+    argument?: ArgumentType,
   ) => {
     if (readOnly) {
       return;
@@ -128,7 +128,7 @@ const FlowGraph = ({
     const newGraphSpec = replaceTaskArgumentsInGraphSpec(
       taskId,
       graphSpec,
-      newTaskSpecArguments
+      newTaskSpecArguments,
     );
 
     updateGraphSpec(newGraphSpec);
@@ -136,7 +136,7 @@ const FlowGraph = ({
 
   const setGraphOutputValue = (
     outputName: string,
-    outputValue?: TaskOutputArgument
+    outputValue?: TaskOutputArgument,
   ) => {
     const nonNullOutputObject = outputValue
       ? { [outputName]: outputValue }
@@ -170,7 +170,7 @@ const FlowGraph = ({
     // Not really needed since react-flow sends the node's incoming and outcoming edges for deletion when a node is deleted
     for (const [taskId, taskSpec] of Object.entries(graphSpec.tasks)) {
       for (const [inputName, argument] of Object.entries(
-        taskSpec.arguments ?? {}
+        taskSpec.arguments ?? {},
       )) {
         if (typeof argument !== "string" && "graphInput" in argument) {
           if (argument.graphInput.inputName === inputNameToRemove) {
@@ -181,7 +181,7 @@ const FlowGraph = ({
     }
 
     const newInputs = (componentSpec.inputs ?? []).filter(
-      (inputSpec) => inputSpec.name !== inputNameToRemove
+      (inputSpec) => inputSpec.name !== inputNameToRemove,
     );
     setComponentSpec({ ...componentSpec, inputs: newInputs });
   };
@@ -190,7 +190,7 @@ const FlowGraph = ({
     setGraphOutputValue(outputNameToRemove);
     // Removing the output itself
     const newOutputs = (componentSpec.outputs ?? []).filter(
-      (outputSpec) => outputSpec.name !== outputNameToRemove
+      (outputSpec) => outputSpec.name !== outputNameToRemove,
     );
     setComponentSpec({ ...componentSpec, outputs: newOutputs });
   };
@@ -217,15 +217,15 @@ const FlowGraph = ({
     // Step 2: Remove any connections from this task to graph outputs
     const newGraphOutputValues = Object.fromEntries(
       Object.entries(graphSpec.outputValues ?? {}).filter(
-        ([_, argument]) => argument.taskOutput.taskId !== taskIdToRemove
-      )
+        ([_, argument]) => argument.taskOutput.taskId !== taskIdToRemove,
+      ),
     );
 
     // Step 3: Remove the task itself from the graph
     const newTasks = Object.fromEntries(
       Object.entries(graphSpec.tasks).filter(
-        ([taskId]) => taskId !== taskIdToRemove
-      )
+        ([taskId]) => taskId !== taskIdToRemove,
+      ),
     );
 
     // Step 4: Update the graph spec with our changes
@@ -272,7 +272,7 @@ const FlowGraph = ({
         reactFlowInstance,
         componentSpec,
         setComponentSpec,
-        graphSpec
+        graphSpec,
       );
     }
   };
@@ -323,7 +323,7 @@ const FlowGraph = ({
   const handleOnNodesChange = (changes: NodeChange[]) => {
     // Process position changes and update component spec
     const positionChanges = changes.filter(
-      (change) => change.type === "position" && change.dragging === false
+      (change) => change.type === "position" && change.dragging === false,
     );
 
     if (positionChanges.length > 0) {

--- a/src/components/shared/ReactFlow/FlowGraph/TaskNode/ArgumentsEditor/ArgumentsEditorDialog.tsx
+++ b/src/components/shared/ReactFlow/FlowGraph/TaskNode/ArgumentsEditor/ArgumentsEditorDialog.tsx
@@ -18,9 +18,9 @@ import { ArgumentsEditor } from "./ArgumentsEditor";
 interface ArgumentsEditorDialogProps {
   initialPosition?: { x: number; y: number };
   taskSpec: TaskSpec;
+  disabled?: boolean;
   closeEditor: () => void;
   setArguments?: (args: Record<string, ArgumentType>) => void;
-  disabled?: boolean;
   handleDelete: () => void;
 }
 

--- a/src/components/shared/ReactFlow/FlowGraph/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowGraph/TaskNode/TaskNode.tsx
@@ -14,7 +14,6 @@ import {
   CircleDashed,
   EyeIcon,
   RefreshCcw,
-  SettingsIcon,
 } from "lucide-react";
 import {
   type CSSProperties,
@@ -24,7 +23,6 @@ import {
   useState,
 } from "react";
 
-import { Button } from "@/components/ui/button";
 import { useDynamicFontSize } from "@/hooks/useDynamicFontSize";
 import { cn } from "@/lib/utils";
 import type { ComponentTaskNodeCallbacks } from "@/types/taskNode";
@@ -273,8 +271,8 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
     }
   };
 
-  const handleDoubleClick = () => {
-    if (!isArgumentsEditorOpen) {
+  const handleClick = () => {
+    if (!isArgumentsEditorOpen && !runStatus) {
       setIsArgumentsEditorOpen(true);
     }
   };
@@ -295,26 +293,17 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
         )}
         style={{ width: `${NODE_WIDTH_IN_PX}px` }}
         ref={nodeRef}
+        onClick={handleClick}
       >
         <div className="p-3 flex items-center justify-between">
           <div
-            className="font-medium text-gray-800 w-3/4 text-center whitespace-nowrap"
+            className="font-medium text-gray-800 whitespace-nowrap w-full text-center"
             title={title}
             ref={textRef}
           >
             {label}
           </div>
           <div className="flex items-center gap-2">
-            {!runStatus && (
-              <Button
-                variant="outline"
-                size="icon"
-                className="cursor-pointer"
-                onClick={handleDoubleClick}
-              >
-                <SettingsIcon className="w-3 h-3" />
-              </Button>
-            )}
             {runStatus && (
               <TaskDetailsSheet
                 taskSpec={taskSpec}

--- a/src/components/shared/ReactFlow/FlowGraph/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowGraph/TaskNode/TaskNode.tsx
@@ -279,7 +279,6 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
 
   const handleDelete = () => {
     typedData.onDelete();
-    closeArgumentsEditor();
   };
 
   return (

--- a/src/components/shared/ReactFlow/FlowGraph/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowGraph/TaskNode/TaskNode.tsx
@@ -197,7 +197,7 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
   // ][Math.floor(Math.random() * 10)];
 
   if (componentSpec === undefined) {
-    return <></>;
+    return null;
   }
 
   const label = componentSpec.name ?? "<component>";

--- a/src/utils/nodes/createNodes.test.ts
+++ b/src/utils/nodes/createNodes.test.ts
@@ -1,11 +1,10 @@
-import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { ComponentSpec } from "../utils/componentSpec";
-import { isGraphImplementation } from "../utils/componentSpec";
-import useComponentSpecToNodes from "./useComponentSpecToNodes";
+import type { ComponentSpec } from "../componentSpec";
+import { isGraphImplementation } from "../componentSpec";
+import createNodes from "./createNodes";
 
-describe("useComponentSpecToNodes", () => {
+describe("createNodes", () => {
   const createBasicComponentSpec = (implementation: any): ComponentSpec => ({
     name: "Test Component",
     implementation,
@@ -27,11 +26,9 @@ describe("useComponentSpecToNodes", () => {
       container: { image: "test" },
     });
 
-    const { result } = renderHook(() =>
-      useComponentSpecToNodes(componentSpec, mockNodeCallbacks),
-    );
+    const result = createNodes(componentSpec, mockNodeCallbacks);
 
-    expect(result.current.nodes).toEqual([]);
+    expect(result).toEqual([]);
   });
 
   it("creates task nodes correctly", () => {
@@ -53,11 +50,9 @@ describe("useComponentSpecToNodes", () => {
       throw new Error("Expected graph implementation");
     }
 
-    const { result } = renderHook(() =>
-      useComponentSpecToNodes(componentSpec, mockNodeCallbacks),
-    );
+    const result = createNodes(componentSpec, mockNodeCallbacks);
 
-    expect(result.current.nodes).toContainEqual(
+    expect(result).toContainEqual(
       expect.objectContaining({
         id: "task_task1",
         position: { x: 100, y: 200 },
@@ -83,11 +78,9 @@ describe("useComponentSpecToNodes", () => {
       outputs: [],
     };
 
-    const { result } = renderHook(() =>
-      useComponentSpecToNodes(componentSpec, mockNodeCallbacks),
-    );
+    const result = createNodes(componentSpec, mockNodeCallbacks);
 
-    expect(result.current.nodes).toContainEqual({
+    expect(result).toContainEqual({
       id: "input_input1",
       data: { label: "input1" },
       position: { x: 50, y: 100 },
@@ -110,11 +103,9 @@ describe("useComponentSpecToNodes", () => {
       ],
     };
 
-    const { result } = renderHook(() =>
-      useComponentSpecToNodes(componentSpec, mockNodeCallbacks),
-    );
+    const result = createNodes(componentSpec, mockNodeCallbacks);
 
-    expect(result.current.nodes).toContainEqual({
+    expect(result).toContainEqual({
       id: "output_output1",
       data: { label: "output1" },
       position: { x: 300, y: 150 },
@@ -139,24 +130,22 @@ describe("useComponentSpecToNodes", () => {
       outputs: [{ name: "output1" }],
     };
 
-    const { result } = renderHook(() =>
-      useComponentSpecToNodes(componentSpec, mockNodeCallbacks),
-    );
+    const result = createNodes(componentSpec, mockNodeCallbacks);
     const defaultPosition = { x: 0, y: 0 };
 
-    expect(result.current.nodes).toContainEqual(
+    expect(result).toContainEqual(
       expect.objectContaining({
         id: "task_task1",
         position: defaultPosition,
       }),
     );
-    expect(result.current.nodes).toContainEqual(
+    expect(result).toContainEqual(
       expect.objectContaining({
         id: "input_input1",
         position: defaultPosition,
       }),
     );
-    expect(result.current.nodes).toContainEqual(
+    expect(result).toContainEqual(
       expect.objectContaining({
         id: "output_output1",
         position: defaultPosition,
@@ -182,10 +171,8 @@ describe("useComponentSpecToNodes", () => {
       },
     });
 
-    const { result } = renderHook(() =>
-      useComponentSpecToNodes(componentSpec, mockNodeCallbacks),
-    );
-    const taskNode = result.current.nodes.find((node) => node.id === nodeId) as
+    const result = createNodes(componentSpec, mockNodeCallbacks);
+    const taskNode = result.find((node) => node.id === nodeId) as
       | { id: string; data: { setArguments: (args: any) => void } }
       | undefined;
 

--- a/src/utils/nodes/createNodes.ts
+++ b/src/utils/nodes/createNodes.ts
@@ -1,9 +1,9 @@
-import { type Node, type NodeChange, useNodesState } from "@xyflow/react";
-import { useEffect } from "react";
+import { type Node } from "@xyflow/react";
 
 import type { ComponentTaskNodeCallbacks } from "@/types/taskNode";
 import type { ComponentSpec, GraphSpec } from "@/utils/componentSpec";
 import { extractPositionFromAnnotations } from "@/utils/nodes/extractPositionFromAnnotations";
+import { taskIdToNodeId } from "@/utils/nodes/nodeIdUtils";
 
 export type NodeAndTaskId = {
   taskId: string;
@@ -26,28 +26,7 @@ type NodeCallbacks = {
   [K in keyof ComponentTaskNodeCallbacks]: CallbackWithIds<K>;
 };
 
-const useComponentSpecToNodes = (
-  componentSpec: ComponentSpec,
-  nodeCallbacks: NodeCallbacks,
-): {
-  nodes: Node[];
-  onNodesChange: (changes: NodeChange[]) => void;
-} => {
-  const initialNodes = createNodes(componentSpec, nodeCallbacks);
-  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
-
-  useEffect(() => {
-    const newNodes = createNodes(componentSpec, nodeCallbacks);
-    setNodes(newNodes);
-  }, [componentSpec]);
-
-  return {
-    nodes,
-    onNodesChange,
-  };
-};
-
-const createNodes = (
+export const createNodes = (
   componentSpec: ComponentSpec,
   nodeCallbacks: NodeCallbacks,
 ): Node[] => {
@@ -69,7 +48,7 @@ const createTaskNodes = (
 ) => {
   return Object.entries(graphSpec.tasks).map(([taskId, taskSpec]) => {
     const position = extractPositionFromAnnotations(taskSpec.annotations);
-    const nodeId = `task_${taskId}`;
+    const nodeId = taskIdToNodeId(taskId);
 
     // Dynamically add callbacks to node by first injecting the node & task id
     const dynamicCallbacks = Object.fromEntries(
@@ -121,4 +100,4 @@ const createOutputNodes = (componentSpec: ComponentSpec) => {
   });
 };
 
-export default useComponentSpecToNodes;
+export default createNodes;


### PR DESCRIPTION
Some changes to the Arguments Editor:

1. Remove the 'Setting' button - a single click (not drag) will now open the Argument Editor
2. `esc` to close the editor (applies to all other dialogs as well) - nb. click-outside the editor will not close it so that users can still click and drag around the graph without closing the editor
3. Fix `delete` node button not working
4. Delete Confirmation Dialog will not longer appear behind other dialogs
5. Argument Editor Dialog will remain open while the user confirms deletion (i.e. if the delete operation is canceled the dialog doesn't need to be reopened)
6. Fix app crash when applying changes to arguments

Closes https://github.com/Shopify/oasis-frontend/issues/39
Closes https://github.com/Cloud-Pipelines/pipeline-studio-app/issues/183

This PR will be followed later by one that moves the Argument Editor Dialog into a sidebar component.