### PR TITLE
Drag and Drop to Replace Nodes

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/ConfirmationDialogs/DeleteConfirmation.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/ConfirmationDialogs/DeleteConfirmation.tsx
@@ -1,0 +1,88 @@
+import type { NodesAndEdges } from "../types";
+import { thisCannotBeUndone } from "./shared";
+
+export function getDeleteConfirmationDetails(deletedElements: NodesAndEdges) {
+  const deletedNodes = deletedElements.nodes;
+  const deletedEdges = deletedElements.edges;
+
+  if (deletedNodes.length > 0) {
+    const isDeletingMultipleNodes = deletedNodes.length > 1;
+
+    if (!isDeletingMultipleNodes) {
+      const singleDeleteTitle =
+        "Delete Node" +
+        (deletedNodes.length > 0 ? ` '${deletedNodes[0].id}'` : "") +
+        "?";
+
+      const singleDeleteDesc = (
+        <div className="text-sm">
+          <p>This will also delete all connections to and from the Node.</p>
+          <br />
+          {thisCannotBeUndone}
+        </div>
+      );
+
+      return {
+        title: singleDeleteTitle,
+        content: singleDeleteDesc,
+        description: "",
+      };
+    }
+
+    const multiDeleteTitle = `Delete Nodes?`;
+
+    const multiDeleteDesc = (
+      <div className="text-sm">
+        <p>{`
+          Deleting
+          ${deletedNodes
+            .map((node) => {
+              return `'${node.id}'`;
+            })
+            .join(
+              ", ",
+            )} will also remove all connections to and from these nodes.`}</p>
+        <br />
+        {thisCannotBeUndone}
+      </div>
+    );
+
+    return {
+      title: multiDeleteTitle,
+      content: multiDeleteDesc,
+      description: "",
+    };
+  }
+
+  if (deletedEdges.length > 0) {
+    const isDeletingMultipleEdges = deletedEdges.length > 1;
+
+    const edgeDeleteTitle = isDeletingMultipleEdges
+      ? "Delete Connections?"
+      : "Delete Connection?";
+
+    const edgeDeleteDesc = (
+      <div className="text-sm">
+        <p>This will remove the follow connections between task nodes:</p>
+        <p>
+          {deletedEdges
+            .map((edge) => {
+              return `'${edge.id}'`;
+            })
+            .join(", ")}
+        </p>
+        <br />
+        {thisCannotBeUndone}
+      </div>
+    );
+
+    return {
+      title: edgeDeleteTitle,
+      content: edgeDeleteDesc,
+      description: "",
+    };
+  }
+
+  // Fallback to default
+  return {};
+}

