### PR TITLE
Add Link component

### DIFF
--- a/src/components/shared/CondensedUrl.tsx
+++ b/src/components/shared/CondensedUrl.tsx
@@ -1,3 +1,5 @@
+import { Link } from "@/components/ui/link";
+
 interface CondensedUrlProps {
   url: string;
   className?: string;
@@ -10,17 +12,16 @@ const CondensedUrl = ({ url, className }: CondensedUrlProps) => {
         {url.split("/").pop()}
       </a>
       {url.includes("raw.githubusercontent.com") && (
-        <a
+        <Link
           className="text-blue-500 ml-2"
           href={url
             .replace("raw.githubusercontent.com", "github.com")
             .replace(/\/([^/]+)\/([^/]+)\/([^/]+)\//, "/$1/$2/$3/tree/")
             .replace(/\/[^/]+$/, "")}
-          target="_blank"
-          rel="noopener noreferrer"
+          external
         >
           View Repo
-        </a>
+        </Link>
       )}
     </p>
   );

--- a/src/components/ui/link.tsx
+++ b/src/components/ui/link.tsx
@@ -1,0 +1,24 @@
+import { ExternalLink } from "lucide-react";
+import { type AnchorHTMLAttributes } from "react";
+
+import { cn } from "@/lib/utils";
+
+interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  external?: boolean;
+}
+
+function Link({ external, children, className, ...props }: LinkProps) {
+  return (
+    <a
+      {...props}
+      target={external ? "_blank" : undefined}
+      rel={external ? "noopener noreferrer" : undefined}
+      className={cn("items-center inline-flex", className)}
+    >
+      {children}
+      {external && <ExternalLink className="h-4" />}
+    </a>
+  );
+}
+
+export { Link };


### PR DESCRIPTION
Adds a customized `a` tag that allows us to render an external link indicator next to a url