### PR TITLE
Add Details and Implementation Tabs to Task Config Sheet

### DIFF
--- a/src/components/shared/CodeViewer.tsx
+++ b/src/components/shared/CodeViewer.tsx
@@ -33,6 +33,7 @@ interface CodeViewerProps {
   code: string;
   language?: string;
   title?: string;
+  filename?: string;
   onFullscreenChange?: (isFullscreen: boolean) => void;
 }
 
@@ -97,6 +98,7 @@ const CodeViewer = ({
   code,
   language = "yaml",
   title = "Code Implementation",
+  filename = "",
   onFullscreenChange,
 }: CodeViewerProps) => {
   const { openFullscreen } = useFullscreen();
@@ -109,7 +111,9 @@ const CodeViewer = ({
   return (
     <div className="border rounded-md h-full overflow-hidden hide-scrollbar bg-slate-900">
       <div className="flex justify-between items-center p-2 sticky top-0 z-10 bg-slate-800">
-        <h2 className="text-white font-medium">(Read Only)</h2>
+        <h3 className="text-secondary font-medium ml-2">
+          {filename} <span className="text-sm">(Read Only)</span>
+        </h3>
         <Button
           variant="ghost"
           size="icon"

--- a/src/components/shared/Dialogs/ComponentDetails/tabs/index.ts
+++ b/src/components/shared/Dialogs/ComponentDetails/tabs/index.ts
@@ -1,3 +1,0 @@
-export { default as DetailsTab } from "./DetailsTab";
-export { default as ImplementationTab } from "./ImplementationTab";
-export { default as IOTab } from "./IOTab";

--- a/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
+++ b/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
@@ -14,8 +14,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { ComponentSpec } from "@/utils/componentSpec";
 import { downloadYamlFromComponentText } from "@/utils/URL";
 
-import InfoIconButton from "../../Buttons/InfoIconButton";
-import { DetailsTab, ImplementationTab, IOTab } from "./tabs";
+import InfoIconButton from "../Buttons/InfoIconButton";
+import { TaskDetails, TaskImplementation, TaskIO } from "../TaskDetails";
 
 interface ComponentDetailsProps {
   url: string;
@@ -90,7 +90,7 @@ const ComponentDetails = ({
 
           <div className="overflow-hidden h-[40vh]">
             <TabsContent value="details" className="h-full">
-              <DetailsTab
+              <TaskDetails
                 displayName={displayName}
                 componentSpec={componentSpec}
                 componentDigest={componentDigest}
@@ -101,11 +101,11 @@ const ComponentDetails = ({
             </TabsContent>
 
             <TabsContent value="io" className="h-full">
-              <IOTab componentSpec={componentSpec} />
+              <TaskIO componentSpec={componentSpec} />
             </TabsContent>
 
             <TabsContent value="implementation" className="h-full">
-              <ImplementationTab
+              <TaskImplementation
                 displayName={displayName}
                 componentSpec={componentSpec}
               />

--- a/src/components/shared/Dialogs/index.ts
+++ b/src/components/shared/Dialogs/index.ts
@@ -1,3 +1,4 @@
+export { default as ComponentDetailsDialog } from "./ComponentDetailsDialog";
 export { default as ConfirmationDialog } from "./ConfirmationDialog";
 export { default as DraggableDialog } from "./DraggableDialog";
 export { default as NewExperimentDialog } from "./NewExperimentDialog";

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/TaskConfigurationSheet.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/TaskConfigurationSheet.tsx
@@ -1,7 +1,10 @@
-import { Info } from "lucide-react";
+import { Code, InfoIcon, Parentheses } from "lucide-react";
 import { type ReactNode } from "react";
 
-import CondensedUrl from "@/components/shared/CondensedUrl";
+import {
+  TaskDetails,
+  TaskImplementation,
+} from "@/components/shared/TaskDetails";
 import { Button, type ButtonProps } from "@/components/ui/button";
 import {
   Sheet,
@@ -12,8 +15,10 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { ArgumentType, TaskSpec } from "@/utils/componentSpec";
 import { TOP_NAV_HEIGHT } from "@/utils/constants";
+import { getComponentName } from "@/utils/getComponentName";
 
 import ArgumentsSection from "../ArgumentsEditor/ArgumentsSection";
 
@@ -51,6 +56,8 @@ const TaskConfigurationSheet = ({
 
   const sheetHeight = window.innerHeight - TOP_NAV_HEIGHT;
 
+  const displayName = getComponentName(taskSpec.componentRef);
+
   return (
     <Sheet open={isOpen} onOpenChange={onOpenChange}>
       <SheetTrigger asChild>{trigger}</SheetTrigger>
@@ -66,17 +73,11 @@ const TaskConfigurationSheet = ({
         <SheetHeader>
           <SheetTitle>
             <div className="flex gap-2">
-              <Info />
+              <InfoIcon />
               {componentSpec.name ?? "<component>"}
             </div>
           </SheetTitle>
           <SheetDescription>id: {taskId}</SheetDescription>
-          {taskSpec.componentRef.url && (
-            <div className="flex gap-2 text-sidebar-primary text-sm">
-              Source:
-              <CondensedUrl url={taskSpec.componentRef.url} />
-            </div>
-          )}
           <div className="mt-4 flex flex-col gap-2">
             <div className="flex gap-2">
               {actions &&
@@ -87,18 +88,48 @@ const TaskConfigurationSheet = ({
           </div>
         </SheetHeader>
         <hr className="mx-4" />
-        <div className="flex flex-col overflow-y-auto px-4 gap-4">
-          <div>
-            <h2>Arguments</h2>
-            <p className="text-sm text-muted-foreground">
-              Configure the arguments for this task node.
-            </p>
-            <ArgumentsSection
-              taskSpec={taskSpec}
-              setArguments={setArguments}
-              disabled={disabled}
-            />
-          </div>
+        <div className="flex flex-col px-4 gap-4 overflow-y-auto">
+          <Tabs defaultValue="details">
+            <TabsList className="mb-2">
+              <TabsTrigger value="details" className="flex-1">
+                <InfoIcon className="h-4 w-4" />
+                Details
+              </TabsTrigger>
+              <TabsTrigger value="arguments" className="flex-1">
+                <Parentheses className="w-4 h-4" />
+                Arguments
+              </TabsTrigger>
+              <TabsTrigger value="implementation" className="flex-1">
+                <Code className="h-4 w-4" />
+                Implementation
+              </TabsTrigger>
+            </TabsList>
+            <TabsContent value="details" className="h-full">
+              <TaskDetails
+                displayName={displayName}
+                componentSpec={componentSpec}
+                componentDigest={taskSpec.componentRef.digest}
+                url={taskSpec.componentRef.url}
+              />
+            </TabsContent>
+            <TabsContent value="arguments" className="h-full">
+              <h2>Arguments</h2>
+              <p className="text-sm text-muted-foreground">
+                Configure the arguments for this task node.
+              </p>
+              <ArgumentsSection
+                taskSpec={taskSpec}
+                setArguments={setArguments}
+                disabled={disabled}
+              />
+            </TabsContent>
+            <TabsContent value="implementation" className="h-full">
+              <TaskImplementation
+                displayName={displayName}
+                componentSpec={componentSpec}
+              />
+            </TabsContent>
+          </Tabs>
         </div>
         <hr className="mx-4" />
         <SheetFooter>

--- a/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
@@ -2,7 +2,7 @@ import { File } from "lucide-react";
 import type { DragEvent } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-import ComponentDetails from "@/components/shared/Dialogs/ComponentDetails";
+import { ComponentDetailsDialog } from "@/components/shared/Dialogs";
 import { SidebarMenuItem } from "@/components/ui/sidebar";
 import { cn } from "@/lib/utils";
 import { EMPTY_GRAPH_COMPONENT_SPEC } from "@/providers/ComponentSpecProvider";
@@ -17,6 +17,7 @@ import type {
   ComponentSpec,
   TaskSpec,
 } from "@/utils/componentSpec";
+import { getComponentName } from "@/utils/getComponentName";
 import { getComponentByUrl } from "@/utils/localforge";
 
 interface ComponentMarkupProps {
@@ -97,7 +98,7 @@ const ComponentMarkup = ({
                 </span>
               </div>
               <div className="flex-1 flex justify-end mr-[15px]">
-                <ComponentDetails
+                <ComponentDetailsDialog
                   url={url}
                   displayName={displayName}
                   componentSpec={componentSpec}
@@ -193,10 +194,7 @@ const ComponentItemFromUrl = ({ url }: ComponentItemFromUrlProps) => {
   }, [url]);
 
   const displayName = useMemo(
-    () =>
-      componentSpec?.name ||
-      url.split("/").pop()?.replace(".yaml", "") ||
-      "Component",
+    () => getComponentName({ spec: componentSpec ?? undefined, url }),
     [componentSpec, url],
   );
 

--- a/src/components/shared/ReactFlow/FlowSidebar/components/UserComponentItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/UserComponentItem.tsx
@@ -2,7 +2,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { File, Trash2 } from "lucide-react";
 import { type DragEvent, useCallback, useState } from "react";
 
-import ComponentDetails from "@/components/shared/Dialogs/ComponentDetails";
+import { ComponentDetailsDialog } from "@/components/shared/Dialogs";
 import { Button } from "@/components/ui/button";
 import { SidebarMenuItem } from "@/components/ui/sidebar";
 import type { ComponentReference, ComponentSpec } from "@/utils/componentSpec";
@@ -87,7 +87,7 @@ const UserComponentItem = ({
           </span>
         </div>
         <div className="flex-1 flex justify-end mr-[15px]">
-          <ComponentDetails
+          <ComponentDetailsDialog
             url={url}
             displayName={displayName}
             componentSpec={componentSpec}

--- a/src/components/shared/TaskDetails/Details.tsx
+++ b/src/components/shared/TaskDetails/Details.tsx
@@ -1,26 +1,27 @@
 import { Download, ExternalLink } from "lucide-react";
+import type { ReactNode } from "react";
 
 import { Button } from "@/components/ui/button";
 import type { ComponentSpec } from "@/utils/componentSpec";
 import { convertRawUrlToDirectoryUrl } from "@/utils/URL";
 
-interface DetailsTabProps {
+interface TaskDetailsProps {
   displayName: string;
   componentSpec: ComponentSpec;
-  componentDigest: string;
-  url: string;
-  actions?: React.ReactNode[];
-  handleDownloadYaml: () => void;
+  componentDigest?: string;
+  url?: string;
+  actions?: ReactNode[];
+  handleDownloadYaml?: () => void;
 }
 
-const DetailsTab = ({
+const TaskDetails = ({
   displayName,
   componentSpec,
   componentDigest,
   url,
   actions = [],
   handleDownloadYaml,
-}: DetailsTabProps) => {
+}: TaskDetailsProps) => {
   const canonicalUrl = componentSpec?.metadata?.annotations?.canonical_location;
 
   return (
@@ -127,15 +128,17 @@ const DetailsTab = ({
         )}
 
         <div className="flex flex-row gap-2 px-3 py-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleDownloadYaml}
-            className="flex items-center gap-1 cursor-pointer"
-          >
-            <Download className="size-4" />
-            Download YAML
-          </Button>
+          {handleDownloadYaml && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleDownloadYaml}
+              className="flex items-center gap-1 cursor-pointer"
+            >
+              <Download className="size-4" />
+              Download YAML
+            </Button>
+          )}
           {actions.map((action, index) => (
             <div
               key={index}
@@ -150,4 +153,4 @@ const DetailsTab = ({
   );
 };
 
-export default DetailsTab;
+export default TaskDetails;

--- a/src/components/shared/TaskDetails/IO.tsx
+++ b/src/components/shared/TaskDetails/IO.tsx
@@ -1,11 +1,11 @@
 import { Badge } from "@/components/ui/badge";
 import type { ComponentSpec } from "@/utils/componentSpec";
 
-interface IOTabProps {
+interface TaskIOProps {
   componentSpec: ComponentSpec;
 }
 
-const IOTab = ({ componentSpec }: IOTabProps) => {
+const TaskIO = ({ componentSpec }: TaskIOProps) => {
   return (
     <div className="h-full overflow-auto hide-scrollbar">
       {componentSpec?.inputs && componentSpec.inputs.length > 0 && (
@@ -68,4 +68,4 @@ const IOTab = ({ componentSpec }: IOTabProps) => {
   );
 };
 
-export default IOTab;
+export default TaskIO;

--- a/src/components/shared/TaskDetails/Implementation.tsx
+++ b/src/components/shared/TaskDetails/Implementation.tsx
@@ -2,16 +2,19 @@ import yaml from "js-yaml";
 
 import CodeViewer from "@/components/shared/CodeViewer";
 import type { ComponentSpec } from "@/utils/componentSpec";
+import { getComponentFilename } from "@/utils/getComponentFilename";
 
-interface ImplementationTabProps {
+interface TaskImplementationProps {
   displayName: string;
   componentSpec: ComponentSpec;
 }
 
-const ImplementationTab = ({
+const TaskImplementation = ({
   displayName,
   componentSpec,
-}: ImplementationTabProps) => {
+}: TaskImplementationProps) => {
+  const filename = getComponentFilename(componentSpec);
+
   return (
     <>
       {componentSpec?.implementation ? (
@@ -23,6 +26,7 @@ const ImplementationTab = ({
           })}
           language="yaml"
           title={`${displayName} Implementation (read-only)`}
+          filename={filename}
         />
       ) : (
         <div className="text-sm text-gray-500 p-4 border rounded-md">
@@ -33,4 +37,4 @@ const ImplementationTab = ({
   );
 };
 
-export default ImplementationTab;
+export default TaskImplementation;

--- a/src/components/shared/TaskDetails/index.ts
+++ b/src/components/shared/TaskDetails/index.ts
@@ -1,0 +1,3 @@
+export { default as TaskDetails } from "./Details";
+export { default as TaskImplementation } from "./Implementation";
+export { default as TaskIO } from "./IO";

--- a/src/utils/getComponentFilename.ts
+++ b/src/utils/getComponentFilename.ts
@@ -1,0 +1,10 @@
+import type { ComponentSpec } from "./componentSpec";
+
+export const getComponentFilename = (componentSpec: ComponentSpec) => {
+  const url = componentSpec?.metadata?.annotations?.canonical_location;
+  if (url) {
+    const urlParts = url.split("/");
+    return urlParts[urlParts.length - 1];
+  }
+  return "component.yaml";
+};

--- a/src/utils/getComponentName.ts
+++ b/src/utils/getComponentName.ts
@@ -1,0 +1,9 @@
+import type { ComponentReference } from "./componentSpec";
+
+export const getComponentName = (component: ComponentReference): string => {
+  return (
+    component.spec?.name ||
+    component.url?.split("/").pop()?.replace(".yaml", "") ||
+    "Component"
+  );
+};


### PR DESCRIPTION
Closes https://github.com/Shopify/oasis-frontend/issues/79
Closes https://github.com/Cloud-Pipelines/pipeline-studio-app/issues/23

Adds tabs to the TaskConfig sheet for Task Nodes in the pipeline editor.

Tabs are:

- Details: uses the same component as the TaskInfo sheet
- Arguments: uses the existing arguments components
- Implementation: uses the same component as thew TaskInfo sheet

Removes the component url from the header as it is now surfaced in the `details` tab.

![image](https://github.com/user-attachments/assets/a51b7ca8-b617-4658-a369-ea2700f5f89a)

Also includes a few misc improvements, such as the yaml filename on the implementation tab codeviewer
