### PR TITLE
Add button to duplicate a Task Node

### DIFF
--- a/src/DragNDrop/ComponentTaskNode.tsx
+++ b/src/DragNDrop/ComponentTaskNode.tsx
@@ -12,6 +12,7 @@ import {
   CircleAlert,
   CircleCheck,
   CircleDashed,
+  Copy,
   EyeIcon,
   RefreshCcw,
   SettingsIcon,
@@ -290,6 +291,12 @@ const ComponentTaskNode = ({ data }: NodeProps) => {
     }
   };
 
+  const handleCopy = () => {
+    if ("duplicateTask" in data && typeof data.duplicateTask === "function") {
+      (data as { duplicateTask: () => void }).duplicateTask();
+    }
+  };
+
   return (
     <>
       <div
@@ -314,6 +321,14 @@ const ComponentTaskNode = ({ data }: NodeProps) => {
                 <SettingsIcon className="w-3 h-3" />
               </Button>
             )}
+            <Button
+              variant="outline"
+              size="icon"
+              className="cursor-pointer"
+              onClick={handleCopy}
+            >
+              <Copy className="w-3 h-3" />
+            </Button>
             {runStatus && (
               <TaskDetailsSheet
                 taskSpec={taskSpec}

--- a/src/DragNDrop/ShopifyCloud.tsx
+++ b/src/DragNDrop/ShopifyCloud.tsx
@@ -159,9 +159,7 @@ const ShopifyCloudSubmitter = ({
             Submitting...
           </>
         ) : cooldownTime > 0 ? (
-          <>
-            Submit Run ({cooldownTime}s)
-          </>
+          <>Submit Run ({cooldownTime}s)</>
         ) : (
           "Submit Run"
         )}

--- a/src/hooks/useComponentSpecToNodes.tsx
+++ b/src/hooks/useComponentSpecToNodes.tsx
@@ -74,6 +74,30 @@ const getTaskNodes = (
               implementation: { graph: newGraphSpec },
             });
           },
+          duplicateTask: () => {
+            const newTaskId = generateDuplicateTaskId(taskId);
+            const offset = 10;
+            const annotations = taskSpec.annotations || {};
+            const updatedAnnotations = setPositionInAnnotations(annotations, {
+              x: position.x + offset,
+              y: position.y + offset,
+            });
+            const newTaskSpec = {
+              ...taskSpec,
+              annotations: { ...updatedAnnotations },
+            };
+            const newGraphSpec = {
+              ...graphSpec,
+              tasks: {
+                ...graphSpec.tasks,
+                [newTaskId]: newTaskSpec,
+              },
+            };
+            setComponentSpec({
+              ...componentSpec,
+              implementation: { graph: newGraphSpec },
+            });
+          },
         },
         position: position,
         type: "task",
@@ -127,6 +151,41 @@ const extractPositionFromAnnotations = (
   } catch {
     return defaultPosition;
   }
+};
+
+const setPositionInAnnotations = (
+  annotations: Record<string, unknown>,
+  position: XYPosition,
+): Record<string, unknown> => {
+  const updatedAnnotations = { ...annotations };
+  updatedAnnotations["editor.position"] = JSON.stringify(position);
+  return updatedAnnotations;
+};
+
+const generateDuplicateTaskId = (taskId: string): string => {
+  // If taskId does not end with "_copy", append "_copy"
+  // e.g., "task" becomes "task_copy"
+  if (!taskId.endsWith("_copy")) {
+    return taskId + "_copy";
+  }
+
+  // If taskId ends with "_copy", add a number to the end
+  // e.g., "task_copy" becomes "task_copy2"
+  if (taskId.endsWith("_copy")) {
+    return taskId + "2";
+  }
+
+  // If taskId ends with "_copyX", increment X
+  // e.g., "task_copy2" becomes "task_copy3"
+  const match = taskId.match(/^(.*_copy)(\d+)$/);
+  if (match) {
+    const base = match[1];
+    const number = parseInt(match[2], 10);
+    return `${base}${number + 1}`;
+  }
+
+  // Otherwise, append "_c" - this case should not occur
+  return taskId + "_c";
 };
 
 export default useComponentSpecToNodes;


### PR DESCRIPTION
Closes https://github.com/Cloud-Pipelines/pipeline-studio-app/issues/19
Closes https://github.com/Cloud-Pipelines/pipeline-studio-app/issues/156
Closes https://github.com/Shopify/oasis-frontend/issues/24


Adds a button to the interface of a TaskNode that will duplicate it.