### PR TITLE
Update TaskNodes

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -31,7 +31,7 @@ import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import type { ArgumentType } from "@/utils/componentSpec";
 import { createNodes, type NodeAndTaskId } from "@/utils/nodes/createNodes";
 
-import ComponentTaskNode from "./TaskNode/TaskNode";
+import TaskNode from "./TaskNode/TaskNode";
 import { cleanupDeletedTasks } from "./utils/cleanupDeletedTasks";
 import { handleConnection } from "./utils/handleConnection";
 import onDropNode from "./utils/onDropNode";
@@ -41,7 +41,7 @@ import replaceTaskArgumentsInGraphSpec from "./utils/replaceTaskArgumentsInGraph
 import { updateNodePositions } from "./utils/updateNodePosition";
 
 const nodeTypes: Record<string, ComponentType<any>> = {
-  task: ComponentTaskNode,
+  task: TaskNode,
 };
 
 type NodesAndEdges = {
@@ -93,10 +93,6 @@ const FlowCanvas = ({
 
   const onDelete = useCallback(
     async (ids: NodeAndTaskId) => {
-      if (readOnly) {
-        return;
-      }
-
       const nodeId = ids.nodeId;
       const node = nodes.find((n) => n.id === nodeId);
       const edgesToRemove = edges.filter(
@@ -120,10 +116,6 @@ const FlowCanvas = ({
 
   const setArguments = useCallback(
     (ids: NodeAndTaskId, args: Record<string, ArgumentType>) => {
-      if (readOnly) {
-        return;
-      }
-
       const taskId = ids.taskId;
       const newGraphSpec = replaceTaskArgumentsInGraphSpec(
         taskId,
@@ -137,10 +129,6 @@ const FlowCanvas = ({
 
   const onConnect = useCallback(
     (connection: Connection) => {
-      if (readOnly) {
-        return;
-      }
-
       const updatedGraphSpec = handleConnection(graphSpec, connection);
       updateGraphSpec(updatedGraphSpec);
     },
@@ -155,10 +143,6 @@ const FlowCanvas = ({
   const onDrop = (event: DragEvent) => {
     event.preventDefault();
 
-    if (readOnly) {
-      return;
-    }
-
     if (reactFlowInstance) {
       const newComponentSpec = onDropNode(
         event,
@@ -171,10 +155,6 @@ const FlowCanvas = ({
 
   const onElementsRemove = useCallback(
     (params: NodesAndEdges) => {
-      if (readOnly) {
-        return;
-      }
-
       let updatedComponentSpec = { ...componentSpec };
 
       for (const edge of params.edges) {
@@ -268,6 +248,9 @@ const FlowCanvas = ({
         deleteKeyCode={["Delete", "Backspace"]}
         onSelectionChange={handleSelectionChange}
         onSelectionDragStop={handleSelectionDragEnd}
+        nodesDraggable={!readOnly}
+        nodesConnectable={!readOnly}
+        connectOnClick={!readOnly}
       >
         {children}
       </ReactFlow>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
@@ -18,7 +18,7 @@ import {
 
 import { useDynamicFontSize } from "@/hooks/useDynamicFontSize";
 import { cn } from "@/lib/utils";
-import type { ComponentTaskNodeCallbacks } from "@/types/taskNode";
+import type { TaskNodeCallbacks } from "@/types/taskNode";
 import type { InputSpec, OutputSpec, TaskSpec } from "@/utils/componentSpec";
 
 import ArgumentsEditorDialog from "./ArgumentsEditor";
@@ -33,7 +33,7 @@ const NODE_WIDTH_IN_PX = 200;
 
 export interface ComponentTaskNodeProps
   extends Record<string, unknown>,
-    ComponentTaskNodeCallbacks {
+    TaskNodeCallbacks {
   taskSpec: TaskSpec;
   taskId: string;
 }

--- a/src/types/taskNode.ts
+++ b/src/types/taskNode.ts
@@ -1,6 +1,7 @@
 import type { ArgumentType } from "@/utils/componentSpec";
 
-export interface ComponentTaskNodeCallbacks {
-  setArguments?: (args: Record<string, ArgumentType>) => void;
+/* Note: Optional callbacks will cause TypeScript to break when applying the callbacks to the Nodes. */
+export interface TaskNodeCallbacks {
+  setArguments: (args: Record<string, ArgumentType>) => void;
   onDelete: () => void;
 }


### PR DESCRIPTION
A couple small improvements and terminology updates to TaskNodes.

Fixes a hidden TS error with the way dynamic callbacks were being created on new nodes.
(additional callback props were causing issues - this fix enables us to add more callbacks, such as duplicate)

Closes https://github.com/Shopify/oasis-frontend/issues/56 and disables most ReactFlow interactions when in `readOnly` mode