### PR TITLE
Quick Toolbar Update

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -343,7 +343,7 @@ const FlowCanvas = ({
   );
 
   const handleSelectionEnd = useCallback(() => {
-    if (selectedElements.nodes.length > 0) {
+    if (selectedElements.nodes.length > 0 && !readOnly) {
       showToolbar(selectedElements.nodes);
     } else {
       hideToolbar();

--- a/src/hooks/useSelectionToolbar.ts
+++ b/src/hooks/useSelectionToolbar.ts
@@ -10,6 +10,7 @@ const TOOLBAR_NODE_BASE = {
   position: { x: 0, y: 0 },
   zIndex: 1200,
   selectable: false,
+  // hidden: true, // Note: using data.hidden instead for manual control over toolbar rendering
   data: {
     hidden: true,
   },


### PR DESCRIPTION
Toolbar no longer renders in run view.

And a note on why we are using `data.hidden` rather than ReactFlow's native `hidden` property.