### PR TITLE
Copy + Paste Singular Nodes

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
@@ -20,12 +20,11 @@ import {
 import { useDynamicFontSize } from "@/hooks/useDynamicFontSize";
 import useToastNotification from "@/hooks/useToastNotification";
 import { cn } from "@/lib/utils";
-import type { TaskNodeCallbacks } from "@/types/taskNode";
+import type { TaskNodeData } from "@/types/taskNode";
 import type {
   ArgumentType,
   InputSpec,
   OutputSpec,
-  TaskSpec,
 } from "@/utils/componentSpec";
 
 import TaskConfigurationSheet from "./TaskConfigurationSheet";
@@ -37,13 +36,6 @@ const outputHandlePosition = Position.Bottom;
 type InputOrOutputSpec = InputSpec | OutputSpec;
 
 const NODE_WIDTH_IN_PX = 200;
-
-export interface ComponentTaskNodeProps
-  extends Record<string, unknown>,
-    TaskNodeCallbacks {
-  taskSpec: TaskSpec;
-  taskId: string;
-}
 
 function generateHandles(
   ioSpecs: InputOrOutputSpec[],
@@ -155,7 +147,7 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
 
   const notify = useToastNotification();
 
-  const typedData = data as ComponentTaskNodeProps;
+  const typedData = data as TaskNodeData;
   const taskSpec = typedData.taskSpec;
   const componentSpec = taskSpec.componentRef.spec;
 

--- a/src/hooks/useCopyPaste.ts
+++ b/src/hooks/useCopyPaste.ts
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+
+interface UseCopyPasteProps {
+  onCopy: () => void;
+  onPaste: () => void;
+}
+
+export function useCopyPaste({ onCopy, onPaste }: UseCopyPasteProps) {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+      const copyKey = isMac ? event.metaKey : event.ctrlKey;
+
+      if (copyKey && event.key === "c") {
+        event.preventDefault();
+        onCopy();
+      }
+
+      if (copyKey && event.key === "v") {
+        event.preventDefault();
+        onPaste();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onCopy, onPaste]);
+}

--- a/src/types/taskNode.ts
+++ b/src/types/taskNode.ts
@@ -1,4 +1,12 @@
-import type { ArgumentType } from "@/utils/componentSpec";
+import type { ArgumentType, TaskSpec } from "@/utils/componentSpec";
+
+export interface TaskNodeData
+  extends Record<string, unknown>,
+    TaskNodeCallbacks {
+  taskSpec: TaskSpec;
+  taskId: string;
+  readOnly: boolean;
+}
 
 /* Note: Optional callbacks will cause TypeScript to break when applying the callbacks to the Nodes. */
 export interface TaskNodeCallbacks {

--- a/src/utils/nodes/copyToNewTaskNode.ts
+++ b/src/utils/nodes/copyToNewTaskNode.ts
@@ -1,0 +1,69 @@
+import { type Node, type XYPosition } from "@xyflow/react";
+
+import type { TaskNodeData } from "@/types/taskNode";
+
+import type { GraphSpec, TaskSpec } from "../componentSpec";
+import { getUniqueTaskName } from "../unique";
+import { createTaskNode } from "./createTaskNode";
+import type { NodeCallbacks } from "./generateDynamicNodeCallbacks";
+import { setPositionInAnnotations } from "./setPositionInAnnotations";
+
+export const copyToNewTaskNode = (
+  node: Node,
+  nodeCallbacks: NodeCallbacks,
+  position: XYPosition,
+  graphSpec: GraphSpec,
+) => {
+  const updatedGraphSpec = { ...graphSpec };
+
+  const data = node.data as TaskNodeData;
+
+  const taskSpec = data.taskSpec as TaskSpec;
+  const annotations = taskSpec.annotations || {};
+
+  const updatedTaskSpec = {
+    ...taskSpec,
+  };
+
+  const taskId = getUniqueTaskName(
+    updatedGraphSpec,
+    updatedTaskSpec.componentRef.spec?.name,
+  );
+
+  // Remove Argument links to other nodes
+  if (updatedTaskSpec.arguments) {
+    updatedTaskSpec.arguments = Object.fromEntries(
+      Object.entries(updatedTaskSpec.arguments).filter(([_key, value]) => {
+        return !(value && typeof value === "object" && "taskOutput" in value);
+      }),
+    );
+  }
+
+  const newNode = createTaskNode(
+    [taskId, updatedTaskSpec],
+    data.readOnly as boolean,
+    nodeCallbacks,
+  );
+
+  const centeredPosition = {
+    x: position.x - (newNode.width || 0) / 2,
+    y: position.y - (newNode.height || 0) / 2,
+  };
+
+  const updatedAnnotations = setPositionInAnnotations(
+    annotations,
+    centeredPosition,
+  );
+
+  updatedGraphSpec.tasks[taskId] = {
+    ...updatedTaskSpec,
+    annotations: {
+      ...updatedAnnotations,
+      selected: true,
+    },
+  };
+
+  newNode.position = centeredPosition;
+
+  return { newNode, updatedGraphSpec };
+};


### PR DESCRIPTION
Progresses https://github.com/Cloud-Pipelines/pipeline-studio-app/issues/19

Implements Copy + Pasting of Task Nodes via `ctrl-c + ctrl-v` (or cmd on mac).

- New `useCopyPaste` hook to manage copy + paste callbacks
- Copy will save the selected nodes to the clipboard as a JSON string
- Paste will attempt to parse the saved string in the clipboard into a Node object and then place it in the centre of the current ReactFlow instance.
- Arguments and other task data will be copied over, but edges/connections to other nodes will be removed.
- Assuming correct structure nodes can be pasted into any pipeline editor instance even if it did not originate from that instance.
- The new node(s) will be selected and everything else deselected.


https://github.com/user-attachments/assets/95d1e14d-ddc9-4a4b-ac04-102596ca06dc



Known issues:

- Copy+Pasting a group of nodes will stack them all in the centre of canvas rather than maintain their structure and connections. I want to address this after merging #169, since that PR introduces and improves logic for dealing with multiple selections.