### PR TITLE
Add Tooltip to Argument Input Placeholders

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
@@ -113,26 +113,33 @@ export const ArgumentInputField = ({
         </div>
       </div>
       <div className="relative w-48">
-        <Input
-          id={argument.inputSpec.name}
-          value={inputValue}
-          onChange={(e) => {
-            handleInputChange(e.target.value);
-          }}
-          placeholder={placeholder}
-          required={!argument.inputSpec.optional}
-          className={cn(
-            "flex-1",
-            canUndo && "pr-10",
-            argument.isRemoved &&
-              !argument.inputSpec.optional &&
-              "border-red-200",
-            argument.isRemoved &&
-              argument.inputSpec.optional &&
-              "border-gray-100 text-gray-500",
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Input
+              id={argument.inputSpec.name}
+              value={inputValue}
+              onChange={(e) => {
+                handleInputChange(e.target.value);
+              }}
+              placeholder={placeholder}
+              required={!argument.inputSpec.optional}
+              className={cn(
+                "flex-1",
+                canUndo && "pr-10",
+                argument.isRemoved &&
+                  !argument.inputSpec.optional &&
+                  "border-red-200",
+                argument.isRemoved &&
+                  argument.inputSpec.optional &&
+                  "border-gray-100 text-gray-500",
+              )}
+              disabled={disabled}
+            />
+          </TooltipTrigger>
+          {placeholder && !inputValue && (
+            <TooltipContent className="z-9999">{placeholder}</TooltipContent>
           )}
-          disabled={disabled}
-        />
+        </Tooltip>
         {canUndo && (
           <Tooltip>
             <TooltipTrigger asChild>


### PR DESCRIPTION
Minor change to add a tooltip to the placeholder on Argument Input so the full value can be read

![image](https://github.com/user-attachments/assets/7f941591-1063-4ac8-8e08-e89ac9211c4a)
