### PR TITLE
Update duplicate nodes method

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -32,18 +32,15 @@ import { useCopyPaste } from "@/hooks/useCopyPaste";
 import { useSelectionToolbar } from "@/hooks/useSelectionToolbar";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+import type { NodeAndTaskId } from "@/types/taskNode";
 import type { ArgumentType } from "@/utils/componentSpec";
 import { SELECTION_TOOLBAR_ID } from "@/utils/constants";
 import { copyToNewTaskNode } from "@/utils/nodes/copyToNewTaskNode";
 import { createNodesFromComponentSpec } from "@/utils/nodes/createNodesFromComponentSpec";
-import { createTaskNode } from "@/utils/nodes/createTaskNode";
-import { duplicateTask } from "@/utils/nodes/duplicateTask";
-import type { NodeAndTaskId } from "@/utils/nodes/generateDynamicNodeCallbacks";
-import { nodeIdToTaskId, taskIdToNodeId } from "@/utils/nodes/nodeIdUtils";
 
 import SelectionToolbar from "./SelectionToolbar";
 import TaskNode from "./TaskNode/TaskNode";
-import { duplicateSelectedNodes } from "./utils/duplicateSelectedNodes";
+import { duplicateNodes } from "./utils/duplicateNodes";
 import { handleConnection } from "./utils/handleConnection";
 import onDropNode from "./utils/onDropNode";
 import { removeEdge } from "./utils/removeEdge";
