### PR TITLE
Improve logic for Argument Editor placeholders and defaults

### DIFF
--- a/src/DragNDrop/PipelineSubmitter.tsx
+++ b/src/DragNDrop/PipelineSubmitter.tsx
@@ -33,7 +33,6 @@ const PipelineSubmitter = ({
         initialValue: "",
         inputSpec: input,
         isRemoved: false,
-        linkedNode: false,
       } as ArgumentInput;
     }) ?? [];
 

--- a/src/DragNDrop/PipelineSubmitter.tsx
+++ b/src/DragNDrop/PipelineSubmitter.tsx
@@ -8,8 +8,10 @@
 
 import { useEffect, useState } from "react";
 
+import type { ArgumentInput } from "@/components/ArgumentsEditor";
+
 import { ArgumentsEditor } from "../components/ArgumentsEditor/ArgumentsEditor";
-import type { ArgumentInput, ComponentSpec } from "../componentSpec";
+import type { ComponentSpec } from "../componentSpec";
 import GoogleCloudSubmitter from "./GoogleCloud";
 import KubeflowPipelinesSubmitter from "./KubeflowPipelinesSubmitter";
 import ShopifyCloudSubmitter from "./ShopifyCloud";

--- a/src/DragNDrop/ShopifyCloud.tsx
+++ b/src/DragNDrop/ShopifyCloud.tsx
@@ -159,9 +159,7 @@ const ShopifyCloudSubmitter = ({
             Submitting...
           </>
         ) : cooldownTime > 0 ? (
-          <>
-            Submit Run ({cooldownTime}s)
-          </>
+          <>Submit Run ({cooldownTime}s)</>
         ) : (
           "Submit Run"
         )}

