### PR TITLE
Fixes delete user components bug and adds component link

### DIFF
--- a/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
@@ -1,4 +1,4 @@
-import { File } from "lucide-react";
+import { ExternalLink, File } from "lucide-react";
 import type { DragEvent } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
@@ -141,9 +141,21 @@ const ComponentMarkup = ({
                   Error loading component
                 </span>
               ) : (
-                <span className="truncate text-xs text-gray-800">
-                  {displayName}
-                </span>
+                <div className="flex-1 flex">
+                  <span className="truncate text-xs text-gray-800 max-w-[200px]">
+                    {displayName}
+                  </span>
+                  <div className="flex-1 flex justify-end mr-[15px]">
+                    <a
+                      href={url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="cursor-pointer"
+                    >
+                      <ExternalLink className="size-4 text-sky-500" />
+                    </a>
+                  </div>
+                </div>
               )}
             </div>
           </SidebarMenuItem>

--- a/src/components/shared/ReactFlow/FlowSidebar/components/UserComponentItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/UserComponentItem.tsx
@@ -110,23 +110,24 @@ const UserComponentItem = ({
             draggable
             onDragStart={onDragStart}
           >
-            <div className="flex items-center gap-2">
-              <File className="h-4 w-4 text-gray-400 flex-shrink-0" />
-              <span className="truncate text-xs text-gray-800">
-                {displayName}
-              </span>
+            <div className="flex items-center gap-2 w-full">
+              <div className="flex gap-2 w-full">
+                <File className="h-4 w-4 text-gray-400 flex-shrink-0" />
+                <span className="truncate text-xs text-gray-800 max-w-[200px]">
+                  {displayName}
+                </span>
+              </div>
+              <ConfirmationDialog
+                trigger={
+                  <div className="cursor-pointer mr-[15px]">
+                    <Trash2 className="size-4 text-red-500" />
+                  </div>
+                }
+                title="Delete component"
+                description="Are you sure you want to delete this component?"
+                onConfirm={handleDelete}
+              />
             </div>
-
-            <ConfirmationDialog
-              trigger={
-                <div className="cursor-pointer mr-[15px]">
-                  <Trash2 className="size-4 text-red-500" />
-                </div>
-              }
-              title="Delete component"
-              description="Are you sure you want to delete this component?"
-              onConfirm={handleDelete}
-            />
           </SidebarMenuItem>
         </TooltipTrigger>
         <TooltipContent side="left" className="max-w-xs whitespace-pre-wrap">


### PR DESCRIPTION
The user components now have a delete button no matter the length of the title
Components now have a link button no matter the length of their name

<img width="314" alt="Screenshot 2025-04-24 at 2 15 55 PM" src="https://github.com/user-attachments/assets/9f096ec9-4b4d-41b5-b588-01beaaadf282" />

Closes https://github.com/Shopify/oasis-frontend/issues/65
