### PR TITLE
Update the task/node info sheet/dialog

### DIFF
--- a/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
+++ b/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
@@ -12,7 +12,6 @@ import {
 } from "@/components/ui/dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { ComponentSpec } from "@/utils/componentSpec";
-import { downloadYamlFromComponentText } from "@/utils/URL";
 
 import InfoIconButton from "../Buttons/InfoIconButton";
 import { TaskDetails, TaskImplementation, TaskIO } from "../TaskDetails";
@@ -33,7 +32,6 @@ const ComponentDetails = ({
   displayName,
   componentSpec,
   componentDigest,
-  componentText,
   trigger,
   actions = [],
   onClose,
@@ -41,9 +39,6 @@ const ComponentDetails = ({
   // Get global fullscreen state
   const { isAnyFullscreen } = useFullscreen();
 
-  const handleDownloadYaml = () => {
-    downloadYamlFromComponentText(componentText, componentSpec, displayName);
-  };
   const dialogTriggerButton = trigger || <InfoIconButton />;
 
   const onOpenChange = (open: boolean) => {
@@ -96,7 +91,6 @@ const ComponentDetails = ({
                 componentDigest={componentDigest}
                 url={url}
                 actions={actions}
-                handleDownloadYaml={handleDownloadYaml}
               />
             </TabsContent>
 

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/TaskConfigurationSheet.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/TaskConfigurationSheet.tsx
@@ -9,24 +9,32 @@ import { Button, type ButtonProps } from "@/components/ui/button";
 import {
   Sheet,
   SheetContent,
-  SheetDescription,
   SheetFooter,
   SheetHeader,
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import type { ArgumentType, TaskSpec } from "@/utils/componentSpec";
 import { TOP_NAV_HEIGHT } from "@/utils/constants";
 import { getComponentName } from "@/utils/getComponentName";
 
 import ArgumentsSection from "../ArgumentsEditor/ArgumentsSection";
 
+interface ButtonPropsWithTooltip extends ButtonProps {
+  tooltip?: string;
+}
 interface TaskConfigurationSheetProps {
   trigger?: ReactNode;
   taskId: string;
   taskSpec: TaskSpec;
-  actions?: ButtonProps[];
+  actions?: ButtonPropsWithTooltip[];
   isOpen: boolean;
   disabled?: boolean;
   onOpenChange: (isOpen: boolean) => void;
@@ -70,24 +78,9 @@ const TaskConfigurationSheet = ({
         }}
         overlay={false}
       >
-        <SheetHeader>
-          <SheetTitle>
-            <div className="flex gap-2">
-              <InfoIcon />
-              {componentSpec.name ?? "<component>"}
-            </div>
-          </SheetTitle>
-          <SheetDescription>id: {taskId}</SheetDescription>
-          <div className="mt-4 flex flex-col gap-2">
-            <div className="flex gap-2">
-              {actions &&
-                actions.map((action, index) => (
-                  <Button key={index} {...action} />
-                ))}
-            </div>
-          </div>
+        <SheetHeader className="pb-0">
+          <SheetTitle>{componentSpec.name ?? "<component>"}</SheetTitle>
         </SheetHeader>
-        <hr className="mx-4" />
         <div className="flex flex-col px-4 gap-4 overflow-y-auto">
           <Tabs defaultValue="details">
             <TabsList className="mb-2">
@@ -108,8 +101,19 @@ const TaskConfigurationSheet = ({
               <TaskDetails
                 displayName={displayName}
                 componentSpec={componentSpec}
+                taskId={taskId}
                 componentDigest={taskSpec.componentRef.digest}
                 url={taskSpec.componentRef.url}
+                actions={actions?.map((action, index) => (
+                  <TooltipProvider key={index}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button {...action} />
+                      </TooltipTrigger>
+                      <TooltipContent>{action.tooltip}</TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                ))}
               />
             </TabsContent>
             <TabsContent value="arguments" className="h-full">
@@ -131,7 +135,6 @@ const TaskConfigurationSheet = ({
             </TabsContent>
           </Tabs>
         </div>
-        <hr className="mx-4" />
         <SheetFooter>
           <Button
             onClick={() => onOpenChange(false)}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
@@ -1,14 +1,6 @@
-/**
- * @license
- * Copyright 2021 Alexey Volkov
- * SPDX-License-Identifier: Apache-2.0
- * @author         Alexey Volkov <alexey.volkov+oss@ark-kun.com>
- * @copyright 2021 Alexey Volkov <alexey.volkov+oss@ark-kun.com>
- */
 import type { HandleType, NodeProps } from "@xyflow/react";
 import { Handle, Position } from "@xyflow/react";
-import yaml from "js-yaml";
-import { BookCopy, Copy, Trash } from "lucide-react";
+import { CopyIcon, TrashIcon } from "lucide-react";
 import {
   type CSSProperties,
   memo,
@@ -281,19 +273,6 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
     setIsComponentEditorOpen(false);
   };
 
-  const handleCopyYaml = () => {
-    const code = yaml.dump(componentSpec?.implementation, {
-      lineWidth: 80,
-      noRefs: true,
-      indent: 2,
-    });
-
-    navigator.clipboard.writeText(code).then(
-      () => notify("Implementation copied to clipboard", "success"),
-      (err) => notify("Failed to copy Implementation: " + err, "error"),
-    );
-  };
-
   const handleTaskDetailsSheetClose = () => {
     setIsTaskDetailsSheetOpen(false);
   };
@@ -342,34 +321,23 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
               {
                 children: (
                   <div className="flex items-center gap-2">
-                    <BookCopy />
-                    Copy yaml
+                    <CopyIcon />
                   </div>
                 ),
                 variant: "secondary",
                 className: "cursor-pointer",
-                onClick: handleCopyYaml,
-              },
-              {
-                children: (
-                  <div className="flex items-center gap-2">
-                    <Copy />
-                    Duplicate
-                  </div>
-                ),
-                variant: "secondary",
-                className: "cursor-pointer",
+                tooltip: "Duplicate Task",
                 onClick: handleDuplicateTaskNode,
               },
               {
                 children: (
                   <div className="flex items-center gap-2">
-                    <Trash />
-                    Delete
+                    <TrashIcon />
                   </div>
                 ),
                 variant: "destructive",
                 className: "cursor-pointer",
+                tooltip: "Delete Task",
                 onClick: handleDeleteTaskNode,
               },
             ]}

--- a/src/utils/URL.ts
+++ b/src/utils/URL.ts
@@ -1,3 +1,4 @@
+import yaml from "js-yaml";
 const transformGcsUrl = (url: string) => {
   if (url.startsWith("gs://")) {
     return url.replace("gs://", "https://storage.cloud.google.com/");
@@ -27,10 +28,14 @@ const convertRawUrlToDirectoryUrl = (rawUrl: string) => {
 };
 
 const downloadYamlFromComponentText = (
-  componentText: string,
   componentSpec: ComponentSpec,
   displayName: string,
 ) => {
+  const componentText = yaml.dump(componentSpec, {
+    lineWidth: 80,
+    noRefs: true,
+    indent: 2,
+  });
   const blob = new Blob([componentText], { type: "text/yaml" });
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -5,4 +5,5 @@ const formatBytes = (bytes: number) => {
   const i = Math.floor(Math.log(bytes) / Math.log(k));
   return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
 };
+
 export { formatBytes };

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -1,0 +1,16 @@
+import yaml from "js-yaml";
+
+const copyToYaml = (text: string | object, onSuccess: (message: string) => void, onFail: (message: string) => void) => {
+    const code = yaml.dump(text, {
+      lineWidth: 80,
+      noRefs: true,
+      indent: 2,
+    });
+
+    navigator.clipboard.writeText(code).then(
+      () => onSuccess("YAML copied to clipboard"),
+      (err) => onFail("Failed to copy YAML: " + err),
+    );
+  };
+
+export default copyToYaml;


### PR DESCRIPTION
I have updated the sheet and dialog for task/nodes:

- Copy now copies the entire YAML not the just the implementation portion
- Actions
   - I have moved the actions to the action portion of the src/components/shared/TaskDetails/Details.tsx for consistency
   - I moved some logic, like copy YAML and download to the details component
   - I've removed the text next to the buttons, and gave them new icons that I believe better represent the action.
   - I've added tool tips to the buttons
- I've added a collapsible component around description as the information isn't immediately  required and causes the details to grow quite large in some cases 
- I've moved the task ID to the details component instead of under the header

![Screenshot 2025-05-06 at 11 37 36 AM](https://github.com/user-attachments/assets/11817226-289c-45ff-825d-9bd6e4dd276f)
![Screenshot 2025-05-06 at 11 38 02 AM](https://github.com/user-attachments/assets/c1a5828d-1648-405f-8a83-9e261932d1c5)
![Screenshot 2025-05-06 at 11 38 12 AM](https://github.com/user-attachments/assets/4100aa45-2e0a-4b14-973f-6ffd3ff6fdf1)
![Screenshot 2025-05-06 at 11 38 24 AM](https://github.com/user-attachments/assets/8a51be94-51ac-4130-87ee-533e9569a542)

https://github.com/user-attachments/assets/e5951eaa-9314-434b-b1c8-acda799cb5ce

