### PR TITLE
Remove unnecessary instances of TooltipProvider

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentsEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentsEditor.tsx
@@ -6,7 +6,6 @@
  * @copyright 2021 Alexey Volkov <alexey.volkov+oss@ark-kun.com>
  */
 
-import { TooltipProvider } from "@/components/ui/tooltip";
 import type { ArgumentInput } from "@/types/arguments";
 
 import { ArgumentInputField } from "./ArgumentInputField";
@@ -29,17 +28,15 @@ export const ArgumentsEditor = ({
   };
 
   return (
-    <TooltipProvider>
-      <div className="h-auto flex flex-col gap-2 max-h-[60vh] overflow-y-auto pr-4">
-        {argumentData.map((argument) => (
-          <ArgumentInputField
-            key={argument.key}
-            argument={argument}
-            setArgument={handleInputChange}
-            disabled={disabled}
-          />
-        ))}
-      </div>
-    </TooltipProvider>
+    <div className="h-auto flex flex-col gap-2 max-h-[60vh] overflow-y-auto pr-4">
+      {argumentData.map((argument) => (
+        <ArgumentInputField
+          key={argument.key}
+          argument={argument}
+          setArgument={handleInputChange}
+          disabled={disabled}
+        />
+      ))}
+    </div>
   );
 };

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/TaskConfigurationSheet.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/TaskConfigurationSheet.tsx
@@ -21,7 +21,6 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { TooltipProvider } from "@/components/ui/tooltip";
 import type { ArgumentType, TaskSpec } from "@/utils/componentSpec";
 import { TOP_NAV_HEIGHT } from "@/utils/constants";
 import { getComponentName } from "@/utils/getComponentName";
@@ -108,15 +107,13 @@ const TaskConfigurationSheet = ({
                 taskId={taskId}
                 componentDigest={taskSpec.componentRef.digest}
                 url={taskSpec.componentRef.url}
-                actions={actions?.map((action, index) => (
-                  <TooltipProvider key={index}>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button {...action} />
-                      </TooltipTrigger>
-                      <TooltipContent>{action.tooltip}</TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
+                actions={actions?.map((action) => (
+                  <Tooltip key={action.tooltip}>
+                    <TooltipTrigger asChild>
+                      <Button {...action} />
+                    </TooltipTrigger>
+                    <TooltipContent>{action.tooltip}</TooltipContent>
+                  </Tooltip>
                 ))}
               />
             </TabsContent>

--- a/src/components/shared/TaskDetails/Details.tsx
+++ b/src/components/shared/TaskDetails/Details.tsx
@@ -15,7 +15,6 @@ import {
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import useToastNotification from "@/hooks/useToastNotification";
@@ -183,33 +182,31 @@ const TaskDetails = ({
           </div>
         )}
 
-        <div className="px-3 py-2 flex flex-row gap-2" key={0}>
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="secondary"
-                  className="cursor-pointer"
-                  onClick={handleDownloadYaml}
-                >
-                  <DownloadIcon />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Download YAML</TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="secondary"
-                  className="cursor-pointer"
-                  onClick={handleCopyYaml}
-                >
-                  <ClipboardIcon />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Copy YAML</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+        <div className="px-3 py-2 flex flex-row gap-2">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="secondary"
+                className="cursor-pointer"
+                onClick={handleDownloadYaml}
+              >
+                <DownloadIcon />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Download YAML</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="secondary"
+                className="cursor-pointer"
+                onClick={handleCopyYaml}
+              >
+                <ClipboardIcon />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Copy YAML</TooltipContent>
+          </Tooltip>
 
           {actions}
         </div>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -17,7 +17,6 @@ import { Skeleton } from "@/components/ui/skeleton";
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -126,25 +125,23 @@ function SidebarProvider({
 
   return (
     <SidebarContext.Provider value={contextValue}>
-      <TooltipProvider delayDuration={0}>
-        <div
-          data-slot="sidebar-wrapper"
-          style={
-            {
-              "--sidebar-width": SIDEBAR_WIDTH,
-              "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
-              ...style,
-            } as React.CSSProperties
-          }
-          className={cn(
-            "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-vh w-full",
-            className,
-          )}
-          {...props}
-        >
-          {children}
-        </div>
-      </TooltipProvider>
+      <div
+        data-slot="sidebar-wrapper"
+        style={
+          {
+            "--sidebar-width": SIDEBAR_WIDTH,
+            "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+            ...style,
+          } as React.CSSProperties
+        }
+        className={cn(
+          "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-vh w-full",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
     </SidebarContext.Provider>
   );
 }


### PR DESCRIPTION
The `Tooltip` component has its own provider built in, so we don't need to manually call it each time we want to use a tooltip.