--- a/src/components/shared/ReactFlow/FlowCanvas/ConfirmationDialogs/ReplaceConfirmation.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/ConfirmationDialogs/ReplaceConfirmation.tsx
@@ -1,0 +1,129 @@
+import { type Node } from "@xyflow/react";
+import { Unlink } from "lucide-react";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import type { ArgumentType, InputSpec, TaskSpec } from "@/utils/componentSpec";
+
+import { thisCannotBeUndone } from "./shared";
+
+export function getReplaceConfirmationDetails(
+  replacedNode: Node,
+  newTaskId: string,
+  lostInputs: InputSpec[],
+) {
+  const oldTaskId = replacedNode.data.taskId as string;
+  const oldTaskSpec = replacedNode.data.taskSpec as TaskSpec | undefined;
+  const oldTaskInputs = oldTaskSpec?.componentRef.spec?.inputs;
+  const oldTaskArguments = oldTaskSpec?.arguments;
+
+  const hasLostInputs = lostInputs.length > 0;
+  const hasMigratedInputs =
+    oldTaskInputs && lostInputs.length < oldTaskInputs.length;
+
+  const argumentsList = (
+    <div className="flex flex-col gap-0 my-1">
+      {lostInputs.map((input) => {
+        const argument = getArgumentDetails(oldTaskArguments, input.name);
+
+        return (
+          <div key={input.name} className="flex items-center">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Unlink
+                  className={cn(
+                    "h-3 w-3 mr-1 text-destructive font-bold",
+                    !argument.isBrokenConnection && "invisible",
+                  )}
+                />
+              </TooltipTrigger>
+              <TooltipContent className="z-[9999]">
+                Linked node will be disconnected
+              </TooltipContent>
+            </Tooltip>
+            <span className="font-bold">{input.name}</span>
+            <span className="font-light ml-1">{`(${input.type})`}</span>
+            <span>:</span>
+            <span className="ml-1">{argument.value}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+
+  const title = "Replace Node?";
+  const description = "";
+  const content = (
+    <div className="text-sm">
+      <p>{`Are you sure you want to replace "${oldTaskId}" with "${newTaskId}"?`}</p>
+      <br />
+      {hasLostInputs ? (
+        <>
+          <p>The following input arguments will be removed:</p>
+          <div>{argumentsList}</div>
+          {hasMigratedInputs && (
+            <>
+              <br />
+              <p>All other inputs will be preserved.</p>
+            </>
+          )}
+        </>
+      ) : (
+        <p>All inputs will be preserved.</p>
+      )}
+      <br />
+      {thisCannotBeUndone}
+    </div>
+  );
+
+  return {
+    title,
+    description,
+    content,
+  };
+}
+
+function getArgumentDetails(
+  taskArguments: { [k: string]: ArgumentType } | undefined,
+  inputName: string,
+) {
+  const notSet = "No value";
+
+  if (!taskArguments) {
+    return { value: notSet, isBrokenConnection: false };
+  }
+
+  const argument = taskArguments[inputName];
+
+  if (!argument) {
+    return { value: notSet, isBrokenConnection: false };
+  }
+
+  if (typeof argument === "object" && argument !== null) {
+    if ("taskOutput" in argument && argument.taskOutput) {
+      return {
+        value: `from "${argument.taskOutput.taskId}"`,
+        isBrokenConnection: true,
+      };
+    }
+    if ("graphInput" in argument && argument.graphInput) {
+      return {
+        value: `"${argument.graphInput.inputName}"`,
+        isBrokenConnection: true,
+      };
+    }
+  }
+
+  if (typeof argument === "string") {
+    if (argument === "") {
+      return { value: notSet, isBrokenConnection: false };
+    }
+    return { value: `"${argument}"`, isBrokenConnection: false };
+  }
+
+  return { value: notSet, isBrokenConnection: false };
+}

--- a/src/components/shared/ReactFlow/FlowCanvas/ConfirmationDialogs/shared.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/ConfirmationDialogs/shared.tsx
@@ -1,0 +1,3 @@
+export const thisCannotBeUndone = (
+  <p className="text-muted-foreground">This cannot be undone.</p>
+);

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
@@ -152,6 +152,7 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
   const componentSpec = taskSpec.componentRef.spec;
 
   const readOnly = typedData.readOnly;
+  const highlighted = typedData.highlighted;
 
   const runStatus = taskStatusMap.get(taskId ?? "");
 
@@ -284,7 +285,8 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
           "border rounded-md shadow-sm transition-all duration-200",
           getBorderColor(),
           getBgColor(),
-          selected ? "border-sky-500" : " hover:border-slate-400",
+          selected ? "border-sky-500" : "hover:border-slate-400",
+          highlighted && "border-orange-500",
         )}
         style={{ width: `${NODE_WIDTH_IN_PX}px` }}
         ref={nodeRef}

--- a/src/components/shared/ReactFlow/FlowCanvas/types.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/types.ts
@@ -1,0 +1,6 @@
+import type { Edge, Node } from "@xyflow/react";
+
+export type NodesAndEdges = {
+  nodes: Node[];
+  edges: Edge[];
+};

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/isPositionInNode.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/isPositionInNode.ts
@@ -1,0 +1,17 @@
+import type { Node, XYPosition } from "@xyflow/react";
+
+export const isPositionInNode = (node: Node, position: XYPosition) => {
+  const nodeRect = {
+    x: node.position.x,
+    y: node.position.y,
+    width: node.measured?.width || 0,
+    height: node.measured?.height || 0,
+  };
+
+  return (
+    position.x >= nodeRect.x &&
+    position.x <= nodeRect.x + nodeRect.width &&
+    position.y >= nodeRect.y &&
+    position.y <= nodeRect.y + nodeRect.height
+  );
+};

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/replaceTaskNode.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/replaceTaskNode.ts
@@ -1,0 +1,109 @@
+import type { Node } from "@xyflow/react";
+
+import type {
+  ArgumentType,
+  GraphSpec,
+  InputSpec,
+  TaskSpec,
+} from "@/utils/componentSpec";
+import { deepClone } from "@/utils/deepClone";
+import { getUniqueTaskName } from "@/utils/unique";
+
+export const replaceTaskNode = (
+  nodeToReplace: Node,
+  newTask: TaskSpec,
+  graphSpec: GraphSpec,
+) => {
+  const updatedGraphSpec = deepClone(graphSpec);
+
+  const newComponentRef = newTask.componentRef;
+  const taskName = newComponentRef.spec?.name;
+  const newTaskInputs = newComponentRef.spec?.inputs;
+  const newTaskOutputs = newComponentRef.spec?.outputs;
+  const newTaskId = getUniqueTaskName(graphSpec, taskName);
+
+  const oldTaskId = nodeToReplace.data.taskId as string;
+  const oldTask = deepClone(nodeToReplace.data.taskSpec) as TaskSpec;
+  const oldTaskInputs = oldTask.componentRef.spec?.inputs;
+
+  // Migrate the task to the new componentRef
+  const updatedTask = {
+    ...oldTask,
+  };
+
+  updatedTask.componentRef = newComponentRef;
+
+  // Determine which of the original task's inputs will be removed
+  const lostInputs: InputSpec[] = [];
+
+  if (oldTaskInputs) {
+    oldTaskInputs.forEach((input: InputSpec) => {
+      const inputName = input.name;
+
+      if (newTaskInputs?.some((input: InputSpec) => input.name === inputName)) {
+        return;
+      }
+
+      lostInputs.push(input);
+    });
+  }
+
+  // Migrate Inputs
+  const oldArguments = updatedTask.arguments;
+  if (oldArguments) {
+    const updatedArguments = Object.keys(oldArguments)
+      .filter((arg) => !lostInputs.some((input) => input.name === arg))
+      .reduce(
+        (acc, key) => {
+          acc[key] = oldArguments[key];
+          return acc;
+        },
+        {} as Record<string, ArgumentType>,
+      );
+
+    updatedTask.arguments = updatedArguments;
+  }
+
+  // Migrate outputs
+  Object.values(updatedGraphSpec.tasks).forEach((task) => {
+    const updatedArguments = { ...task.arguments };
+
+    Object.entries(updatedArguments).forEach(([inputName, argument]) => {
+      if (
+        typeof argument === "object" &&
+        argument !== null &&
+        "taskOutput" in argument &&
+        argument.taskOutput &&
+        argument.taskOutput.taskId === oldTaskId
+      ) {
+        const outputName = argument.taskOutput.outputName;
+
+        if (newTaskOutputs?.some((output) => output.name === outputName)) {
+          // Update the taskOutput taskId to the new taskId
+          updatedArguments[inputName] = {
+            ...argument,
+            taskOutput: {
+              ...argument.taskOutput,
+              taskId: newTaskId,
+            },
+          };
+        } else {
+          // Remove the argument if the new task does not have the same output
+          delete updatedArguments[inputName];
+        }
+      }
+    });
+
+    task.arguments = updatedArguments;
+  });
+
+  // Update GraphSpec
+  delete updatedGraphSpec.tasks[oldTaskId];
+
+  updatedGraphSpec.tasks = {
+    ...updatedGraphSpec.tasks,
+    [newTaskId]: updatedTask,
+  };
+
+  return { updatedGraphSpec, lostInputs, newTaskId, updatedTask } as const;
+};

--- a/src/hooks/useConfirmationDialog.ts
+++ b/src/hooks/useConfirmationDialog.ts
@@ -48,5 +48,12 @@ export default function useConfirmationDialog() {
     });
   };
 
-  return { title, description, content, isOpen, handlers, triggerDialog };
+  return {
+    title,
+    description,
+    content,
+    isOpen,
+    handlers,
+    triggerDialog,
+  };
 }

