### PR TITLE
Move Argument Editor to Side-Sheet

### DIFF
--- a/src/components/deprecated/Sidebar/PipelineSubmitter/PipelineSubmitter.tsx
+++ b/src/components/deprecated/Sidebar/PipelineSubmitter/PipelineSubmitter.tsx
@@ -9,10 +9,8 @@
 import { useEffect, useState } from "react";
 
 import OasisSubmitter from "@/components/shared/OasisSubmitter";
-import {
-  type ArgumentInput,
-  ArgumentsEditor,
-} from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor";
+import { ArgumentsEditor } from "@/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor";
+import type { ArgumentInput } from "@/types/arguments";
 import type { ComponentSpec } from "@/utils/componentSpec";
 
 import { GoogleCloudSubmitter, KubeflowPipelinesSubmitter } from "./Submitters";

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
@@ -18,28 +18,17 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import type {
-  ArgumentType,
-  InputSpec,
-  TypeSpecType,
-} from "@/utils/componentSpec";
-
-export type ArgumentInput = {
-  key: string;
-  value: ArgumentType;
-  initialValue: ArgumentType;
-  inputSpec: InputSpec;
-  isRemoved?: boolean;
-};
+import type { ArgumentInput } from "@/types/arguments";
+import type { ArgumentType, TypeSpecType } from "@/utils/componentSpec";
 
 export const ArgumentInputField = ({
   argument,
-  setArgument,
   disabled = false,
+  setArgument,
 }: {
   argument: ArgumentInput;
-  setArgument: (value: ArgumentInput) => void;
   disabled?: boolean;
+  setArgument: (value: ArgumentInput) => void;
 }) => {
   const [inputValue, setInputValue] = useState(getInputValue(argument));
 
@@ -97,28 +86,33 @@ export const ArgumentInputField = ({
   }, [argument]);
 
   return (
-    <div className="flex w-full items-center gap-2 py-1">
-      <div
-        className={cn(
-          "w-[256px] min-w-[256px] flex flex-col",
-          argument.isRemoved ? "opacity-50" : "",
-        )}
-      >
-        <Label
-          htmlFor={argument.inputSpec.name}
-          className="text-sm break-words"
+    <div className="flex w-full items-center justify-between gap-2 py-1">
+      <div className="flex items-center gap-2 w-2/5">
+        <div
+          className={cn(
+            "bg-warning rounded-full h-1 w-1",
+            !canUndo && "invisible",
+          )}
+        />
+        <div
+          className={cn("flex flex-col", argument.isRemoved && "opacity-50")}
         >
-          {argument.inputSpec.name.replace(/_/g, " ")}
-        </Label>
-        <span
-          className="text-xs text-gray-500 truncate"
-          title={typeSpecToString(argument.inputSpec.type)}
-        >
-          ({typeSpecToString(argument.inputSpec.type)}
-          {!argument.inputSpec.optional ? "*" : ""})
-        </span>
+          <Label
+            htmlFor={argument.inputSpec.name}
+            className="text-sm break-words"
+          >
+            {argument.inputSpec.name.replace(/_/g, " ")}
+          </Label>
+          <span
+            className="text-xs text-gray-500 truncate"
+            title={typeSpecToString(argument.inputSpec.type)}
+          >
+            ({typeSpecToString(argument.inputSpec.type)}
+            {!argument.inputSpec.optional ? "*" : ""})
+          </span>
+        </div>
       </div>
-      <div className="flex flex-1 items-center relative">
+      <div className="relative w-48">
         <Input
           id={argument.inputSpec.name}
           value={inputValue}
@@ -130,10 +124,12 @@ export const ArgumentInputField = ({
           className={cn(
             "flex-1",
             canUndo && "pr-10",
-            !argument.inputSpec.optional && argument.isRemoved
-              ? "border-red-200"
-              : "",
-            argument.isRemoved ? "border-gray-100 text-gray-500" : "",
+            argument.isRemoved &&
+              !argument.inputSpec.optional &&
+              "border-red-200",
+            argument.isRemoved &&
+              argument.inputSpec.optional &&
+              "border-gray-100 text-gray-500",
           )}
           disabled={disabled}
         />
@@ -142,7 +138,7 @@ export const ArgumentInputField = ({
             <TooltipTrigger asChild>
               <Button
                 onClick={handleUndo}
-                className="absolute right-1 text-xs h-min w-min p-1"
+                className="absolute right-1 top-1/2 transform -translate-y-1/2"
                 disabled={disabled}
                 variant="ghost"
                 style={{
@@ -157,7 +153,7 @@ export const ArgumentInputField = ({
         )}
       </div>
 
-      <div className="flex gap-1 items-center">
+      <div className="flex gap-1 items-center w-1/5 justify-end">
         <Tooltip>
           <TooltipTrigger asChild>
             <Button

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentsEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentsEditor.tsx
@@ -7,8 +7,9 @@
  */
 
 import { TooltipProvider } from "@/components/ui/tooltip";
+import type { ArgumentInput } from "@/types/arguments";
 
-import { type ArgumentInput, ArgumentInputField } from "./ArgumentInputField";
+import { ArgumentInputField } from "./ArgumentInputField";
 
 interface ArgumentsEditorProps {
   argumentData: ArgumentInput[];
@@ -29,17 +30,15 @@ export const ArgumentsEditor = ({
 
   return (
     <TooltipProvider>
-      <div className="h-auto w-[650px] flex flex-col gap-2 max-h-[60vh] overflow-y-auto pr-4">
-        {argumentData.map((argument) => {
-          return (
-            <ArgumentInputField
-              key={argument.key}
-              argument={argument}
-              setArgument={handleInputChange}
-              disabled={disabled}
-            />
-          );
-        })}
+      <div className="h-auto flex flex-col gap-2 max-h-[60vh] overflow-y-auto pr-4">
+        {argumentData.map((argument) => (
+          <ArgumentInputField
+            key={argument.key}
+            argument={argument}
+            setArgument={handleInputChange}
+            disabled={disabled}
+          />
+        ))}
       </div>
     </TooltipProvider>
   );

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentsEditorDialog.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentsEditorDialog.tsx
@@ -10,9 +10,9 @@ import { Copy, Trash } from "lucide-react";
 import { useState } from "react";
 
 import { DraggableDialog } from "@/components/shared/Dialogs";
+import type { ArgumentInput } from "@/types/arguments";
 import type { ArgumentType, TaskSpec } from "@/utils/componentSpec";
 
-import type { ArgumentInput } from "./ArgumentInputField";
 import { ArgumentsEditor } from "./ArgumentsEditor";
 
 interface ArgumentsEditorDialogProps {

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentsSection.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentsSection.tsx
@@ -1,0 +1,86 @@
+import { AlertCircle } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import type { ArgumentInput } from "@/types/arguments";
+import type { ArgumentType, TaskSpec } from "@/utils/componentSpec";
+
+import { ArgumentsEditor } from "../ArgumentsEditor";
+
+interface ArgumentsSectionProps {
+  taskSpec: TaskSpec;
+  setArguments: (args: Record<string, ArgumentType>) => void;
+  disabled?: boolean;
+}
+
+const ArgumentsSection = ({
+  taskSpec,
+  setArguments,
+  disabled = false,
+}: ArgumentsSectionProps) => {
+  const componentSpec = taskSpec.componentRef.spec;
+
+  const argumentInputs =
+    componentSpec?.inputs?.map((input) => {
+      const existingArgument = taskSpec.arguments?.[input.name];
+      const initialValue = existingArgument ?? input.default;
+
+      return {
+        key: input.name,
+        value: initialValue ?? "",
+        initialValue: initialValue ?? "",
+        inputSpec: input,
+        isRemoved: initialValue === undefined,
+      } as ArgumentInput;
+    }) ?? [];
+
+  const [currentArguments, setCurrentArguments] =
+    useState<ArgumentInput[]>(argumentInputs);
+
+  if (componentSpec === undefined) {
+    console.error(
+      "ArgumentsEditor called with missing taskSpec.componentRef.spec",
+      taskSpec,
+    );
+    return null;
+  }
+
+  const handleApply = () => {
+    const argumentValues = Object.fromEntries(
+      currentArguments
+        .filter(({ isRemoved }) => !isRemoved)
+        .map(({ key, value }) => [key, value]),
+    );
+
+    setArguments(argumentValues);
+  };
+
+  const dirty =
+    JSON.stringify(currentArguments) !== JSON.stringify(argumentInputs);
+
+  return (
+    <div className="flex-1 overflow-y-auto p-2">
+      <ArgumentsEditor
+        argumentData={currentArguments}
+        setArguments={setCurrentArguments}
+        disabled={disabled}
+      />
+      <div className="flex justify-end gap-4 p-4 items-center">
+        {dirty && (
+          <div className="text-sm text-warning flex gap-1 items-center">
+            <AlertCircle height={16} /> Unsaved changes
+          </div>
+        )}
+        <Button
+          onClick={handleApply}
+          disabled={disabled}
+          className="cursor-pointer"
+        >
+          Apply
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default ArgumentsSection;

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/TaskConfigurationSheet.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/TaskConfigurationSheet.tsx
@@ -1,0 +1,118 @@
+import { Info } from "lucide-react";
+import { type ReactNode } from "react";
+
+import CondensedUrl from "@/components/shared/CondensedUrl";
+import { Button, type ButtonProps } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import type { ArgumentType, TaskSpec } from "@/utils/componentSpec";
+import { TOP_NAV_HEIGHT } from "@/utils/constants";
+
+import ArgumentsSection from "../ArgumentsEditor/ArgumentsSection";
+
+interface TaskConfigurationSheetProps {
+  trigger: ReactNode;
+  taskId: string;
+  taskSpec: TaskSpec;
+  actions?: ButtonProps[];
+  isOpen: boolean;
+  disabled?: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  setArguments: (args: Record<string, ArgumentType>) => void;
+  onDelete?: () => void;
+}
+
+const TaskConfigurationSheet = ({
+  trigger,
+  taskId,
+  taskSpec,
+  actions,
+  isOpen,
+  disabled = false,
+  onOpenChange,
+  setArguments,
+}: TaskConfigurationSheetProps) => {
+  const componentSpec = taskSpec.componentRef.spec;
+
+  if (componentSpec === undefined) {
+    console.error(
+      "ArgumentsEditor called with missing taskSpec.componentRef.spec",
+      taskSpec,
+    );
+    return null;
+  }
+
+  const sheetHeight = window.innerHeight - TOP_NAV_HEIGHT;
+
+  return (
+    <Sheet open={isOpen} onOpenChange={onOpenChange}>
+      <SheetTrigger asChild>{trigger}</SheetTrigger>
+      <SheetContent
+        side="right"
+        className={`!w-[512px] !max-w-[512px] top-[${TOP_NAV_HEIGHT}px] shadow-none`}
+        style={{
+          height: sheetHeight + "px",
+        }}
+        overlay={false}
+      >
+        <SheetHeader>
+          <SheetTitle>
+            <div className="flex gap-2">
+              <Info />
+              {componentSpec.name ?? "<component>"}
+            </div>
+          </SheetTitle>
+          <SheetDescription>id: {taskId}</SheetDescription>
+          {taskSpec.componentRef.url && (
+            <div className="flex gap-2 text-sidebar-primary text-sm">
+              Source:
+              <CondensedUrl url={taskSpec.componentRef.url} />
+            </div>
+          )}
+          <div className="mt-4 flex flex-col gap-2">
+            <div className="flex gap-2">
+              {actions &&
+                actions.map((action, index) => (
+                  <Button key={index} {...action} />
+                ))}
+            </div>
+          </div>
+        </SheetHeader>
+        <hr className="mx-4" />
+        <div className="flex flex-col overflow-y-auto px-4 gap-4">
+          <div>
+            <h2>Arguments</h2>
+            <p className="text-sm text-muted-foreground">
+              Configure the arguments for this task node.
+            </p>
+            <ArgumentsSection
+              taskSpec={taskSpec}
+              setArguments={setArguments}
+              disabled={disabled}
+            />
+          </div>
+        </div>
+        <hr className="mx-4" />
+        <SheetFooter>
+          <Button
+            onClick={() => onOpenChange(false)}
+            disabled={disabled}
+            variant="secondary"
+            className="w-fit cursor-pointer"
+          >
+            Close
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+};
+
+export default TaskConfigurationSheet;

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/index.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TaskConfigurationSheet";

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -46,13 +46,16 @@ function SheetContent({
   className,
   children,
   side = "right",
+  overlay = true,
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Content> & {
   side?: "top" | "right" | "bottom" | "left";
+  overlay?: boolean;
 }) {
   return (
     <SheetPortal>
-      <SheetOverlay />
+      {/* The optional overlay is a custom modification to the standard Shadcn Sheet component */}
+      {overlay && <SheetOverlay />}
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -35,6 +35,8 @@ code {
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
   --destructive-foreground: oklch(0.577 0.245 27.325);
+  --warning: oklch(0.85 0.2 50);
+  --warning-foreground: oklch(0.145 0 0);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
@@ -71,6 +73,8 @@ code {
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.396 0.141 25.723);
   --destructive-foreground: oklch(0.637 0.237 25.331);
+  --warning: oklch(0.85 0.2 50);
+  --warning-foreground: oklch(0.145 0 0);
   --border: oklch(0.269 0 0);
   --input: oklch(0.269 0 0);
   --ring: oklch(0.439 0 0);
@@ -106,6 +110,8 @@ code {
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);

--- a/src/types/arguments.ts
+++ b/src/types/arguments.ts
@@ -1,0 +1,13 @@
+import type { ArgumentType, InputSpec } from "@/utils/componentSpec";
+
+/**
+ * Argument input to the Argument Editor.
+ */
+
+export type ArgumentInput = {
+  key: string;
+  value: ArgumentType;
+  initialValue: ArgumentType;
+  inputSpec: InputSpec;
+  isRemoved?: boolean;
+};

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -40,3 +40,6 @@ export const DB_NAME = "components";
 export const PIPELINE_RUNS_STORE_NAME = "pipeline_runs";
 
 export const USER_COMPONENTS_LIST_NAME = "user_components";
+
+export const TOP_NAV_HEIGHT = 56; // px
+export const FOOTER_HEIGHT = 30; // px


### PR DESCRIPTION
Closes https://github.com/Shopify/oasis-frontend/issues/50

Migrates the Arguments Editor into a pop-up side-sheet.
Also adds a button to copy component yaml to clipboard.

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/2d657da6-5d10-439f-be4c-c9077b29f3ca" />


**Known issues**

- Not strictly a regression, but it is now more difficult to copy arguments between nodes, since only one editor can now be open at a time. This will be addressed separately at some point in the future.
- There is a bug where unsetting an argument resets it to default when reopening the editor. This will be addressed as part of https://github.com/Shopify/oasis-frontend/issues/83, since that will rework a lot of the argument input logic anyway.
- There are a few other tidbits (particularly UX) relating to editing arguments which will be address as part of https://github.com/Shopify/oasis-frontend/issues/83 instead.

This PR does not address https://github.com/Shopify/oasis-frontend/issues/83 or https://github.com/Shopify/oasis-frontend/issues/84