### PR TITLE
Fix Toolbar Impacting Viewport Bounds on Load

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -495,6 +495,10 @@ const FlowCanvas = ({
 
   const { title, content } = getConfirmationDialogDetails(selectedElements);
 
+  const nodesWithoutToolbar = nodes.filter(
+    (node) => node.id !== SELECTION_TOOLBAR_ID,
+  );
+
   return (
     <>
       <ReactFlow
@@ -518,6 +522,10 @@ const FlowCanvas = ({
         nodesDraggable={!readOnly}
         nodesConnectable={!readOnly}
         connectOnClick={!readOnly}
+        fitView
+        fitViewOptions={{
+          nodes: nodesWithoutToolbar,
+        }}
       >
         {children}
       </ReactFlow>


### PR DESCRIPTION
Fixes and issue where the hidden `selection-toolbar` is impacting the viewport on load. The viewport will now load centred on the task nodes again.