--- a/src/types/taskNode.ts
+++ b/src/types/taskNode.ts
@@ -4,6 +4,7 @@ export interface TaskNodeData extends Record<string, unknown> {
   taskSpec?: TaskSpec;
   taskId?: string;
   readOnly?: boolean;
+  highlighted?: boolean;
   callbacks?: TaskNodeCallbacks;
   nodeCallbacks: NodeCallbacks;
 }

--- a/src/utils/deepClone.ts
+++ b/src/utils/deepClone.ts
@@ -1,0 +1,1 @@
+export const deepClone = <T>(obj: T): T => structuredClone(obj);

--- a/src/utils/nodes/createTaskNode.ts
+++ b/src/utils/nodes/createTaskNode.ts
@@ -26,6 +26,7 @@ export const createTaskNode = (
       ...nodeData,
       taskSpec,
       taskId,
+      highlighted: false,
       callbacks: dynamicCallbacks, // Use these callbacks internally within the node
     },
     position: position,


### PR DESCRIPTION
Closes https://github.com/Shopify/oasis-frontend/issues/74

### Drag and Drop Task Node Replacement

Replace task nodes on the canvas by dragging a Task from the sidebar on top of them. The node will highlight orange if the drop operation will trigger a replacement and a confirmation dialog will appear when the drop occurs.

![image](https://github.com/user-attachments/assets/b5f27773-7d5d-44f2-97e4-8cec6715b68c)
![image](https://github.com/user-attachments/assets/4d809b97-c06d-4749-b105-084fe85f7ba7)



Upon confirmation the new task node will replace the old one, assuming its position and attempting to maintain as many arguments, inputs and outputs as possible.


https://github.com/user-attachments/assets/26219321-7dca-4cd3-90f7-6f0b6ed0b93c

#### Known Issues

Replacement by Input/Output node is currently unsupported, due to these nodes not being available in the sidebar. We will need to make them compatible once they are available.

Upgrade-in-Place and Group-Replace features will come in later PRs.