--- a/src/componentSpec.ts
+++ b/src/componentSpec.ts
@@ -201,18 +201,6 @@ export interface TaskOutputArgument {
 export type ArgumentType = string | GraphInputArgument | TaskOutputArgument;
 
 /**
- * Argument input to the Argument Editor.
- */
-export type ArgumentInput = {
-  key: string;
-  value: ArgumentType;
-  initialValue: ArgumentType;
-  inputSpec: InputSpec;
-  isRemoved?: boolean;
-  linkedNode?: boolean;
-};
-
-/**
  * Pair of operands for a binary operation.
  */
 export interface TwoArgumentOperands {

--- a/src/components/ArgumentsEditor/ArgumentInputField.tsx
+++ b/src/components/ArgumentsEditor/ArgumentInputField.tsx
@@ -21,16 +21,12 @@ import type {
 } from "../../componentSpec";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 
-/**
- * Argument input to the Argument Editor.
- */
 export type ArgumentInput = {
   key: string;
   value: ArgumentType;
   initialValue: ArgumentType;
   inputSpec: InputSpec;
   isRemoved?: boolean;
-  linkedNode?: boolean;
 };
 
 export const ArgumentInputField = ({
@@ -48,7 +44,7 @@ export const ArgumentInputField = ({
 
   const handleInputChange = (value: string) => {
     setInputValue(value);
-    setArgument({ ...argument, value, linkedNode: false, isRemoved: false });
+    setArgument({ ...argument, value, isRemoved: false });
   };
 
   const handleRemove = () => {
@@ -60,10 +56,9 @@ export const ArgumentInputField = ({
     if (!updatedArgument.isRemoved && updatedArgument.value === "") {
       const defaultValue = getDefaultValue(updatedArgument);
 
-      updatedArgument.value = defaultValue.value;
-      updatedArgument.linkedNode = false;
+      updatedArgument.value = defaultValue;
 
-      setInputValue(defaultValue.value);
+      setInputValue(defaultValue);
     }
 
     setArgument(updatedArgument);
@@ -72,9 +67,8 @@ export const ArgumentInputField = ({
   const handleReset = () => {
     const defaultValue = getDefaultValue(argument);
 
-    setInputValue(defaultValue.value);
-
-    setArgument({ ...argument, value: defaultValue.value, linkedNode: false });
+    setInputValue(defaultValue);
+    setArgument({ ...argument, value: defaultValue });
   };
 
   const handleUndo = () => {
@@ -91,8 +85,13 @@ export const ArgumentInputField = ({
     if (argument.inputSpec.default !== undefined) {
       return argument.inputSpec.default;
     }
+
+    if (argument.isRemoved) {
+      return "";
+    }
+
     return getPlaceholder(argument.value);
-  }, [argument.inputSpec.default, argument.value]);
+  }, [argument]);
 
   return (
     <div className="flex w-full items-center gap-2 py-1">
@@ -186,7 +185,7 @@ export const ArgumentInputField = ({
               disabled={
                 disabled ||
                 argument.isRemoved ||
-                argument.value === getDefaultValue(argument).value
+                argument.value === getDefaultValue(argument)
               }
               variant="ghost"
               size="icon"
@@ -244,11 +243,5 @@ const getInputValue = (argumentInput: ArgumentInput) => {
 };
 
 const getDefaultValue = (argumentInput: ArgumentInput) => {
-  const value = argumentInput.inputSpec.default ?? "";
-
-  if (argumentInput.inputSpec.default === undefined) {
-    return { value, linkedNode: false };
-  }
-
-  return { value, linkedNode: argumentInput.linkedNode };
+  return argumentInput.inputSpec.default ?? "";
 };

--- a/src/components/ArgumentsEditor/ArgumentsEditor.tsx
+++ b/src/components/ArgumentsEditor/ArgumentsEditor.tsx
@@ -6,9 +6,8 @@
  * @copyright 2021 Alexey Volkov <alexey.volkov+oss@ark-kun.com>
  */
 
-import type { ArgumentInput } from "../../componentSpec";
 import { TooltipProvider } from "../ui/tooltip";
-import { ArgumentInputField } from "./ArgumentInputField";
+import { type ArgumentInput, ArgumentInputField } from "./ArgumentInputField";
 
 interface ArgumentsEditorProps {
   argumentData: ArgumentInput[];

--- a/src/components/ArgumentsEditor/ArgumentsEditorDialog.tsx
+++ b/src/components/ArgumentsEditor/ArgumentsEditorDialog.tsx
@@ -40,7 +40,6 @@ const ArgumentsEditorDialog = ({
         * [initialValue] - This is the initial value of the argument when the Editor is opened. Immutable. It is used to determine if the argument has been changed during the current editing session.
         * [inputSpec] - These are some general constants for the argument. Immutable. It is used to display the argument name and type in the UI.
         * [isRemoved] - This is used to remove unwanted arguments from the Task Spec, as specified by the user. This is essentially used in place of an "undefined" input, since React requires an empty string for controlled components.
-        * [linkedNode] - This is used to determine if the argument is linked to a node in the graph (i.e. there is a visible line). This is used for showing the informative placeholder text in the UI.
         
         * Note that "undefined" and "empty string" are treated differently in the task spec, but we can only use "empty string" in the UI due to React's rules around controlled components.
         * The difference is best seen in a required argument with a linked node:
@@ -58,12 +57,6 @@ const ArgumentsEditorDialog = ({
         initialValue: initialValue ?? "",
         inputSpec: input,
         isRemoved: initialValue === undefined,
-        linkedNode: !!(
-          initialValue &&
-          typeof initialValue === "object" &&
-          "taskOutput" in initialValue &&
-          initialValue.taskOutput
-        ),
       } as ArgumentInput;
     }) ?? [];
 

--- a/src/components/ArgumentsEditor/ArgumentsEditorDialog.tsx
+++ b/src/components/ArgumentsEditor/ArgumentsEditorDialog.tsx
@@ -10,11 +10,8 @@ import { useState } from "react";
 
 import DraggableDialog from "@/DragNDrop/DraggableDialog";
 
-import type {
-  ArgumentInput,
-  ArgumentType,
-  TaskSpec,
-} from "../../componentSpec";
+import type { ArgumentType, TaskSpec } from "../../componentSpec";
+import type { ArgumentInput } from "./ArgumentInputField";
 import { ArgumentsEditor } from "./ArgumentsEditor";
 
 interface ArgumentsEditorDialogProps {
@@ -53,18 +50,19 @@ const ArgumentsEditorDialog = ({
       */
 
       const existingArgument = taskSpec.arguments?.[input.name];
+      const initialValue = existingArgument ?? input.default;
 
       return {
         key: input.name,
-        value: existingArgument ?? "",
-        initialValue: existingArgument,
+        value: initialValue ?? "",
+        initialValue: initialValue ?? "",
         inputSpec: input,
-        isRemoved: existingArgument === undefined,
+        isRemoved: initialValue === undefined,
         linkedNode: !!(
-          existingArgument &&
-          typeof existingArgument === "object" &&
-          "taskOutput" in existingArgument &&
-          existingArgument.taskOutput
+          initialValue &&
+          typeof initialValue === "object" &&
+          "taskOutput" in initialValue &&
+          initialValue.taskOutput
         ),
       } as ArgumentInput;
     }) ?? [];


### PR DESCRIPTION
Follow-up to https://github.com/Cloud-Pipelines/pipeline-studio-app/pull/163

- Argument Input Fields will be pre-populated with their default value if there is one.
- Argument Input Fields will be "Included" if there is a default value.
- "Excluded" Argument Input Fields can be typed in to. Typing will automatically "Include" the field.
- Empty fields will now show their default value as a placeholder, if there is one.
- Simplified placeholder logic - removed the `linkedNodes` property from `ArgumentInput` as I found a smarter way of managing placeholder text.
- Moved the `ArgumentInput` type into the `ArgumentEditorInput` component.