### PR TITLE
Fix Missing Key in Component Sidebar

### DIFF
--- a/src/components/shared/ReactFlow/FlowSidebar/components/FolderItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/FolderItem.tsx
@@ -43,7 +43,7 @@ const FolderItem = ({ folder }: FolderItemProps) => {
           {hasComponents && folder.components && (
             <div>
               {folder.components.map((component) => {
-                const key = `${folder.name}-component-${component.name || component?.spec?.name}`;
+                const key = `${folder.name}-component-${component.name || component?.spec?.name || component.url}`;
                 // if the component has a spec or is a user component, render the appropriate component
                 // otherwise, render using URL
                 if (component.spec) {


### PR DESCRIPTION
Superquick fix to this error that appears when exploring the componentsidebar:
![image](https://github.com/user-attachments/assets/895e7bf1-6bbf-4517-96bf-7629d2db3afc)
