### PR TITLE
Fix errors in Sheet logic

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -224,7 +224,7 @@ const FlowCanvas = ({
 
   useEffect(() => {
     // Update ReactFlow based on the component spec
-    const newNodes = createNodesFromComponentSpec(componentSpec, {
+    const newNodes = createNodesFromComponentSpec(componentSpec, !!readOnly, {
       onDelete,
       setArguments,
       onDuplicate,

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/TaskConfigurationSheet.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/TaskConfigurationSheet.tsx
@@ -18,7 +18,7 @@ import { TOP_NAV_HEIGHT } from "@/utils/constants";
 import ArgumentsSection from "../ArgumentsEditor/ArgumentsSection";
 
 interface TaskConfigurationSheetProps {
-  trigger: ReactNode;
+  trigger?: ReactNode;
   taskId: string;
   taskSpec: TaskSpec;
   actions?: ButtonProps[];
@@ -56,8 +56,9 @@ const TaskConfigurationSheet = ({
       <SheetTrigger asChild>{trigger}</SheetTrigger>
       <SheetContent
         side="right"
-        className={`!w-[512px] !max-w-[512px] top-[${TOP_NAV_HEIGHT}px] shadow-none`}
+        className={`!w-[512px] !max-w-[512px] shadow-none`}
         style={{
+          top: TOP_NAV_HEIGHT + "px",
           height: sheetHeight + "px",
         }}
         overlay={false}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskDetailsSheet/index.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskDetailsSheet/index.tsx
@@ -10,6 +10,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 import type { TaskSpec } from "@/utils/componentSpec";
+import { TOP_NAV_HEIGHT } from "@/utils/constants";
 
 import Info from "./info";
 import Io from "./io";
@@ -32,13 +33,19 @@ const TaskDetailsSheet = ({
 }: TaskDetailsSheetProps) => {
   const [activeTab, setActiveTab] = useState("info");
 
+  const sheetHeight = window.innerHeight - TOP_NAV_HEIGHT;
+
   return (
     <Sheet modal={false} open={isOpen} onOpenChange={onClose}>
       <SheetContent
         className={cn(
-          "!max-w-none overflow-y-auto mt-[56px] h-[calc(100vh-56px)] transition-[width] duration-150",
-          activeTab === "logs" ? "!w-[50%]" : "!w-[33.333333%]",
+          "!max-w-none overflow-y-auto transition-[width] duration-150",
+          activeTab === "logs" ? "!w-1/2" : "!w-1/3",
         )}
+        style={{
+          top: TOP_NAV_HEIGHT + "px",
+          height: sheetHeight + "px",
+        }}
       >
         <SheetHeader>
           <SheetTitle>Task Details - {taskId}</SheetTitle>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
@@ -159,21 +159,9 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
   const taskSpec = typedData.taskSpec;
   const componentSpec = taskSpec.componentRef.spec;
 
+  const readOnly = typedData.readOnly;
+
   const runStatus = taskSpec.annotations?.["status"] as string | undefined;
-  // for testing can we assign a status to the node randomly
-  // const runStatus = [
-  //   "SUCCEEDED",
-  //   "FAILED",
-  //   "RUNNING",
-  //   "STARTING",
-  //   "CANCELLING",
-  //   "CONDITIONALLY_SKIPPED",
-  //   "CANCELLED",
-  //   "SYSTEM_ERROR",
-  //   "INVALID",
-  //   "UPSTREAM_FAILED",
-  //   "UPSTREAM_FAILED_OR_SKIPPED",
-  // ][Math.floor(Math.random() * 10)];
 
   if (componentSpec === undefined) {
     return null;
@@ -247,10 +235,10 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
   };
 
   const handleClick = () => {
-    if (!isComponentEditorOpen && !runStatus) {
+    if (!isComponentEditorOpen && !readOnly) {
       setIsComponentEditorOpen(true);
     }
-    if (!isTaskDetailsSheetOpen && runStatus) {
+    if (!isTaskDetailsSheetOpen && readOnly) {
       setIsTaskDetailsSheetOpen(true);
     }
   };
@@ -288,6 +276,37 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
 
   return (
     <>
+      <div
+        className={cn(
+          "border rounded-md shadow-sm transition-all duration-200",
+          getBorderColor(),
+          getBgColor(),
+          selected ? "border-sky-500" : " hover:border-slate-400",
+        )}
+        style={{ width: `${NODE_WIDTH_IN_PX}px` }}
+        ref={nodeRef}
+        onClick={handleClick}
+      >
+        <div className="p-3 flex items-center justify-between">
+          <div
+            className="font-medium text-gray-800 whitespace-nowrap w-full text-center"
+            title={title}
+            ref={textRef}
+          >
+            {label}
+          </div>
+          {handleComponents}
+        </div>
+      </div>
+
+      <TaskDetailsSheet
+        isOpen={isTaskDetailsSheetOpen}
+        taskSpec={taskSpec}
+        taskId={typedData.taskId}
+        runStatus={runStatus}
+        onClose={handleTaskDetailsSheetClose}
+      />
+
       <TaskConfigurationSheet
         taskId={typedData.taskId}
         taskSpec={taskSpec}
@@ -330,41 +349,6 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
         ]}
         setArguments={handleSetArguments}
         disabled={!!runStatus}
-        trigger={
-          <div
-            className={cn(
-              "border rounded-md shadow-sm transition-all duration-200",
-              getBorderColor(),
-              getBgColor(),
-              selected ? "border-sky-500" : " hover:border-slate-400",
-            )}
-            style={{ width: `${NODE_WIDTH_IN_PX}px` }}
-            ref={nodeRef}
-            onClick={handleClick}
-          >
-            <div className="p-3 flex items-center justify-between">
-              <div
-                className="font-medium text-gray-800 whitespace-nowrap w-full text-center"
-                title={title}
-                ref={textRef}
-              >
-                {label}
-              </div>
-              <div className="flex items-center gap-2">
-                {runStatus && (
-                  <TaskDetailsSheet
-                    isOpen={isTaskDetailsSheetOpen}
-                    taskSpec={taskSpec}
-                    taskId={typedData.taskId}
-                    runStatus={runStatus}
-                    onClose={handleTaskDetailsSheetClose}
-                  />
-                )}
-              </div>
-              {handleComponents}
-            </div>
-          </div>
-        }
       />
     </>
   );

--- a/src/utils/nodes/createNodesFromComponentSpec.test.ts
+++ b/src/utils/nodes/createNodesFromComponentSpec.test.ts
@@ -18,6 +18,8 @@ describe("createNodesFromComponentSpec", () => {
     onDuplicate: vi.fn(),
   };
 
+  const readOnly = false;
+
   beforeEach(() => {
     mockNodeCallbacks.setArguments.mockClear();
   });
@@ -29,6 +31,7 @@ describe("createNodesFromComponentSpec", () => {
 
     const result = createNodesFromComponentSpec(
       componentSpec,
+      readOnly,
       mockNodeCallbacks,
     );
 
@@ -56,6 +59,7 @@ describe("createNodesFromComponentSpec", () => {
 
     const result = createNodesFromComponentSpec(
       componentSpec,
+      readOnly,
       mockNodeCallbacks,
     );
 
@@ -87,6 +91,7 @@ describe("createNodesFromComponentSpec", () => {
 
     const result = createNodesFromComponentSpec(
       componentSpec,
+      readOnly,
       mockNodeCallbacks,
     );
 
@@ -115,6 +120,7 @@ describe("createNodesFromComponentSpec", () => {
 
     const result = createNodesFromComponentSpec(
       componentSpec,
+      readOnly,
       mockNodeCallbacks,
     );
 
@@ -145,6 +151,7 @@ describe("createNodesFromComponentSpec", () => {
 
     const result = createNodesFromComponentSpec(
       componentSpec,
+      readOnly,
       mockNodeCallbacks,
     );
     const defaultPosition = { x: 0, y: 0 };
@@ -189,6 +196,7 @@ describe("createNodesFromComponentSpec", () => {
 
     const result = createNodesFromComponentSpec(
       componentSpec,
+      readOnly,
       mockNodeCallbacks,
     );
     const taskNode = result.find((node) => node.id === nodeId) as

--- a/src/utils/nodes/createNodesFromComponentSpec.ts
+++ b/src/utils/nodes/createNodesFromComponentSpec.ts
@@ -8,6 +8,7 @@ import { type NodeCallbacks } from "./generateDynamicNodeCallbacks";
 
 export const createNodesFromComponentSpec = (
   componentSpec: ComponentSpec,
+  readOnly: boolean,
   nodeCallbacks: NodeCallbacks,
 ): Node[] => {
   if (!("graph" in componentSpec.implementation)) {
@@ -15,7 +16,7 @@ export const createNodesFromComponentSpec = (
   }
 
   const graphSpec = componentSpec.implementation.graph;
-  const taskNodes = createTaskNodes(graphSpec, nodeCallbacks);
+  const taskNodes = createTaskNodes(graphSpec, readOnly, nodeCallbacks);
   const inputNodes = createInputNodes(componentSpec);
   const outputNodes = createOutputNodes(componentSpec);
 
@@ -24,10 +25,11 @@ export const createNodesFromComponentSpec = (
 
 const createTaskNodes = (
   graphSpec: GraphSpec,
+  readOnly: boolean,
   nodeCallbacks: NodeCallbacks,
 ) => {
   return Object.entries(graphSpec.tasks).map((task) => {
-    return createTaskNode(task, nodeCallbacks);
+    return createTaskNode(task, readOnly, nodeCallbacks);
   });
 };
 

--- a/src/utils/nodes/createTaskNode.ts
+++ b/src/utils/nodes/createTaskNode.ts
@@ -10,6 +10,7 @@ import { taskIdToNodeId } from "./nodeIdUtils";
 
 export const createTaskNode = (
   task: [`${string}`, TaskSpec],
+  readOnly: boolean,
   nodeCallbacks: NodeCallbacks,
 ) => {
   const [taskId, taskSpec] = task;
@@ -24,8 +25,9 @@ export const createTaskNode = (
   return {
     id: nodeId,
     data: {
-      taskSpec: taskSpec,
-      taskId: taskId,
+      readOnly,
+      taskSpec,
+      taskId,
       ...dynamicCallbacks,
     },
     position: position,


### PR DESCRIPTION
Follows #213 

Fixes:

- Wonky sheet position due to Tailwind unable to parse computed value
- Config Sheet overruling Details sheet when viewing Nodes info in a Run
- TaskNode now has access to the ReactFlow `readOnly` state via `data.readOnly` (useful to distinguish between Pipeline Editor and Run views).
- Minor alignments between Config and Details sheets