### PR TITLE
Move minimap to the left

### DIFF
--- a/src/components/Editor/PipelineEditor.tsx
+++ b/src/components/Editor/PipelineEditor.tsx
@@ -30,8 +30,8 @@ const PipelineEditor = () => {
     <>
       <div className="reactflow-wrapper">
         <FlowCanvas snapGrid={[GRID_SIZE, GRID_SIZE]} snapToGrid>
-          <MiniMap />
-          <Controls />
+          <MiniMap position="bottom-left" pannable />
+          <Controls style={{ marginLeft: "224px", marginBottom: "36px" }} />
           <Background gap={GRID_SIZE} />
         </FlowCanvas>
       </div>

--- a/src/components/PipelineRun/PipelineRunPage.tsx
+++ b/src/components/PipelineRun/PipelineRunPage.tsx
@@ -14,8 +14,8 @@ const PipelineRunPage = () => {
         fitView
         readOnly
       >
-        <MiniMap />
-        <Controls />
+        <MiniMap position="bottom-left" pannable />
+        <Controls style={{ marginLeft: "224px", marginBottom: "36px" }} />
         <Background gap={GRID_SIZE} />
       </FlowCanvas>
     </div>

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -60,6 +60,10 @@ details > * {
   background: #ff6060;
 }
 
+.react-flow__attribution {
+  visibility: hidden;
+}
+
 .dndflow .reactflow-wrapper {
   flex-grow: 1;
   height: 100%;


### PR DESCRIPTION
Minimap moved to the left so it no longer gets cover by sidebar sheets that may appear on the right on the screen.
Also makes the minimap pannable and removes the `ReactFlow` label.

![image](https://github.com/user-attachments/assets/2baee379-ad32-4d05-9810-4a55c4e11532)