### PR TITLE
Reorganize and Refactor some recent node replacement logic

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/ConfirmationDialogs/ReplaceConfirmation.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/ConfirmationDialogs/ReplaceConfirmation.tsx
@@ -7,9 +7,9 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import type { ArgumentType, InputSpec, TaskSpec } from "@/utils/componentSpec";
+import type { InputSpec, TaskSpec } from "@/utils/componentSpec";
 
-import { thisCannotBeUndone } from "./shared";
+import { getArgumentDetails, thisCannotBeUndone } from "./shared";
 
 export function getReplaceConfirmationDetails(
   replacedNode: Node,
@@ -85,45 +85,4 @@ export function getReplaceConfirmationDetails(
     description,
     content,
   };
-}
-
-function getArgumentDetails(
-  taskArguments: { [k: string]: ArgumentType } | undefined,
-  inputName: string,
-) {
-  const notSet = "No value";
-
-  if (!taskArguments) {
-    return { value: notSet, isBrokenConnection: false };
-  }
-
-  const argument = taskArguments[inputName];
-
-  if (!argument) {
-    return { value: notSet, isBrokenConnection: false };
-  }
-
-  if (typeof argument === "object" && argument !== null) {
-    if ("taskOutput" in argument && argument.taskOutput) {
-      return {
-        value: `from "${argument.taskOutput.taskId}"`,
-        isBrokenConnection: true,
-      };
-    }
-    if ("graphInput" in argument && argument.graphInput) {
-      return {
-        value: `"${argument.graphInput.inputName}"`,
-        isBrokenConnection: true,
-      };
-    }
-  }
-
-  if (typeof argument === "string") {
-    if (argument === "") {
-      return { value: notSet, isBrokenConnection: false };
-    }
-    return { value: `"${argument}"`, isBrokenConnection: false };
-  }
-
-  return { value: notSet, isBrokenConnection: false };
 }

--- a/src/components/shared/ReactFlow/FlowCanvas/ConfirmationDialogs/shared.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/ConfirmationDialogs/shared.tsx
@@ -1,3 +1,46 @@
+import type { ArgumentType } from "@/utils/componentSpec";
+
 export const thisCannotBeUndone = (
   <p className="text-muted-foreground">This cannot be undone.</p>
 );
+
+export function getArgumentDetails(
+  taskArguments: { [k: string]: ArgumentType } | undefined,
+  inputName: string,
+) {
+  const notSet = "No value";
+
+  if (!taskArguments) {
+    return { value: notSet, isBrokenConnection: false };
+  }
+
+  const argument = taskArguments[inputName];
+
+  if (!argument) {
+    return { value: notSet, isBrokenConnection: false };
+  }
+
+  if (typeof argument === "object" && argument !== null) {
+    if ("taskOutput" in argument && argument.taskOutput) {
+      return {
+        value: `from "${argument.taskOutput.taskId}"`,
+        isBrokenConnection: true,
+      };
+    }
+    if ("graphInput" in argument && argument.graphInput) {
+      return {
+        value: `"${argument.graphInput.inputName}"`,
+        isBrokenConnection: true,
+      };
+    }
+  }
+
+  if (typeof argument === "string") {
+    if (argument === "") {
+      return { value: notSet, isBrokenConnection: false };
+    }
+    return { value: `"${argument}"`, isBrokenConnection: false };
+  }
+
+  return { value: notSet, isBrokenConnection: false };
+}

