### PR TITLE
Removes info icon so you can click the node anywhere to see details

### DIFF
--- a/src/components/shared/ReactFlow/FlowGraph/TaskNode/TaskDetailsSheet/index.tsx
+++ b/src/components/shared/ReactFlow/FlowGraph/TaskNode/TaskDetailsSheet/index.tsx
@@ -1,14 +1,11 @@
-import type { Content } from "@radix-ui/react-dialog";
 import { ArrowDownToLine, Box, InfoIcon, Terminal } from "lucide-react";
-import { type ComponentProps, useState } from "react";
+import { useState } from "react";
 
-import { Button } from "@/components/ui/button";
 import {
   Sheet,
   SheetContent,
   SheetHeader,
   SheetTitle,
-  SheetTrigger,
 } from "@/components/ui/sheet";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
@@ -23,45 +20,26 @@ interface TaskDetailsSheetProps {
   taskSpec: TaskSpec;
   taskId: string;
   runStatus?: string;
+  isOpen: boolean;
+  onClose: () => void;
 }
 
 const TaskDetailsSheet = ({
   taskSpec,
   taskId,
   runStatus,
+  isOpen,
+  onClose,
 }: TaskDetailsSheetProps) => {
   const [activeTab, setActiveTab] = useState("info");
 
-  const handleInteractOutside: ComponentProps<
-    typeof Content
-  >["onInteractOutside"] = (event) => {
-    const target = event.target as HTMLElement;
-
-    if (target.closest('[data-slot="sheet-trigger"]')) {
-      return;
-    }
-    event.preventDefault();
-  };
-
   return (
-    <Sheet modal={false}>
-      <SheetTrigger asChild>
-        <Button
-          variant="outline"
-          size="icon"
-          className="cursor-pointer"
-          disabled={!runStatus}
-          data-slot="sheet-trigger"
-        >
-          <InfoIcon className="w-3 h-3" />
-        </Button>
-      </SheetTrigger>
+    <Sheet modal={false} open={isOpen} onOpenChange={onClose}>
       <SheetContent
         className={cn(
           "!max-w-none overflow-y-auto mt-[56px] h-[calc(100vh-56px)] transition-[width] duration-150",
           activeTab === "logs" ? "!w-[50%]" : "!w-[33.333333%]",
         )}
-        onInteractOutside={handleInteractOutside}
       >
         <SheetHeader>
           <SheetTitle>Task Details - {taskId}</SheetTitle>

--- a/src/components/shared/ReactFlow/FlowGraph/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowGraph/TaskNode/TaskNode.tsx
@@ -9,13 +9,6 @@
 import type { HandleType, NodeProps } from "@xyflow/react";
 import { Handle, Position } from "@xyflow/react";
 import {
-  CircleAlert,
-  CircleCheck,
-  CircleDashed,
-  EyeIcon,
-  RefreshCcw,
-} from "lucide-react";
-import {
   type CSSProperties,
   memo,
   type ReactElement,
@@ -146,31 +139,9 @@ function generateOutputHandles(outputSpecs: OutputSpec[]): ReactElement[] {
   );
 }
 
-const getStatusIcon = (status: string) => {
-  switch (status) {
-    case "SUCCEEDED":
-      return <CircleCheck className="w-3.5 h-3.5 text-emerald-500" />;
-    case "FAILED":
-    case "SYSTEM_ERROR":
-    case "INVALID":
-    case "UPSTREAM_FAILED":
-    case "UPSTREAM_FAILED_OR_SKIPPED":
-      return <CircleAlert className="w-3.5 h-3.5 text-rose-500" />;
-    case "RUNNING":
-    case "STARTING":
-    case "CANCELLING":
-      return <RefreshCcw className="w-3.5 h-3.5 text-sky-500 animate-spin" />;
-    case "CONDITIONALLY_SKIPPED":
-    case "CANCELLED":
-      return <EyeIcon className="w-3.5 h-3.5 text-slate-500" />;
-    default:
-      return <CircleDashed className="w-3.5 h-3.5 text-slate-400" />;
-  }
-};
-
 const ComponentTaskNode = ({ data, selected }: NodeProps) => {
   const [isArgumentsEditorOpen, setIsArgumentsEditorOpen] = useState(false);
-
+  const [isTaskDetailsSheetOpen, setIsTaskDetailsSheetOpen] = useState(false);
   const nodeRef = useRef<HTMLDivElement>(null);
   const textRef = useRef<HTMLDivElement>(null);
 
@@ -246,7 +217,7 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
       case "RUNNING":
       case "STARTING":
       case "CANCELLING":
-        return "border-sky-500";
+        return "border-sky-500 animate-pulse duration-2000";
       default:
         return "border-slate-300";
     }
@@ -275,10 +246,17 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
     if (!isArgumentsEditorOpen && !runStatus) {
       setIsArgumentsEditorOpen(true);
     }
+    if (!isTaskDetailsSheetOpen && runStatus) {
+      setIsTaskDetailsSheetOpen(true);
+    }
   };
 
   const handleDelete = () => {
     typedData.onDelete();
+  };
+
+  const handleTaskDetailsSheetClose = () => {
+    setIsTaskDetailsSheetOpen(false);
   };
 
   return (
@@ -305,15 +283,12 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
           <div className="flex items-center gap-2">
             {runStatus && (
               <TaskDetailsSheet
+                isOpen={isTaskDetailsSheetOpen}
                 taskSpec={taskSpec}
                 taskId={typedData.taskId}
                 runStatus={runStatus}
+                onClose={handleTaskDetailsSheetClose}
               />
-            )}
-            {runStatus && (
-              <div className="flex items-center ml-2 flex-shrink-0">
-                {getStatusIcon(runStatus)}
-              </div>
             )}
           </div>
         </div>


### PR DESCRIPTION
resolves: https://github.com/Shopify/oasis-frontend/issues/62

Similar to the pipeline editor, I have removed all icons from the node and now we can just click the node to show the sheet. I have also made it so if you click outside of the sheet it will close. 

I have also updated the status indicators. Instead of an Icon telling us what the status is, we only show the status colour on the nodes. additionally I have made the running nodes pulse slightly to signify that it is running

note: this video shows random status I forced through code.

https://github.com/user-attachments/assets/01e5e292-a1cb-4e67-a18f-78069dce599c

