### PR TITLE
Duplicate Node

### DIFF
--- a/src/components/shared/ReactFlow/FlowGraph/FlowGraph.tsx
+++ b/src/components/shared/ReactFlow/FlowGraph/FlowGraph.tsx
@@ -30,6 +30,7 @@ import useConfirmationDialog from "@/hooks/useConfirmationDialog";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import type { ArgumentType } from "@/utils/componentSpec";
 import { createNodes, type NodeAndTaskId } from "@/utils/nodes/createNodes";
+import { duplicateNode } from "@/utils/nodes/duplicateNode";
 import { nodeIdToTaskId } from "@/utils/nodes/nodeIdUtils";
 
 import TaskNode from "./TaskNode/TaskNode";
@@ -72,15 +73,18 @@ const FlowGraph = ({
     const newNodes = createNodes(componentSpec, {
       onDelete,
       setArguments,
+      onDuplicate,
     });
     setNodes(newNodes);
   }, [componentSpec]);
+
   const [reactFlowInstance, setReactFlowInstance] =
     useState<ReactFlowInstance>();
 
   const onInit: OnInit = (instance) => {
     setReactFlowInstance(instance);
   };
+
   const [selectedNodes, setSelectedNodes] = useState<Node[]>([]);
 
   const onDelete = useCallback(
@@ -117,6 +121,16 @@ const FlowGraph = ({
       updateGraphSpec(newGraphSpec);
     },
     [graphSpec],
+  );
+
+  const onDuplicate = useCallback(
+    (ids: NodeAndTaskId, selected = true) => {
+      const taskId = ids.taskId;
+      const updatedGraphSpec = duplicateNode(taskId, graphSpec, selected);
+
+      updateGraphSpec(updatedGraphSpec);
+    },
+    [graphSpec, updateGraphSpec],
   );
 
   const onConnect = useCallback(

--- a/src/components/shared/ReactFlow/FlowGraph/TaskNode/ArgumentsEditor/ArgumentsEditorDialog.tsx
+++ b/src/components/shared/ReactFlow/FlowGraph/TaskNode/ArgumentsEditor/ArgumentsEditorDialog.tsx
@@ -6,7 +6,7 @@
  * @copyright 2021 Alexey Volkov <alexey.volkov+oss@ark-kun.com>
  */
 
-import { Trash } from "lucide-react";
+import { Copy, Trash } from "lucide-react";
 import { useState } from "react";
 
 import { DraggableDialog } from "@/components/shared/Dialogs";
@@ -18,10 +18,11 @@ import { ArgumentsEditor } from "./ArgumentsEditor";
 interface ArgumentsEditorDialogProps {
   initialPosition?: { x: number; y: number };
   taskSpec: TaskSpec;
+  disabled?: boolean;
   closeEditor: () => void;
   setArguments?: (args: Record<string, ArgumentType>) => void;
-  disabled?: boolean;
   handleDelete: () => void;
+  handleCopy: () => void;
 }
 
 const ArgumentsEditorDialog = ({
@@ -31,6 +32,7 @@ const ArgumentsEditorDialog = ({
   disabled = false,
   initialPosition,
   handleDelete,
+  handleCopy,
 }: ArgumentsEditorDialogProps) => {
   const componentSpec = taskSpec.componentRef.spec;
 
@@ -107,6 +109,18 @@ const ArgumentsEditorDialog = ({
           className: "cursor-pointer",
           disabled,
           onClick: handleDelete,
+        },
+        {
+          children: (
+            <div className="flex items-center gap-2">
+              <Copy />
+              Copy
+            </div>
+          ),
+          variant: "secondary",
+          className: "cursor-pointer",
+          disabled,
+          onClick: handleCopy,
         },
       ]}
     >

--- a/src/components/shared/ReactFlow/FlowGraph/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowGraph/TaskNode/TaskNode.tsx
@@ -259,6 +259,11 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
     setIsTaskDetailsSheetOpen(false);
   };
 
+  const handleCopy = () => {
+    typedData.onDuplicate();
+    setIsArgumentsEditorOpen(false);
+  };
+
   return (
     <>
       <div
@@ -302,6 +307,7 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
           disabled={!!runStatus}
           initialPosition={getDialogPosition(nodeRef.current, 650)}
           handleDelete={handleDelete}
+          handleCopy={handleCopy}
         />
       )}
     </>

--- a/src/types/taskNode.ts
+++ b/src/types/taskNode.ts
@@ -4,4 +4,5 @@ import type { ArgumentType } from "@/utils/componentSpec";
 export interface TaskNodeCallbacks {
   setArguments: (args: Record<string, ArgumentType>) => void;
   onDelete: () => void;
+  onDuplicate: (selected?: boolean) => void;
 }

--- a/src/utils/nodes/createNodes.test.ts
+++ b/src/utils/nodes/createNodes.test.ts
@@ -15,6 +15,7 @@ describe("createNodes", () => {
   const mockNodeCallbacks = {
     onDelete: vi.fn(),
     setArguments: vi.fn(),
+    onDuplicate: vi.fn(),
   };
 
   beforeEach(() => {

--- a/src/utils/nodes/duplicateNode.ts
+++ b/src/utils/nodes/duplicateNode.ts
@@ -1,0 +1,51 @@
+import type { GraphSpec } from "../componentSpec";
+import { getUniqueTaskName } from "../unique";
+import { extractPositionFromAnnotations } from "./extractPositionFromAnnotations";
+import { setPositionInAnnotations } from "./setPositionInAnnotations";
+
+const OFFSET = 10;
+
+/* This is direct duplication of a singular node */
+export const duplicateNode = (
+  taskId: string,
+  graphSpec: GraphSpec,
+  selected: boolean,
+) => {
+  const updatedGraphSpec = { ...graphSpec };
+
+  const taskSpec = updatedGraphSpec.tasks[taskId];
+  const annotations = taskSpec.annotations || {};
+  annotations.selected = false; // deselect the original task
+
+  const newTaskId = getUniqueTaskName(
+    updatedGraphSpec,
+    taskSpec.componentRef.spec?.name,
+  );
+
+  const position = extractPositionFromAnnotations(taskSpec.annotations);
+
+  const updatedTaskSpec = {
+    ...taskSpec,
+    annotations: annotations,
+  };
+
+  const newAnnotations = setPositionInAnnotations(annotations, {
+    x: position.x + OFFSET,
+    y: position.y + OFFSET,
+  });
+
+  newAnnotations.selected = selected; // new duplicate tasks are selected by default
+
+  const newTaskSpec = {
+    ...taskSpec,
+    annotations: { ...newAnnotations },
+  };
+
+  updatedGraphSpec.tasks = {
+    ...updatedGraphSpec.tasks,
+    [taskId]: updatedTaskSpec,
+    [newTaskId]: newTaskSpec,
+  };
+
+  return updatedGraphSpec;
+};


### PR DESCRIPTION
Closes https://github.com/Cloud-Pipelines/pipeline-studio-app/issues/156
Closes https://github.com/Shopify/oasis-frontend/issues/24

Adds a button to the Arguments Editor that will duplicate a node, including any input connections it has.
The original node will be deselected and the arguments editor closed.

Follows #204 
Progresses toward https://github.com/Cloud-Pipelines/pipeline-studio-app/pull/169


Note: The arguments editor is not the ideal place for a duplicate button, but we currently do not have a better place to put this action so this is where it will live for now.