--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -63,15 +63,9 @@ const FlowCanvas = ({
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
 
   const {
-    handlers: deleteConfirmationHandlers,
-    triggerDialog: triggerDeleteConfirmation,
-    ...deleteConfirmationProps
-  } = useConfirmationDialog();
-
-  const {
-    handlers: replaceConfirmationHandlers,
-    triggerDialog: triggerReplaceConfirmation,
-    ...replaceConfirmationProps
+    handlers: confirmationHandlers,
+    triggerDialog: triggerConfirmation,
+    ...confirmationProps
   } = useConfirmationDialog();
 
   const notify = useToastNotification();
@@ -143,7 +137,7 @@ const FlowCanvas = ({
           edges: edgesToRemove,
         } as NodesAndEdges;
 
-        const confirmed = await triggerDeleteConfirmation(
+        const confirmed = await triggerConfirmation(
           getDeleteConfirmationDetails(params),
         );
 
@@ -152,7 +146,7 @@ const FlowCanvas = ({
         }
       }
     },
-    [nodes, edges, componentSpec, setComponentSpec, triggerDeleteConfirmation],
+    [nodes, edges, componentSpec, setComponentSpec, triggerConfirmation],
   );
 
   const setArguments = useCallback(
@@ -259,7 +253,7 @@ const FlowCanvas = ({
 
         const { updatedGraphSpec, lostInputs, newTaskId } = replaceTaskNode(
           replaceTarget,
-          droppedTask,
+          droppedTask.componentRef,
           graphSpec,
         );
 
@@ -269,7 +263,7 @@ const FlowCanvas = ({
           lostInputs,
         );
 
-        const confirmed = await triggerReplaceConfirmation(dialogData);
+        const confirmed = await triggerConfirmation(dialogData);
 
         setReplaceTarget(null);
 
@@ -300,7 +294,7 @@ const FlowCanvas = ({
       replaceTarget,
       setComponentSpec,
       updateGraphSpec,
-      triggerReplaceConfirmation,
+      triggerConfirmation,
     ],
   );
 
@@ -321,13 +315,13 @@ const FlowCanvas = ({
   );
 
   const onRemoveNodes = useCallback(async () => {
-    const confirmed = await triggerDeleteConfirmation(
+    const confirmed = await triggerConfirmation(
       getDeleteConfirmationDetails({ nodes: selectedNodes, edges: [] }),
     );
     if (confirmed) {
       onElementsRemove(selectedElements);
     }
-  }, [selectedElements, onElementsRemove, triggerDeleteConfirmation]);
+  }, [selectedElements, onElementsRemove, triggerConfirmation]);
 
   const handleOnNodesChange = (changes: NodeChange[]) => {
     const positionChanges = changes.filter(
@@ -367,7 +361,7 @@ const FlowCanvas = ({
       return false;
     }
 
-    const confirmed = await triggerDeleteConfirmation(
+    const confirmed = await triggerConfirmation(
       getDeleteConfirmationDetails(params),
     );
     return confirmed;
@@ -542,16 +536,9 @@ const FlowCanvas = ({
       </ReactFlow>
       {!readOnly && (
         <ConfirmationDialog
-          {...deleteConfirmationProps}
-          onConfirm={() => deleteConfirmationHandlers?.onConfirm()}
-          onCancel={() => deleteConfirmationHandlers?.onCancel()}
-        />
-      )}
-      {!readOnly && (
-        <ConfirmationDialog
-          {...replaceConfirmationProps}
-          onConfirm={() => replaceConfirmationHandlers?.onConfirm()}
-          onCancel={() => replaceConfirmationHandlers?.onCancel()}
+          {...confirmationProps}
+          onConfirm={() => confirmationHandlers?.onConfirm()}
+          onCancel={() => confirmationHandlers?.onCancel()}
         />
       )}
     </>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/TaskConfigurationSheet.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/TaskConfigurationSheet.tsx
@@ -72,7 +72,7 @@ const TaskConfigurationSheet = ({
       <SheetTrigger asChild>{trigger}</SheetTrigger>
       <SheetContent
         side="right"
-        className={`!w-[512px] !max-w-[512px] shadow-none`}
+        className={`!w-[528px] !max-w-[528px] shadow-none`}
         style={{
           top: TOP_NAV_HEIGHT + "px",
           height: sheetHeight + "px",

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
@@ -134,6 +134,7 @@ function generateOutputHandles(outputSpecs: OutputSpec[]): ReactElement[] {
 
 const ComponentTaskNode = ({ data, selected }: NodeProps) => {
   const { taskStatusMap } = useComponentSpec();
+
   const [isComponentEditorOpen, setIsComponentEditorOpen] = useState(false);
   const [isTaskDetailsSheetOpen, setIsTaskDetailsSheetOpen] = useState(false);
   const taskId = useMemo(

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/replaceTaskNode.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/replaceTaskNode.ts
@@ -2,6 +2,7 @@ import type { Node } from "@xyflow/react";
 
 import type {
   ArgumentType,
+  ComponentReference,
   GraphSpec,
   InputSpec,
   TaskSpec,
@@ -11,12 +12,11 @@ import { getUniqueTaskName } from "@/utils/unique";
 
 export const replaceTaskNode = (
   nodeToReplace: Node,
-  newTask: TaskSpec,
+  newComponentRef: ComponentReference,
   graphSpec: GraphSpec,
 ) => {
   const updatedGraphSpec = deepClone(graphSpec);
 
-  const newComponentRef = newTask.componentRef;
   const taskName = newComponentRef.spec?.name;
   const newTaskInputs = newComponentRef.spec?.inputs;
   const newTaskOutputs = newComponentRef.spec?.outputs;

--- a/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
@@ -1,16 +1,12 @@
 import { File } from "lucide-react";
 import type { DragEvent } from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 
 import { ComponentDetailsDialog } from "@/components/shared/Dialogs";
 import { SidebarMenuItem } from "@/components/ui/sidebar";
+import useComponentFromUrl from "@/hooks/useComponentFromUrl";
 import { cn } from "@/lib/utils";
 import { EMPTY_GRAPH_COMPONENT_SPEC } from "@/providers/ComponentSpecProvider";
-import {
-  fetchAndStoreComponent,
-  generateDigest,
-  parseComponentData,
-} from "@/services/componentService";
 import { type ComponentItemFromUrlProps } from "@/types/componentLibrary";
 import type {
   ComponentReference,
@@ -18,7 +14,6 @@ import type {
   TaskSpec,
 } from "@/utils/componentSpec";
 import { getComponentName } from "@/utils/getComponentName";
-import { getComponentByUrl } from "@/utils/localforge";
 
 interface ComponentMarkupProps {
   url: string;
@@ -122,93 +117,21 @@ const ComponentMarkup = ({
 const ComponentItemFromUrl = ({ url }: ComponentItemFromUrlProps) => {
   if (!url) return null;
 
-  const [isLoading, setIsLoading] = useState(true);
-  const [componentSpec, setComponentSpec] = useState<ComponentSpec | null>(
-    null,
-  );
-  const [componentText, setComponentText] = useState<string | null>(null);
-  const [componentDigest, setComponentDigest] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const { isLoading, error, componentRef } = useComponentFromUrl(url);
 
-  useEffect(() => {
-    const controller = new AbortController();
-    const signal = controller.signal;
-
-    const loadComponent = async () => {
-      if (!url) return;
-
-      try {
-        setIsLoading(true);
-        setError(null);
-
-        const storedComponent = await getComponentByUrl(url);
-
-        if (storedComponent) {
-          if (signal.aborted) return;
-          // Parse the component data
-          const text = storedComponent.data;
-          setComponentText(text);
-
-          try {
-            // Parse the component spec from the text
-            const parsedSpec = parseComponentData(text);
-            if (parsedSpec) {
-              setComponentSpec(parsedSpec);
-              const digest = await generateDigest(text);
-              setComponentDigest(digest);
-              setIsLoading(false);
-              return;
-            }
-          } catch (err) {
-            console.error("Error parsing component from local storage:", err);
-            // Fall through to network fetch
-          }
-        }
-
-        // If component doesn't exist in storage or parsing failed, fetch and store it
-        const spec = await fetchAndStoreComponent(url);
-        if (signal.aborted) return;
-
-        if (spec) {
-          setComponentSpec(spec);
-
-          // Get the stored component to get the text
-          const updatedComponent = await getComponentByUrl(url);
-          if (updatedComponent && !signal.aborted) {
-            const text = updatedComponent.data;
-            setComponentText(text);
-            const digest = await generateDigest(text);
-            setComponentDigest(digest);
-          }
-        } else {
-          throw new Error("Failed to load component specification");
-        }
-      } catch (err) {
-        if (!signal.aborted) {
-          setError(err instanceof Error ? err.message : String(err));
-        }
-      } finally {
-        if (!signal.aborted) {
-          setIsLoading(false);
-        }
-      }
-    };
-
-    loadComponent();
-    return () => controller.abort();
-  }, [url]);
+  const { spec, digest, text } = componentRef;
 
   const displayName = useMemo(
-    () => getComponentName({ spec: componentSpec ?? undefined, url }),
-    [componentSpec, url],
+    () => getComponentName({ spec: spec ?? undefined, url }),
+    [spec, url],
   );
 
   return (
     <ComponentMarkup
       url={url}
-      componentSpec={componentSpec || EMPTY_GRAPH_COMPONENT_SPEC}
-      componentDigest={componentDigest || ""}
-      componentText={componentText || ""}
+      componentSpec={spec || EMPTY_GRAPH_COMPONENT_SPEC}
+      componentDigest={digest || ""}
+      componentText={text || ""}
       displayName={displayName}
       isLoading={isLoading}
       error={error}

--- a/src/hooks/useComponentFromUrl.ts
+++ b/src/hooks/useComponentFromUrl.ts
@@ -1,0 +1,99 @@
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  fetchAndStoreComponent,
+  generateDigest,
+  parseComponentData,
+} from "@/services/componentService";
+import type { ComponentSpec } from "@/utils/componentSpec";
+import { getComponentByUrl } from "@/utils/localforge";
+
+const useComponentFromUrl = (url?: string) => {
+  const [isLoading, setIsLoading] = useState(true);
+  const [componentSpec, setComponentSpec] = useState<ComponentSpec>();
+  const [componentText, setComponentText] = useState<string>();
+  const [componentDigest, setComponentDigest] = useState<string>();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    const loadComponent = async () => {
+      if (!url) return;
+
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        const storedComponent = await getComponentByUrl(url);
+
+        if (storedComponent) {
+          if (signal.aborted) return;
+          // Parse the component data
+          const text = storedComponent.data;
+          setComponentText(text);
+
+          try {
+            // Parse the component spec from the text
+            const parsedSpec = parseComponentData(text);
+            if (parsedSpec) {
+              setComponentSpec(parsedSpec);
+              const digest = await generateDigest(text);
+              setComponentDigest(digest);
+              setIsLoading(false);
+              return;
+            }
+          } catch (err) {
+            console.error("Error parsing component from local storage:", err);
+            // Fall through to network fetch
+          }
+        }
+
+        // If component doesn't exist in storage or parsing failed, fetch and store it
+        const spec = await fetchAndStoreComponent(url);
+        if (signal.aborted) return;
+
+        if (spec) {
+          setComponentSpec(spec);
+
+          // Get the stored component to get the text
+          const updatedComponent = await getComponentByUrl(url);
+          if (updatedComponent && !signal.aborted) {
+            const text = updatedComponent.data;
+            setComponentText(text);
+            const digest = await generateDigest(text);
+            setComponentDigest(digest);
+          }
+        } else {
+          throw new Error("Failed to load component specification");
+        }
+      } catch (err) {
+        if (!signal.aborted) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      } finally {
+        if (!signal.aborted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    loadComponent();
+    return () => controller.abort();
+  }, [url]);
+
+  const componentRef = useMemo(
+    () => ({
+      spec: componentSpec,
+      digest: componentDigest,
+      text: componentText,
+      url: url,
+    }),
+    [componentSpec, componentDigest, componentText],
+  );
+
+  return { isLoading, error, componentRef };
+};
+
+export default useComponentFromUrl;


### PR DESCRIPTION
Precursor to #253 

Just moving some things around, breaking things into their own files or functions so that code can be more easily reached and read. This will keep the size of #253 a little more focused and manageable.

Notably: adds a useComponentFromUrl hook that encapsulates the component fetching logic in the sidebar (this will be used in #253). Also condenses our ReactFlow confirmation dialogs into one.

No change to app functionality.