### PR TITLE
Sync FlowGraph selection state with componentSpec

### DIFF
--- a/src/components/shared/ReactFlow/FlowGraph/FlowGraph.tsx
+++ b/src/components/shared/ReactFlow/FlowGraph/FlowGraph.tsx
@@ -17,7 +17,11 @@ import {
   type ReactFlowProps,
   useNodesState,
 } from "@xyflow/react";
-import type { ComponentType, DragEvent } from "react";
+import type {
+  ComponentType,
+  DragEvent,
+  MouseEvent as ReactMouseEvent,
+} from "react";
 import { useCallback, useEffect, useState } from "react";
 
 import { ConfirmationDialog } from "@/components/shared/Dialogs";
@@ -26,6 +30,7 @@ import useConfirmationDialog from "@/hooks/useConfirmationDialog";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import type { ArgumentType } from "@/utils/componentSpec";
 import { createNodes, type NodeAndTaskId } from "@/utils/nodes/createNodes";
+import { nodeIdToTaskId } from "@/utils/nodes/nodeIdUtils";
 
 import ComponentTaskNode from "./TaskNode/TaskNode";
 import { cleanupDeletedTasks } from "./utils/cleanupDeletedTasks";
@@ -76,6 +81,7 @@ const FlowGraph = ({
   const onInit: OnInit = (instance) => {
     setReactFlowInstance(instance);
   };
+  const [selectedNodes, setSelectedNodes] = useState<Node[]>([]);
 
   const onDelete = useCallback(
     async (ids: NodeAndTaskId) => {
@@ -86,7 +92,7 @@ const FlowGraph = ({
       const nodeId = ids.nodeId;
       const node = nodes.find((n) => n.id === nodeId);
       const edgesToRemove = edges.filter(
-        (edge) => edge.source === nodeId || edge.target === nodeId
+        (edge) => edge.source === nodeId || edge.target === nodeId,
       );
 
       if (node) {
@@ -101,7 +107,7 @@ const FlowGraph = ({
         }
       }
     },
-    [nodes, edges, componentSpec, setComponentSpec, triggerConfirmationDialog]
+    [nodes, edges, componentSpec, setComponentSpec, triggerConfirmationDialog],
   );
 
   const setArguments = useCallback(
@@ -114,11 +120,11 @@ const FlowGraph = ({
       const newGraphSpec = replaceTaskArgumentsInGraphSpec(
         taskId,
         graphSpec,
-        args
+        args,
       );
       updateGraphSpec(newGraphSpec);
     },
-    [graphSpec]
+    [graphSpec],
   );
 
   const onConnect = useCallback(
@@ -130,7 +136,7 @@ const FlowGraph = ({
       const updatedGraphSpec = handleConnection(graphSpec, connection);
       updateGraphSpec(updatedGraphSpec);
     },
-    [graphSpec, handleConnection, updateGraphSpec]
+    [graphSpec, handleConnection, updateGraphSpec],
   );
 
   const onDragOver = (event: DragEvent) => {
@@ -149,7 +155,7 @@ const FlowGraph = ({
       const newComponentSpec = onDropNode(
         event,
         reactFlowInstance,
-        componentSpec
+        componentSpec,
       );
       setComponentSpec(newComponentSpec);
     }
@@ -172,17 +178,17 @@ const FlowGraph = ({
 
       updatedComponentSpec = cleanupDeletedTasks(
         updatedComponentSpec,
-        params.nodes
+        params.nodes,
       );
 
       setComponentSpec(updatedComponentSpec);
     },
-    [componentSpec, setComponentSpec]
+    [componentSpec, setComponentSpec],
   );
 
   const handleOnNodesChange = (changes: NodeChange[]) => {
     const positionChanges = changes.filter(
-      (change) => change.type === "position" && change.dragging === false
+      (change) => change.type === "position" && change.dragging === false,
     );
 
     if (positionChanges.length > 0) {
@@ -204,7 +210,7 @@ const FlowGraph = ({
       if (updatedNodes.length > 0) {
         const updatedComponentSpec = updateNodePositions(
           updatedNodes,
-          componentSpec
+          componentSpec,
         );
         setComponentSpec(updatedComponentSpec);
       }
@@ -222,6 +228,45 @@ const FlowGraph = ({
     return confirmed;
   };
 
+  const handleSelectionChange = useCallback((params: NodesAndEdges) => {
+    const nodes = params.nodes;
+    setSelectedNodes(nodes);
+  }, []);
+
+  const handleSelectionDragEnd = useCallback(
+    (_e: ReactMouseEvent, nodes: Node[]) => {
+      setSelectedNodes(nodes);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    // Sync ReactFlow "selection" changes over to the componentSpec to maintain selection state between re-renders
+    // (createNodes is currently recreating all nodes from scratch each time componentSpec changes, which causes the selection state to desync)
+    const updatedTasks = { ...graphSpec.tasks };
+
+    Object.entries(updatedTasks).forEach(([taskId, taskSpec]) => {
+      const annotations = taskSpec.annotations || {};
+      annotations.selected = selectedNodes.some(
+        (node) => nodeIdToTaskId(node.id) === taskId,
+      );
+      updatedTasks[taskId] = {
+        ...taskSpec,
+        annotations,
+      };
+    });
+
+    const updatedGraphSpec = { ...graphSpec, tasks: updatedTasks };
+
+    if (JSON.stringify(updatedGraphSpec) === JSON.stringify(graphSpec)) {
+      return;
+    }
+
+    updateGraphSpec(updatedGraphSpec);
+  }, [selectedNodes, graphSpec, updateGraphSpec]);
+
+  const { title, desc } = getConfirmationDialogText(selectedNodes);
+
   return (
     <>
       <ReactFlow
@@ -238,13 +283,15 @@ const FlowGraph = ({
         onDelete={onElementsRemove}
         onInit={onInit}
         deleteKeyCode={["Delete", "Backspace"]}
+        onSelectionChange={handleSelectionChange}
+        onSelectionDragStop={handleSelectionDragEnd}
       >
         {children}
       </ReactFlow>
-      {!readOnly && (
+      {selectedNodes.length > 0 && !readOnly && (
         <ConfirmationDialog
-          title="Delete Node"
-          description="This will also will also delete all connections to and from the Node. This cannot be undone."
+          title={title}
+          description={desc}
           isOpen={isOpen}
           onConfirm={() => handlers?.onConfirm()}
           onCancel={() => handlers?.onCancel()}
@@ -255,3 +302,39 @@ const FlowGraph = ({
 };
 
 export default FlowGraph;
+
+function getConfirmationDialogText(selectedNodes: Node[]) {
+  const isDeletingMultipleNodes = selectedNodes.length > 1;
+
+  if (!isDeletingMultipleNodes) {
+    const singleDeleteTitle =
+      "Delete Node" +
+      (selectedNodes.length > 0 ? ` '${selectedNodes[0].id}'` : "") +
+      "?";
+
+    const singleDeleteDesc =
+      "This will also will also delete all connections to and from the Node. This cannot be undone.";
+
+    return {
+      title: singleDeleteTitle,
+      desc: singleDeleteDesc,
+    };
+  }
+
+  const multiDeleteTitle = `Delete Nodes?`;
+
+  const multiDeleteDesc = `Deleting ${
+    selectedNodes.length
+      ? selectedNodes
+          .map((node) => {
+            return `'${node.id}'`;
+          })
+          .join(", ")
+      : "nodes"
+  } will also delete all connections to and from these nodes. This cannot be undone.`;
+
+  return {
+    title: multiDeleteTitle,
+    desc: multiDeleteDesc,
+  };
+}

--- a/src/components/shared/ReactFlow/FlowGraph/FlowGraph.tsx
+++ b/src/components/shared/ReactFlow/FlowGraph/FlowGraph.tsx
@@ -86,7 +86,7 @@ const FlowGraph = ({
       const nodeId = ids.nodeId;
       const node = nodes.find((n) => n.id === nodeId);
       const edgesToRemove = edges.filter(
-        (edge) => edge.source === nodeId || edge.target === nodeId,
+        (edge) => edge.source === nodeId || edge.target === nodeId
       );
 
       if (node) {
@@ -101,7 +101,7 @@ const FlowGraph = ({
         }
       }
     },
-    [nodes, edges, componentSpec, setComponentSpec, triggerConfirmationDialog],
+    [nodes, edges, componentSpec, setComponentSpec, triggerConfirmationDialog]
   );
 
   const setArguments = useCallback(
@@ -114,11 +114,11 @@ const FlowGraph = ({
       const newGraphSpec = replaceTaskArgumentsInGraphSpec(
         taskId,
         graphSpec,
-        args,
+        args
       );
       updateGraphSpec(newGraphSpec);
     },
-    [graphSpec],
+    [graphSpec]
   );
 
   const onConnect = useCallback(
@@ -130,7 +130,7 @@ const FlowGraph = ({
       const updatedGraphSpec = handleConnection(graphSpec, connection);
       updateGraphSpec(updatedGraphSpec);
     },
-    [graphSpec, handleConnection, updateGraphSpec],
+    [graphSpec, handleConnection, updateGraphSpec]
   );
 
   const onDragOver = (event: DragEvent) => {
@@ -149,7 +149,7 @@ const FlowGraph = ({
       const newComponentSpec = onDropNode(
         event,
         reactFlowInstance,
-        componentSpec,
+        componentSpec
       );
       setComponentSpec(newComponentSpec);
     }
@@ -172,17 +172,17 @@ const FlowGraph = ({
 
       updatedComponentSpec = cleanupDeletedTasks(
         updatedComponentSpec,
-        params.nodes,
+        params.nodes
       );
 
       setComponentSpec(updatedComponentSpec);
     },
-    [componentSpec, setComponentSpec],
+    [componentSpec, setComponentSpec]
   );
 
   const handleOnNodesChange = (changes: NodeChange[]) => {
     const positionChanges = changes.filter(
-      (change) => change.type === "position" && change.dragging === false,
+      (change) => change.type === "position" && change.dragging === false
     );
 
     if (positionChanges.length > 0) {
@@ -204,7 +204,7 @@ const FlowGraph = ({
       if (updatedNodes.length > 0) {
         const updatedComponentSpec = updateNodePositions(
           updatedNodes,
-          componentSpec,
+          componentSpec
         );
         setComponentSpec(updatedComponentSpec);
       }

--- a/src/components/shared/ReactFlow/FlowGraph/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowGraph/TaskNode/TaskNode.tsx
@@ -263,10 +263,10 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
     <>
       <div
         className={cn(
-          `border rounded-md shadow-sm transition-all duration-200 hover:border-slate-400`,
+          "border rounded-md shadow-sm transition-all duration-200",
           getBorderColor(),
           getBgColor(),
-          selected && "border-sky-500",
+          selected ? "border-sky-500" : " hover:border-slate-400",
         )}
         style={{ width: `${NODE_WIDTH_IN_PX}px` }}
         ref={nodeRef}

--- a/src/components/shared/ReactFlow/FlowGraph/utils/cleanupDeletedTasks.ts
+++ b/src/components/shared/ReactFlow/FlowGraph/utils/cleanupDeletedTasks.ts
@@ -4,7 +4,7 @@ import type { ComponentSpec } from "@/utils/componentSpec";
 
 export const cleanupDeletedTasks = (
   componentSpec: ComponentSpec,
-  deletedNodes: Node[]
+  deletedNodes: Node[],
 ) => {
   const updatedComponentSpec = { ...componentSpec };
 
@@ -15,7 +15,7 @@ export const cleanupDeletedTasks = (
 
   const nodesToDeleteIds = deletedNodes
     .map((node) =>
-      node.id.startsWith("task_") ? node.id.replace("task_", "") : ""
+      node.id.startsWith("task_") ? node.id.replace("task_", "") : "",
     )
     .filter((id) => id); // Get all task IDs to delete and filter out empty strings
 
@@ -57,8 +57,8 @@ export const cleanupDeletedTasks = (
     ...updatedGraphSpec,
     tasks: Object.fromEntries(
       Object.entries(cleanedTasks).filter(
-        ([taskId]) => !nodesToDeleteIds.includes(taskId)
-      )
+        ([taskId]) => !nodesToDeleteIds.includes(taskId),
+      ),
     ),
   };
 

--- a/src/components/shared/ReactFlow/FlowGraph/utils/cleanupDeletedTasks.ts
+++ b/src/components/shared/ReactFlow/FlowGraph/utils/cleanupDeletedTasks.ts
@@ -4,7 +4,7 @@ import type { ComponentSpec } from "@/utils/componentSpec";
 
 export const cleanupDeletedTasks = (
   componentSpec: ComponentSpec,
-  deletedNodes: Node[],
+  deletedNodes: Node[]
 ) => {
   const updatedComponentSpec = { ...componentSpec };
 
@@ -15,7 +15,7 @@ export const cleanupDeletedTasks = (
 
   const nodesToDeleteIds = deletedNodes
     .map((node) =>
-      node.id.startsWith("task_") ? node.id.replace("task_", "") : "",
+      node.id.startsWith("task_") ? node.id.replace("task_", "") : ""
     )
     .filter((id) => id); // Get all task IDs to delete and filter out empty strings
 
@@ -57,8 +57,8 @@ export const cleanupDeletedTasks = (
     ...updatedGraphSpec,
     tasks: Object.fromEntries(
       Object.entries(cleanedTasks).filter(
-        ([taskId]) => !nodesToDeleteIds.includes(taskId),
-      ),
+        ([taskId]) => !nodesToDeleteIds.includes(taskId)
+      )
     ),
   };
 

--- a/src/utils/nodes/createNodes.ts
+++ b/src/utils/nodes/createNodes.ts
@@ -3,7 +3,8 @@ import { type Node } from "@xyflow/react";
 import type { ComponentTaskNodeCallbacks } from "@/types/taskNode";
 import type { ComponentSpec, GraphSpec } from "@/utils/componentSpec";
 import { extractPositionFromAnnotations } from "@/utils/nodes/extractPositionFromAnnotations";
-import { taskIdToNodeId } from "@/utils/nodes/nodeIdUtils";
+
+import { taskIdToNodeId } from "./nodeIdUtils";
 
 export type NodeAndTaskId = {
   taskId: string;
@@ -48,6 +49,7 @@ const createTaskNodes = (
 ) => {
   return Object.entries(graphSpec.tasks).map(([taskId, taskSpec]) => {
     const position = extractPositionFromAnnotations(taskSpec.annotations);
+    const selected = (taskSpec.annotations?.selected as boolean) ?? false;
     const nodeId = taskIdToNodeId(taskId);
 
     // Dynamically add callbacks to node by first injecting the node & task id
@@ -70,6 +72,7 @@ const createTaskNodes = (
       },
       position: position,
       type: "task",
+      selected: selected,
     } as Node;
   });
 };


### PR DESCRIPTION
Selection state is now synced with componentSpec, allowing selection state to be persisted across operations (such as moving nodes on the canvas).

- Selected Nodes now stored in state for future reference
- Selected Nodes remain selected after moving or operating on them
- Selection border takes precedence over hover border

Also fixes the regression introduced in #199 that removed the dynamic delete dialog text.

### Quick Comment
Natively ReactFlow already persists selection state across operations. However, in Oasis, we are rebuilding the entire node graph from scratch (based on the componentSpec) every time an operation is completed, meaning the selection state currently gets reset frequently.

To solve this a much larger refactor will be needed in future: https://github.com/Shopify/oasis-frontend/issues/61 