### PR TITLE
Explicit import from React

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,14 @@
   },
   "files.readonlyInclude": {
     "**/routeTree.gen.ts": true
-  }
+  },
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ]
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
+import type { ReactNode } from "react";
+
 import AppFooter from "./components/AppFooter";
 
-function App({ children }: { children: React.ReactNode }) {
+function App({ children }: { children: ReactNode }) {
   return (
     <div className="App">
       {children}

--- a/src/DragNDrop/DraggableComponent.tsx
+++ b/src/DragNDrop/DraggableComponent.tsx
@@ -7,7 +7,12 @@
  */
 
 import { CircleX } from "lucide-react";
-import { type DragEvent, type MouseEvent } from "react";
+import {
+  type DetailedHTMLProps,
+  type DragEvent,
+  type HTMLAttributes,
+  type MouseEvent,
+} from "react";
 
 import CondensedUrl from "@/components/CondensedUrl";
 import ConfirmationDialog from "@/components/ConfirmationDialog";
@@ -21,16 +26,13 @@ const onDragStart = (event: DragEvent, nodeData: object) => {
     JSON.stringify({
       offsetX: event.nativeEvent.offsetX,
       offsetY: event.nativeEvent.offsetY,
-    }),
+    })
   );
   event.dataTransfer.effectAllowed = "move";
 };
 
 interface DraggableComponentProps
-  extends React.DetailedHTMLProps<
-    React.HTMLAttributes<HTMLDivElement>,
-    HTMLDivElement
-  > {
+  extends DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
   componentReference: ComponentReference;
   onDelete?: (e: MouseEvent) => void;
 }

--- a/src/DragNDrop/GraphComponentLink.tsx
+++ b/src/DragNDrop/GraphComponentLink.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useStore } from "@xyflow/react";
+import type { CSSProperties, Ref } from "react";
 
 import type { ComponentSpec } from "../componentSpec";
 import { componentSpecToYaml } from "../componentStore";
@@ -16,8 +17,8 @@ interface GraphComponentLinkProps {
   componentSpec: ComponentSpec;
   downloadFileName?: string;
   linkText?: string;
-  linkRef?: React.Ref<HTMLAnchorElement>;
-  style?: React.CSSProperties;
+  linkRef?: Ref<HTMLAnchorElement>;
+  style?: CSSProperties;
 }
 
 const GraphComponentLink = ({

--- a/src/DragNDrop/UserComponentLibrary.tsx
+++ b/src/DragNDrop/UserComponentLibrary.tsx
@@ -6,7 +6,7 @@
  * @copyright 2021 Alexey Volkov <alexey.volkov+oss@ark-kun.com>
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { type MouseEvent, useCallback, useEffect, useState } from "react";
 import { useDropzone } from "react-dropzone";
 
 import { Button } from "@/components/ui/button";
@@ -123,7 +123,7 @@ const UserComponentLibrary = () => {
   );
 
   const handleDelete = useCallback(
-    (fileName: string) => (e: React.MouseEvent) => {
+    (fileName: string) => (e: MouseEvent) => {
       e.stopPropagation();
       e.preventDefault();
       if (fileName) {

--- a/src/components/PipelineSection/PipelineSection.tsx
+++ b/src/components/PipelineSection/PipelineSection.tsx
@@ -1,5 +1,5 @@
 import { CircleX, Terminal } from "lucide-react";
-import { useEffect, useState } from "react";
+import { type ChangeEvent, useEffect, useState } from "react";
 
 import NewExperimentDialog from "@/components/NewExperiment";
 import PipelineRow from "@/components/PipelineRow";
@@ -81,7 +81,7 @@ export const PipelineSection = () => {
     return name.toLowerCase().includes(searchQuery.toLowerCase());
   });
 
-  const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleSearch = (e: ChangeEvent<HTMLInputElement>) => {
     setSearchQuery(e.target.value);
   };
 

--- a/src/components/RunSection/RunRow.tsx
+++ b/src/components/RunSection/RunRow.tsx
@@ -1,4 +1,5 @@
 import { Link, useNavigate } from "@tanstack/react-router";
+import { type MouseEvent } from "react";
 
 import type { PipelineRunResponse } from "@/api/types.gen";
 import {
@@ -58,7 +59,7 @@ const RunRow = ({ run }: { run: PipelineRunResponse }) => {
   const LinkProps = {
     to: clickThroughUrl,
     className: "underline hover:text-blue-500 text-black",
-    onClick: (e: React.MouseEvent) => {
+    onClick: (e: MouseEvent) => {
       e.stopPropagation(); // Prevent triggering the row click handler
     },
   };

--- a/src/components/TaskDetailsSheet/artifacts.tsx
+++ b/src/components/TaskDetailsSheet/artifacts.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import type { ReactNode } from "react";
 
 import type { GetArtifactsApiExecutionsIdArtifactsGetResponse } from "@/api/types.gen";
 import { API_URL } from "@/utils/constants";
@@ -35,7 +36,7 @@ const ArtifactValue = ({
   value,
 }: {
   label: string;
-  value: React.ReactNode;
+  value: ReactNode;
 }) => (
   <div className="flex text-xs">
     <span className="text-gray-500 w-20 flex-shrink-0">{label}:</span>

--- a/src/components/shared/PipelineNameDialog.tsx
+++ b/src/components/shared/PipelineNameDialog.tsx
@@ -1,5 +1,5 @@
 import { AlertCircle, InfoIcon } from "lucide-react";
-import { useState } from "react";
+import { type ChangeEvent, type ReactNode, useState } from "react";
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -18,13 +18,13 @@ import useLoadUserPipelines from "@/hooks/useLoadUserPipelines";
 import { VALID_NAME_MESSAGE, VALID_NAME_REGEX } from "@/utils/constants";
 
 interface PipelineNameDialogProps {
-  trigger: React.ReactNode;
+  trigger: ReactNode;
   title: string;
   description?: string;
   initialName: string;
   onSubmit: (name: string) => void;
   submitButtonText: string;
-  submitButtonIcon?: React.ReactNode;
+  submitButtonIcon?: ReactNode;
   isSubmitDisabled?: (name: string, error: string | null) => boolean;
   onOpenChange?: (open: boolean) => void;
 }
@@ -44,7 +44,7 @@ export const PipelineNameDialog = ({
   const [name, setName] = useState(initialName);
   const { userPipelines, isLoadingUserPipelines } = useLoadUserPipelines();
 
-  const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleOnChange = (e: ChangeEvent<HTMLInputElement>) => {
     const newName = e.target.value;
     const existingPipelineNames = new Set(
       Array.from(userPipelines.keys()).map((name) => name.toLowerCase()),


### PR DESCRIPTION
No more use of `React.[module]`, except in the `ui` folder.


(I tried to put together an ESLint rule to enforce this but couldn't quite get it working... maybe in the future I'll try again)