@@ -91,6 +88,32 @@ const FlowCanvas = ({
     setReactFlowInstance(instance);
   };
 
+  const updateOrAddNodes = useCallback(
+    ({
+      updatedNodes,
+      newNodes,
+    }: {
+      updatedNodes?: Node[];
+      newNodes?: Node[];
+    }) => {
+      setNodes((prev) => {
+        const updated = prev.map((node) => {
+          const updatedNode = updatedNodes?.find(
+            (updatedNode) => updatedNode.id === node.id,
+          );
+          return updatedNode ? { ...node, ...updatedNode } : node;
+        });
+
+        if (!newNodes) {
+          return updated;
+        }
+
+        return [...updated, ...newNodes];
+      });
+    },
+    [setNodes],
+  );
+
   const onDelete = useCallback(
     async (ids: NodeAndTaskId) => {
       const nodeId = ids.nodeId;
@@ -129,50 +152,34 @@ const FlowCanvas = ({
 
   const onDuplicate = useCallback(
     (ids: NodeAndTaskId, selected = true) => {
-      const taskId = ids.taskId;
-      const { newTaskId, updatedGraphSpec } = duplicateTask(taskId, graphSpec);
+      const nodeId = ids.nodeId;
+      const node = nodes.find((n) => n.id === nodeId);
+
+      if (!node) return;
+
+      const { updatedGraphSpec, newNodes, updatedNodes } = duplicateNodes(
+        graphSpec,
+        [node],
+        selected,
+      );
 
       updateGraphSpec(updatedGraphSpec);
 
-      if (selected) {
-        // Move selection state to the new node
-        const newNode = createTaskNode(
-          [newTaskId, updatedGraphSpec.tasks[newTaskId]],
-          !!readOnly,
-          {
-            onDelete,
-            setArguments,
-            onDuplicate,
-          },
-        );
-
-        setNodes((prev) => {
-          const originalNode = prev.find(
-            (node) => node.id === taskIdToNodeId(taskId),
-          );
-
-          if (!originalNode) {
-            return [...prev, newNode];
-          }
-
-          originalNode.selected = false;
-          newNode.selected = true;
-
-          const updatedNodes = prev.map((node) =>
-            node.id === taskIdToNodeId(taskId) ? originalNode : node,
-          );
-
-          return [...updatedNodes, newNode];
-        });
-      }
+      updateOrAddNodes({
+        updatedNodes,
+        newNodes,
+      });
     },
-    [graphSpec, updateGraphSpec, setNodes],
+    [graphSpec, nodes, updateGraphSpec, updateOrAddNodes],
   );
 
-  const nodeCallbacks = {
-    onDelete,
-    setArguments,
-    onDuplicate,
+  const nodeData = {
+    readOnly,
+    nodeCallbacks: {
+      onDelete,
+      setArguments,
+      onDuplicate,
+    },
   };
 
   const onConnect = useCallback(
@@ -217,7 +224,7 @@ const FlowCanvas = ({
     [componentSpec, setComponentSpec],
   );
 
-  const removeNodes = useCallback(async () => {
+  const onRemoveNodes = useCallback(async () => {
     const confirmed = await triggerConfirmationDialog();
     if (confirmed) {
       onElementsRemove(selectedElements);
@@ -266,66 +273,30 @@ const FlowCanvas = ({
     return confirmed;
   };
 
-  const duplicateNodes = useCallback(() => {
-    const { updatedGraphSpec, taskIdMap } = duplicateSelectedNodes(
+  const onDuplicateNodes = useCallback(() => {
+    const { updatedGraphSpec, newNodes, updatedNodes } = duplicateNodes(
       graphSpec,
       selectedElements.nodes,
+      true,
     );
 
     updateGraphSpec(updatedGraphSpec);
 
-    const updatedNodes: Node[] = [];
-
-    const newNodes = Object.entries(taskIdMap)
-      .map(([oldTaskId, newTaskId]) => {
-        const newNode = createTaskNode(
-          [newTaskId, updatedGraphSpec.tasks[newTaskId]],
-          !!readOnly,
-          {
-            onDelete,
-            setArguments,
-            onDuplicate,
-          },
-        );
-
-        const originalNode = selectedElements.nodes.find(
-          (node) => nodeIdToTaskId(node.id) === oldTaskId,
-        );
-
-        if (originalNode) {
-          originalNode.selected = false;
-
-          newNode.measured = originalNode.measured;
-          newNode.selected = true;
-
-          updatedNodes.push(originalNode);
-        }
-
-        return newNode;
-      })
-      .filter(Boolean) as Node[];
-
-    setNodes((prev) => {
-      const updated = prev.map((node) => {
-        const updatedNode = updatedNodes.find(
-          (updatedNode) => updatedNode.id === node.id,
-        );
-        return updatedNode ? { ...node, ...updatedNode } : node;
-      });
-
-      return [...updated, ...newNodes];
+    updateOrAddNodes({
+      updatedNodes,
+      newNodes,
     });
 
     // Workaround: return the new nodes directly to the callbackhandler (which is inside useSelectionToolbar) so that the toolbar position can be updated
     // Without this the toolbar will not automatically shift to the newly copied nodes
     return newNodes;
-  }, [graphSpec, selectedElements, updateGraphSpec, setNodes]);
+  }, [graphSpec, selectedElements, updateGraphSpec, updateOrAddNodes]);
 
   const { toolbar, hideToolbar, showToolbar, updateToolbarPosition } =
     useSelectionToolbar({
       reactFlowInstance,
-      onDeleteNodes: removeNodes,
-      onDuplicateNodes: duplicateNodes,
+      onDeleteNodes: onRemoveNodes,
+      onDuplicateNodes: onDuplicateNodes,
     });
 
   const handleSelectionChange = useCallback(
@@ -372,11 +343,7 @@ const FlowCanvas = ({
 
   useEffect(() => {
     // Update ReactFlow based on the component spec
-    const newNodes = createNodesFromComponentSpec(
-      componentSpec,
-      !!readOnly,
-      nodeCallbacks,
-    );
+    const newNodes = createNodesFromComponentSpec(componentSpec, nodeData);
 
     setNodes((prevNodes) => {
       const updatedNodes = newNodes.map((newNode) => {
@@ -429,6 +396,8 @@ const FlowCanvas = ({
   }, [selectedElements]);
 
   const onPaste = useCallback(() => {
+    if (readOnly) return;
+
     // Paste nodes from clipboard to the centre of the Canvas
     navigator.clipboard.readText().then((clipboardText) => {
       try {
@@ -470,7 +439,6 @@ const FlowCanvas = ({
           const newNodes = nodesToPaste.map((node) => {
             const output = copyToNewTaskNode(
               node,
-              nodeCallbacks,
               reactFlowCenter,
               updatedGraphSpec,
             );
@@ -486,7 +454,7 @@ const FlowCanvas = ({
         console.error("Failed to paste nodes from clipboard:", err);
       }
     });
-  }, [graphSpec, reactFlowInstance, store, setNodes, nodeCallbacks]);
+  }, [graphSpec, reactFlowInstance, store, setNodes, nodeData]);
 
   useCopyPaste({
     onCopy,
@@ -556,10 +524,7 @@ function getConfirmationDialogDetails(selectedElements: NodesAndEdges) {
 
       const singleDeleteDesc = (
         <div className="text-sm">
-          <p>
-            This will also will also delete all connections to and from the
-            Node.
-          </p>
+          <p>This will also delete all connections to and from the Node.</p>
           <br />
           {thisCannotBeUndone}
         </div>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
@@ -25,6 +25,7 @@ import type {
   ArgumentType,
   InputSpec,
   OutputSpec,
+  TaskSpec,
 } from "@/utils/componentSpec";
 
 import TaskConfigurationSheet from "./TaskConfigurationSheet";
@@ -148,7 +149,7 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
   const notify = useToastNotification();
 
   const typedData = data as TaskNodeData;
-  const taskSpec = typedData.taskSpec;
+  const taskSpec = typedData.taskSpec as TaskSpec;
   const componentSpec = taskSpec.componentRef.spec;
 
   const readOnly = typedData.readOnly;
@@ -260,16 +261,16 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
   };
 
   const handleSetArguments = (args: Record<string, ArgumentType>) => {
-    typedData.setArguments(args);
+    typedData.callbacks?.setArguments(args);
     notify("Arguments updated", "success");
   };
 
   const handleDeleteTaskNode = () => {
-    typedData.onDelete();
+    typedData.callbacks?.onDelete();
   };
 
   const handleDuplicateTaskNode = () => {
-    typedData.onDuplicate();
+    typedData.callbacks?.onDuplicate();
     setIsComponentEditorOpen(false);
   };
 
@@ -315,57 +316,61 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
         </div>
       </div>
 
-      <TaskDetailsSheet
-        isOpen={isTaskDetailsSheetOpen}
-        taskSpec={taskSpec}
-        taskId={typedData.taskId}
-        runStatus={runStatus}
-        onClose={handleTaskDetailsSheetClose}
-      />
+      {typedData.taskId && (
+        <>
+          <TaskDetailsSheet
+            isOpen={isTaskDetailsSheetOpen}
+            taskSpec={taskSpec}
+            taskId={typedData.taskId}
+            runStatus={runStatus}
+            onClose={handleTaskDetailsSheetClose}
+          />
 
-      <TaskConfigurationSheet
-        taskId={typedData.taskId}
-        taskSpec={taskSpec}
-        isOpen={isComponentEditorOpen}
-        onOpenChange={setIsComponentEditorOpen}
-        actions={[
-          {
-            children: (
-              <div className="flex items-center gap-2">
-                <BookCopy />
-                Copy yaml
-              </div>
-            ),
-            variant: "secondary",
-            className: "cursor-pointer",
-            onClick: handleCopyYaml,
-          },
-          {
-            children: (
-              <div className="flex items-center gap-2">
-                <Copy />
-                Duplicate
-              </div>
-            ),
-            variant: "secondary",
-            className: "cursor-pointer",
-            onClick: handleDuplicateTaskNode,
-          },
-          {
-            children: (
-              <div className="flex items-center gap-2">
-                <Trash />
-                Delete
-              </div>
-            ),
-            variant: "destructive",
-            className: "cursor-pointer",
-            onClick: handleDeleteTaskNode,
-          },
-        ]}
-        setArguments={handleSetArguments}
-        disabled={!!runStatus}
-      />
+          <TaskConfigurationSheet
+            taskId={typedData.taskId}
+            taskSpec={taskSpec}
+            isOpen={isComponentEditorOpen}
+            onOpenChange={setIsComponentEditorOpen}
+            actions={[
+              {
+                children: (
+                  <div className="flex items-center gap-2">
+                    <BookCopy />
+                    Copy yaml
+                  </div>
+                ),
+                variant: "secondary",
+                className: "cursor-pointer",
+                onClick: handleCopyYaml,
+              },
+              {
+                children: (
+                  <div className="flex items-center gap-2">
+                    <Copy />
+                    Duplicate
+                  </div>
+                ),
+                variant: "secondary",
+                className: "cursor-pointer",
+                onClick: handleDuplicateTaskNode,
+              },
+              {
+                children: (
+                  <div className="flex items-center gap-2">
+                    <Trash />
+                    Delete
+                  </div>
+                ),
+                variant: "destructive",
+                className: "cursor-pointer",
+                onClick: handleDeleteTaskNode,
+              },
+            ]}
+            setArguments={handleSetArguments}
+            disabled={!!runStatus}
+          />
+        </>
+      )}
     </>
   );
 };

--- a/src/types/taskNode.ts
+++ b/src/types/taskNode.ts
@@ -1,12 +1,17 @@
 import type { ArgumentType, TaskSpec } from "@/utils/componentSpec";
 
-export interface TaskNodeData
-  extends Record<string, unknown>,
-    TaskNodeCallbacks {
-  taskSpec: TaskSpec;
-  taskId: string;
-  readOnly: boolean;
+export interface TaskNodeData extends Record<string, unknown> {
+  taskSpec?: TaskSpec;
+  taskId?: string;
+  readOnly?: boolean;
+  callbacks?: TaskNodeCallbacks;
+  nodeCallbacks: NodeCallbacks;
 }
+
+export type NodeAndTaskId = {
+  taskId: string;
+  nodeId: string;
+};
 
 /* Note: Optional callbacks will cause TypeScript to break when applying the callbacks to the Nodes. */
 export interface TaskNodeCallbacks {
@@ -14,3 +19,13 @@ export interface TaskNodeCallbacks {
   onDelete: () => void;
   onDuplicate: (selected?: boolean) => void;
 }
+
+// Dynamic Node Callback types - every callback has a version with the node & task id added to it as an input parameter
+export type CallbackWithIds<K extends keyof TaskNodeCallbacks> =
+  TaskNodeCallbacks[K] extends (...args: infer A) => infer R
+    ? (ids: NodeAndTaskId, ...args: A) => R
+    : never;
+
+export type NodeCallbacks = {
+  [K in keyof TaskNodeCallbacks]: CallbackWithIds<K>;
+};

--- a/src/utils/nodes/copyToNewTaskNode.ts
+++ b/src/utils/nodes/copyToNewTaskNode.ts
@@ -5,12 +5,10 @@ import type { TaskNodeData } from "@/types/taskNode";
 import type { GraphSpec, TaskSpec } from "../componentSpec";
 import { getUniqueTaskName } from "../unique";
 import { createTaskNode } from "./createTaskNode";
-import type { NodeCallbacks } from "./generateDynamicNodeCallbacks";
 import { setPositionInAnnotations } from "./setPositionInAnnotations";
 
 export const copyToNewTaskNode = (
   node: Node,
-  nodeCallbacks: NodeCallbacks,
   position: XYPosition,
   graphSpec: GraphSpec,
 ) => {
@@ -39,11 +37,7 @@ export const copyToNewTaskNode = (
     );
   }
 
-  const newNode = createTaskNode(
-    [taskId, updatedTaskSpec],
-    data.readOnly as boolean,
-    nodeCallbacks,
-  );
+  const newNode = createTaskNode([taskId, updatedTaskSpec], data);
 
   const centeredPosition = {
     x: position.x - (newNode.width || 0) / 2,

--- a/src/utils/nodes/createNodesFromComponentSpec.test.ts
+++ b/src/utils/nodes/createNodesFromComponentSpec.test.ts
@@ -20,6 +20,11 @@ describe("createNodesFromComponentSpec", () => {
 
   const readOnly = false;
 
+  const mockNodeData = {
+    readOnly,
+    nodeCallbacks: mockNodeCallbacks,
+  };
+
   beforeEach(() => {
     mockNodeCallbacks.setArguments.mockClear();
   });
@@ -29,11 +34,7 @@ describe("createNodesFromComponentSpec", () => {
       container: { image: "test" },
     });
 
-    const result = createNodesFromComponentSpec(
-      componentSpec,
-      readOnly,
-      mockNodeCallbacks,
-    );
+    const result = createNodesFromComponentSpec(componentSpec, mockNodeData);
 
     expect(result).toEqual([]);
   });
@@ -57,11 +58,7 @@ describe("createNodesFromComponentSpec", () => {
       throw new Error("Expected graph implementation");
     }
 
-    const result = createNodesFromComponentSpec(
-      componentSpec,
-      readOnly,
-      mockNodeCallbacks,
-    );
+    const result = createNodesFromComponentSpec(componentSpec, mockNodeData);
 
     expect(result).toContainEqual(
       expect.objectContaining({
@@ -89,11 +86,7 @@ describe("createNodesFromComponentSpec", () => {
       outputs: [],
     };
 
-    const result = createNodesFromComponentSpec(
-      componentSpec,
-      readOnly,
-      mockNodeCallbacks,
-    );
+    const result = createNodesFromComponentSpec(componentSpec, mockNodeData);
 
     expect(result).toContainEqual({
       id: "input_input1",
@@ -118,11 +111,7 @@ describe("createNodesFromComponentSpec", () => {
       ],
     };
 
-    const result = createNodesFromComponentSpec(
-      componentSpec,
-      readOnly,
-      mockNodeCallbacks,
-    );
+    const result = createNodesFromComponentSpec(componentSpec, mockNodeData);
 
     expect(result).toContainEqual({
       id: "output_output1",
@@ -149,11 +138,7 @@ describe("createNodesFromComponentSpec", () => {
       outputs: [{ name: "output1" }],
     };
 
-    const result = createNodesFromComponentSpec(
-      componentSpec,
-      readOnly,
-      mockNodeCallbacks,
-    );
+    const result = createNodesFromComponentSpec(componentSpec, mockNodeData);
     const defaultPosition = { x: 0, y: 0 };
 
     expect(result).toContainEqual(
@@ -194,17 +179,16 @@ describe("createNodesFromComponentSpec", () => {
       },
     });
 
-    const result = createNodesFromComponentSpec(
-      componentSpec,
-      readOnly,
-      mockNodeCallbacks,
-    );
+    const result = createNodesFromComponentSpec(componentSpec, mockNodeData);
     const taskNode = result.find((node) => node.id === nodeId) as
-      | { id: string; data: { setArguments: (args: any) => void } }
+      | {
+          id: string;
+          data: { callbacks: { setArguments: (args: any) => void } };
+        }
       | undefined;
 
     const newArgs = { newArg: "newValue" };
-    taskNode?.data.setArguments(newArgs);
+    taskNode?.data.callbacks.setArguments(newArgs);
 
     expect(mockSetArguments).toHaveBeenCalledTimes(1);
     expect(mockSetArguments).toHaveBeenCalledWith({ taskId, nodeId }, newArgs);

--- a/src/utils/nodes/createNodesFromComponentSpec.ts
+++ b/src/utils/nodes/createNodesFromComponentSpec.ts
@@ -1,35 +1,30 @@
 import { type Node } from "@xyflow/react";
 
+import type { TaskNodeData } from "@/types/taskNode";
 import type { ComponentSpec, GraphSpec } from "@/utils/componentSpec";
 import { extractPositionFromAnnotations } from "@/utils/nodes/extractPositionFromAnnotations";
 
 import { createTaskNode } from "./createTaskNode";
-import { type NodeCallbacks } from "./generateDynamicNodeCallbacks";
 
 export const createNodesFromComponentSpec = (
   componentSpec: ComponentSpec,
-  readOnly: boolean,
-  nodeCallbacks: NodeCallbacks,
+  nodeData: TaskNodeData,
 ): Node[] => {
   if (!("graph" in componentSpec.implementation)) {
     return [];
   }
 
   const graphSpec = componentSpec.implementation.graph;
-  const taskNodes = createTaskNodes(graphSpec, readOnly, nodeCallbacks);
+  const taskNodes = createTaskNodes(graphSpec, nodeData);
   const inputNodes = createInputNodes(componentSpec);
   const outputNodes = createOutputNodes(componentSpec);
 
   return [...taskNodes, ...inputNodes, ...outputNodes];
 };
 
-const createTaskNodes = (
-  graphSpec: GraphSpec,
-  readOnly: boolean,
-  nodeCallbacks: NodeCallbacks,
-) => {
+const createTaskNodes = (graphSpec: GraphSpec, nodeData: TaskNodeData) => {
   return Object.entries(graphSpec.tasks).map((task) => {
-    return createTaskNode(task, readOnly, nodeCallbacks);
+    return createTaskNode(task, nodeData);
   });
 };
 

--- a/src/utils/nodes/createTaskNode.ts
+++ b/src/utils/nodes/createTaskNode.ts
@@ -1,17 +1,15 @@
 import { type Node } from "@xyflow/react";
 
+import type { TaskNodeData } from "@/types/taskNode";
+
 import type { TaskSpec } from "../componentSpec";
 import { extractPositionFromAnnotations } from "./extractPositionFromAnnotations";
-import {
-  generateDynamicNodeCallbacks,
-  type NodeCallbacks,
-} from "./generateDynamicNodeCallbacks";
+import { generateDynamicNodeCallbacks } from "./generateDynamicNodeCallbacks";
 import { taskIdToNodeId } from "./nodeIdUtils";
 
 export const createTaskNode = (
   task: [`${string}`, TaskSpec],
-  readOnly: boolean,
-  nodeCallbacks: NodeCallbacks,
+  nodeData: TaskNodeData,
 ) => {
   const [taskId, taskSpec] = task;
 
@@ -19,15 +17,16 @@ export const createTaskNode = (
   const nodeId = taskIdToNodeId(taskId);
 
   // Inject the taskId and nodeId into the callbacks
+  const nodeCallbacks = nodeData.nodeCallbacks;
   const dynamicCallbacks = generateDynamicNodeCallbacks(nodeCallbacks, nodeId);
 
   return {
     id: nodeId,
     data: {
-      readOnly,
+      ...nodeData,
       taskSpec,
       taskId,
-      ...dynamicCallbacks,
+      callbacks: dynamicCallbacks, // Use these callbacks internally within the node
     },
     position: position,
     type: "task",

--- a/src/utils/nodes/duplicateTask.ts
+++ b/src/utils/nodes/duplicateTask.ts
@@ -3,6 +3,8 @@ import { getUniqueTaskName } from "../unique";
 import { extractPositionFromAnnotations } from "./extractPositionFromAnnotations";
 import { setPositionInAnnotations } from "./setPositionInAnnotations";
 
+/* DEPRECATED: to be removed in future versions - Please use duplicateNodes.ts */
+
 const OFFSET = 10;
 
 /* This is direct duplication of a singular Task */

--- a/src/utils/nodes/generateDynamicNodeCallbacks.ts
+++ b/src/utils/nodes/generateDynamicNodeCallbacks.ts
@@ -1,27 +1,16 @@
-import type { TaskNodeCallbacks } from "@/types/taskNode";
+import type {
+  CallbackWithIds,
+  NodeAndTaskId,
+  NodeCallbacks,
+} from "@/types/taskNode";
 
 import { nodeIdToTaskId } from "./nodeIdUtils";
-
-export type NodeAndTaskId = {
-  taskId: string;
-  nodeId: string;
-};
-
-// Dynamic Node Callback types - every callback has the node & task id added to it as an input parameter
-type CallbackWithIds<K extends keyof TaskNodeCallbacks> =
-  TaskNodeCallbacks[K] extends (...args: infer A) => infer R
-    ? (ids: NodeAndTaskId, ...args: A) => R
-    : never;
-
-export type NodeCallbacks = {
-  [K in keyof TaskNodeCallbacks]: CallbackWithIds<K>;
-};
 
 type ExcludeNodeAndTaskId<T> = T extends [NodeAndTaskId, ...infer Rest]
   ? Rest
   : never;
 
-// Utility function
+// Utility function that adds the taskId and nodeId to the callbacks as the first argument
 export const generateDynamicNodeCallbacks = (
   nodeCallbacks: NodeCallbacks,
   nodeId: string,


### PR DESCRIPTION
Some rework of TaskNode stuff relating to duplication. 

- Create new nodes directly inside the duplicate nodes method
- move some types to more logical places
- where possible, node data is copied over from original nodes when duplicated
- Singular node duplication now uses the same method as bulk duplication
- fix for pasting nodes into run view
- fix a typo in the node delete dialog

No changes to app functionality (except bugfixes)