### PR TITLE
Fix inability to delete Edges

### DIFF
--- a/src/components/shared/Dialogs/ConfirmationDialog.tsx
+++ b/src/components/shared/Dialogs/ConfirmationDialog.tsx
@@ -1,4 +1,4 @@
-import type { MouseEvent } from "react";
+import type { MouseEvent, ReactNode } from "react";
 
 import {
   AlertDialog,
@@ -13,13 +13,14 @@ import {
 } from "@/components/ui/alert-dialog";
 
 type ConfirmationDialogProps = {
-  description?: string;
   title?: string;
+  description?: string;
+  content?: ReactNode;
   onConfirm: () => void;
   onCancel?: () => void;
 } & (
-  | { trigger: React.ReactNode; isOpen?: boolean }
-  | { trigger?: React.ReactNode; isOpen: boolean }
+  | { trigger: ReactNode; isOpen?: boolean }
+  | { trigger?: ReactNode; isOpen: boolean }
 );
 
 const defaultTitle = "Are you sure?";
@@ -29,6 +30,7 @@ const ConfirmationDialog = ({
   trigger,
   title = defaultTitle,
   description = defaultDescription,
+  content,
   isOpen,
   onConfirm,
   onCancel = () => {},
@@ -63,6 +65,7 @@ const ConfirmationDialog = ({
           <AlertDialogTitle>{title}</AlertDialogTitle>
           <AlertDialogDescription>{description}</AlertDialogDescription>
         </AlertDialogHeader>
+        {content}
         <AlertDialogFooter>
           <AlertDialogCancel onClick={handleCancel}>Cancel</AlertDialogCancel>
           <AlertDialogAction onClick={handleConfirm}>

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/removeEdge.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/removeEdge.ts
@@ -12,21 +12,27 @@ export const removeEdge = (edge: Edge, componentSpec: ComponentSpec) => {
 
   const inputName = edge.targetHandle?.replace(/^input_/, "");
 
+  const updatedComponentSpec = {
+    ...componentSpec,
+  };
+
   if (inputName !== undefined && graphSpec) {
     const taskId = nodeIdToTaskId(edge.target);
     const newGraphSpec = setTaskArgument(graphSpec, taskId, inputName);
-    componentSpec.implementation = {
-      ...componentSpec.implementation,
+    updatedComponentSpec.implementation = {
+      ...updatedComponentSpec.implementation,
       graph: newGraphSpec,
     };
-    return componentSpec;
+
+    return updatedComponentSpec;
   } else {
     const outputName = nodeIdToOutputName(edge.target);
     const newGraphSpec = setGraphOutputValue(graphSpec, outputName);
-    componentSpec.implementation = {
-      ...componentSpec.implementation,
+    updatedComponentSpec.implementation = {
+      ...updatedComponentSpec.implementation,
       graph: newGraphSpec,
     };
-    return componentSpec;
+
+    return updatedComponentSpec;
   }
 };

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/setTaskArgument.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/setTaskArgument.ts
@@ -13,7 +13,9 @@ export const setTaskArgument = (
 
   const nonNullArgumentObject = argument ? { [inputName]: argument } : {};
   const newTaskSpecArguments = {
-    ...oldTaskSpecArguments,
+    ...Object.fromEntries(
+      Object.entries(oldTaskSpecArguments).filter(([key]) => key !== inputName),
+    ),
     ...nonNullArgumentObject,
   };
 


### PR DESCRIPTION
Fixes a bug where Edges cannot be manually delete from the canvas.

Also adds Edge-specific text to the confirmation dialog. And allows the dialog to accept ReactNode content.

This PR also appears to fix the underlying issue that #197 was created to address.