### PR TITLE
Update nodes on render instead of replace

### DIFF
--- a/src/utils/nodes/createNodes.ts
+++ b/src/utils/nodes/createNodes.ts
@@ -49,7 +49,6 @@ const createTaskNodes = (
 ) => {
   return Object.entries(graphSpec.tasks).map(([taskId, taskSpec]) => {
     const position = extractPositionFromAnnotations(taskSpec.annotations);
-    const selected = (taskSpec.annotations?.selected as boolean) ?? false;
     const nodeId = taskIdToNodeId(taskId);
 
     // Dynamically add callbacks to node by first injecting the node & task id
@@ -72,7 +71,6 @@ const createTaskNodes = (
       },
       position: position,
       type: "task",
-      selected: selected,
     } as Node;
   });
 };


### PR DESCRIPTION
A high-level change to shift the manual node operations on reactflow from `replace` to `update`. In other words, this PR makes it so that we no longer fully replace the node array upon each change to component spec. Instead, existing nodes will be updated, allowing Node state (such as selection) to be preserved between renders.

Related: https://github.com/Shopify/oasis-frontend/issues/61

Further granularity and optimization will be needed before https://github.com/Shopify/oasis-frontend/issues/61 can be considered fully addressed (ideally, we should only update nodes that have changed, or bundle updates together and apply at once). But this is a good first step.

This PR is needed to solve some issues in https://github.com/Cloud-Pipelines/pipeline-studio-app/pull/169 where the toolbar vanishes on each re-render.

This PR also means that we no longer need to manually sync selection state between nodes and componentSpec


