### PR TITLE
Removes blanks state for missing state

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
@@ -13,6 +13,7 @@ import {
   type CSSProperties,
   memo,
   type ReactElement,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -20,6 +21,7 @@ import {
 import { useDynamicFontSize } from "@/hooks/useDynamicFontSize";
 import useToastNotification from "@/hooks/useToastNotification";
 import { cn } from "@/lib/utils";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import type { TaskNodeData } from "@/types/taskNode";
 import type {
   ArgumentType,
@@ -138,8 +140,13 @@ function generateOutputHandles(outputSpecs: OutputSpec[]): ReactElement[] {
 }
 
 const ComponentTaskNode = ({ data, selected }: NodeProps) => {
+  const { taskStatusMap } = useComponentSpec();
   const [isComponentEditorOpen, setIsComponentEditorOpen] = useState(false);
   const [isTaskDetailsSheetOpen, setIsTaskDetailsSheetOpen] = useState(false);
+  const taskId = useMemo(
+    () => data?.taskId as string | undefined,
+    [data?.taskId],
+  );
   const nodeRef = useRef<HTMLDivElement>(null);
   const textRef = useRef<HTMLDivElement>(null);
 
@@ -153,7 +160,7 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
 
   const readOnly = typedData.readOnly;
 
-  const runStatus = taskSpec.annotations?.["status"] as string | undefined;
+  const runStatus = taskStatusMap.get(taskId ?? "");
 
   if (componentSpec === undefined) {
     return null;

--- a/src/providers/ComponentSpecProvider.tsx
+++ b/src/providers/ComponentSpecProvider.tsx
@@ -40,6 +40,8 @@ interface ComponentSpecContextType {
   refetch: () => void;
   updateGraphSpec: (newGraphSpec: GraphSpec) => void;
   saveComponentSpec: (name: string) => Promise<void>;
+  taskStatusMap: Map<string, string>;
+  setTaskStatusMap: (taskStatusMap: Map<string, string>) => void;
 }
 
 const ComponentSpecContext = createContext<
@@ -49,14 +51,19 @@ const ComponentSpecContext = createContext<
 export const ComponentSpecProvider = ({
   experimentName,
   spec,
+  initialTaskStatusMap,
   children,
 }: {
   experimentName?: string;
   spec?: ComponentSpec;
+  initialTaskStatusMap?: Map<string, string>;
   children: ReactNode;
 }) => {
   const [componentSpec, setComponentSpec] = useState<ComponentSpec>(
     spec ?? EMPTY_GRAPH_COMPONENT_SPEC,
+  );
+  const [taskStatusMap, setTaskStatusMap] = useState<Map<string, string>>(
+    initialTaskStatusMap ?? new Map(),
   );
   const [originalComponentSpec, setOriginalComponentSpec] =
     useState<ComponentSpec>(spec ?? EMPTY_GRAPH_COMPONENT_SPEC);
@@ -153,6 +160,8 @@ export const ComponentSpecProvider = ({
         refetch,
         updateGraphSpec,
         saveComponentSpec,
+        taskStatusMap,
+        setTaskStatusMap,
       }}
     >
       {children}

--- a/src/routes/PipelineRun/PipelineRun.tsx
+++ b/src/routes/PipelineRun/PipelineRun.tsx
@@ -1,6 +1,7 @@
 import { DndContext } from "@dnd-kit/core";
 import { useQuery } from "@tanstack/react-query";
 import { ReactFlowProvider } from "@xyflow/react";
+import { useEffect } from "react";
 
 import type {
   GetExecutionInfoResponse,
@@ -8,10 +9,37 @@ import type {
 } from "@/api/types.gen";
 import PipelineRunPage from "@/components/PipelineRun";
 import { useLoadComponentSpecAndDetailsFromId } from "@/hooks/useLoadComponentSpecDetailsFromId";
-import { ComponentSpecProvider } from "@/providers/ComponentSpecProvider";
+import {
+  ComponentSpecProvider,
+  useComponentSpec,
+} from "@/providers/ComponentSpecProvider";
 import { type RunDetailParams, runDetailRoute } from "@/routes/router";
 import { fetchExecutionState } from "@/services/executionService";
-import type { ComponentSpec } from "@/utils/componentSpec";
+
+const PipelineRunHtml = ({
+  detailsData,
+  id,
+}: {
+  detailsData: GetExecutionInfoResponse | undefined;
+  id: string;
+}) => {
+  const { setTaskStatusMap } = useComponentSpec();
+
+  const { data: stateData } = useQuery<GetGraphExecutionStateResponse>({
+    queryKey: ["run_state", id],
+    queryFn: () => fetchExecutionState(id),
+    refetchInterval: 5000,
+    refetchIntervalInBackground: false,
+    staleTime: 1000,
+  });
+
+  useEffect(() => {
+    const taskStatusMap = buildTaskStatusMap(detailsData, stateData);
+    setTaskStatusMap(taskStatusMap);
+  }, [stateData]);
+
+  return <PipelineRunPage />;
+};
 
 const PipelineRun = () => {
   const { id } = runDetailRoute.useParams() as RunDetailParams;
@@ -21,15 +49,7 @@ const PipelineRun = () => {
     isLoading: detailsLoading,
   } = useLoadComponentSpecAndDetailsFromId(id);
 
-  const { data: stateData, isLoading: stateLoading } =
-    useQuery<GetGraphExecutionStateResponse>({
-      queryKey: ["run_state", id],
-      queryFn: () => fetchExecutionState(id),
-      refetchInterval: 5000,
-      refetchIntervalInBackground: false,
-    });
-
-  if (detailsLoading || stateLoading) {
+  if (detailsLoading) {
     return (
       <div className="flex items-center justify-center h-full">
         Loading run details...
@@ -37,7 +57,7 @@ const PipelineRun = () => {
     );
   }
 
-  if (!componentSpec || !detailsData || !stateData) {
+  if (!componentSpec) {
     return (
       <div className="flex items-center justify-center h-full">
         No pipeline data available
@@ -45,19 +65,12 @@ const PipelineRun = () => {
     );
   }
 
-  const taskStatusMap = buildTaskStatusMap(detailsData, stateData);
-  const newComponentSpec = addStatusToComponentSpec(
-    componentSpec,
-    taskStatusMap,
-    detailsData,
-  );
-
   return (
-    <ComponentSpecProvider spec={newComponentSpec}>
+    <ComponentSpecProvider spec={componentSpec}>
       <div className="dndflow">
         <DndContext>
           <ReactFlowProvider>
-            <PipelineRunPage />
+            <PipelineRunHtml detailsData={detailsData} id={id} />
           </ReactFlowProvider>
         </DndContext>
       </div>
@@ -68,10 +81,21 @@ const PipelineRun = () => {
 export default PipelineRun;
 
 const buildTaskStatusMap = (
-  detailsData: GetExecutionInfoResponse,
-  stateData: GetGraphExecutionStateResponse,
+  detailsData?: GetExecutionInfoResponse,
+  stateData?: GetGraphExecutionStateResponse,
 ) => {
   const taskStatusMap = new Map();
+  if (!detailsData) {
+    return taskStatusMap;
+  }
+
+  // If no state data is available, set all tasks to WAITING_FOR_UPSTREAM
+  if (!stateData && detailsData?.child_task_execution_ids) {
+    Object.keys(detailsData.child_task_execution_ids).forEach((taskId) => {
+      taskStatusMap.set(taskId, "WAITING_FOR_UPSTREAM");
+    });
+    return taskStatusMap;
+  }
 
   if (
     detailsData?.child_task_execution_ids &&
@@ -86,53 +110,13 @@ const buildTaskStatusMap = (
         if (statusStats) {
           const status = Object.keys(statusStats)[0];
           taskStatusMap.set(taskId, status);
+        } else {
+          // If this task doesn't have status in state data, mark as WAITING
+          taskStatusMap.set(taskId, "WAITING_FOR_UPSTREAM");
         }
       },
     );
   }
 
   return taskStatusMap;
-};
-
-const addStatusToComponentSpec = (
-  componentSpec: ComponentSpec,
-  taskStatusMap: Map<string, string>,
-  detailsData: GetExecutionInfoResponse,
-): ComponentSpec => {
-  if (
-    !componentSpec ||
-    !("graph" in componentSpec.implementation) ||
-    taskStatusMap.size === 0
-  ) {
-    return componentSpec;
-  }
-
-  const tasksWithStatus = Object.fromEntries(
-    Object.entries(componentSpec.implementation.graph.tasks).map(
-      ([taskId, taskSpec]) => {
-        const status = taskStatusMap.get(taskId);
-        const executionId = detailsData?.child_task_execution_ids?.[taskId];
-        const enhancedTaskSpec = {
-          ...taskSpec,
-          annotations: {
-            ...taskSpec.annotations,
-            status: status,
-            executionId: executionId,
-          },
-        };
-        return [taskId, enhancedTaskSpec];
-      },
-    ),
-  );
-
-  return {
-    ...componentSpec,
-    implementation: {
-      ...componentSpec.implementation,
-      graph: {
-        ...componentSpec.implementation.graph,
-        tasks: tasksWithStatus,
-      },
-    },
-  };
 };


### PR DESCRIPTION
I've added to the componentspec provider to also hold the status of the nodes. We need to do this because the API can't block or re-render the entire tree on every call. This fixes the issue where we were not seeing the status updating.
https://github.com/user-attachments/assets/906a7c84-7bcd-43ea-a58d-992cbbccaa6d

