### PR TITLE
Bulk Upgrade Nodes via Selection Toolbar

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/ConfirmationDialogs/BulkUpdateConfirmationDialog.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/ConfirmationDialogs/BulkUpdateConfirmationDialog.tsx
@@ -1,0 +1,57 @@
+import type { Node } from "@xyflow/react";
+
+import type { InputSpec } from "@/utils/componentSpec";
+
+import { thisCannotBeUndone } from "./shared";
+
+export function getBulkUpdateConfirmationDetails(
+  nodesToUpdate: Node[],
+  unchangedNodes: Node[],
+  allLostInputs: InputSpec[],
+) {
+  const hasLostInputs = allLostInputs.length > 0;
+  const hasExcludedNodes = unchangedNodes.length > 0;
+
+  const nodeToUpdatePluralSuffix = nodesToUpdate.length === 1 ? "" : "s";
+
+  const title = `Upgrade Component${nodeToUpdatePluralSuffix}`;
+  const description = "";
+  const content = (
+    <div className="text-sm">
+      <p>
+        Are you sure you want to update{" "}
+        {nodesToUpdate.length === 1 ? "this node" : "these nodes"}?
+      </p>
+      <p>
+        This will upgrade {nodesToUpdate.length} node
+        {nodeToUpdatePluralSuffix} to {nodesToUpdate.length === 1 ? "a " : ""}{" "}
+        new version
+        {nodeToUpdatePluralSuffix} from{" "}
+        {nodesToUpdate.length === 1 ? "its" : "their"} source URL.
+      </p>
+      {hasExcludedNodes && (
+        <>
+          <br />
+          <p>
+            {unchangedNodes.length} custom component
+            {unchangedNodes.length === 1 ? "" : "s"} will not be updated.
+          </p>
+        </>
+      )}
+      {hasLostInputs && (
+        <>
+          <br />
+          <p>Some input arguments may be lost.</p>
+        </>
+      )}
+      <br />
+      {thisCannotBeUndone}
+    </div>
+  );
+
+  return {
+    title,
+    content,
+    description,
+  };
+}

--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -24,9 +24,12 @@ import type {
   ArgumentType,
   ComponentReference,
   ComponentSpec,
+  InputSpec,
+  TaskSpec,
 } from "@/utils/componentSpec";
 import { createNodesFromComponentSpec } from "@/utils/nodes/createNodesFromComponentSpec";
 
+import { getBulkUpdateConfirmationDetails } from "./ConfirmationDialogs/BulkUpdateConfirmationDialog";
 import { getDeleteConfirmationDetails } from "./ConfirmationDialogs/DeleteConfirmation";
 import { getReplaceConfirmationDetails } from "./ConfirmationDialogs/ReplaceConfirmation";
 import { getUpgradeConfirmationDetails } from "./ConfirmationDialogs/UpgradeComponent";
@@ -92,7 +95,7 @@ const FlowCanvas = ({
       setNodes((prev) => {
         const updated = prev.map((node) => {
           const updatedNode = updatedNodes?.find(
-            (updatedNode) => updatedNode.id === node.id
+            (updatedNode) => updatedNode.id === node.id,
           );
           return updatedNode ? { ...node, ...updatedNode } : node;
         });
@@ -104,16 +107,16 @@ const FlowCanvas = ({
         return [...updated, ...newNodes];
       });
     },
-    [setNodes]
+    [setNodes],
   );
 
   const selectedNodes = useMemo(
     () => nodes.filter((node) => node.selected),
-    [nodes]
+    [nodes],
   );
   const selectedEdges = useMemo(
     () => edges.filter((edge) => edge.selected),
-    [edges]
+    [edges],
   );
 
   const selectedElements = useMemo(
@@ -121,7 +124,7 @@ const FlowCanvas = ({
       nodes: selectedNodes,
       edges: selectedEdges,
     }),
-    [selectedNodes, selectedEdges]
+    [selectedNodes, selectedEdges],
   );
 
   const onDelete = useCallback(
@@ -129,7 +132,7 @@ const FlowCanvas = ({
       const nodeId = ids.nodeId;
       const node = nodes.find((n) => n.id === nodeId);
       const edgesToRemove = edges.filter(
-        (edge) => edge.source === nodeId || edge.target === nodeId
+        (edge) => edge.source === nodeId || edge.target === nodeId,
       );
 
       if (node) {
@@ -139,7 +142,7 @@ const FlowCanvas = ({
         } as NodesAndEdges;
 
         const confirmed = await triggerConfirmation(
-          getDeleteConfirmationDetails(params)
+          getDeleteConfirmationDetails(params),
         );
 
         if (confirmed) {
@@ -147,7 +150,7 @@ const FlowCanvas = ({
         }
       }
     },
-    [nodes, edges, componentSpec, setComponentSpec, triggerConfirmation]
+    [nodes, edges, componentSpec, setComponentSpec, triggerConfirmation],
   );
 
   const setArguments = useCallback(
@@ -156,11 +159,11 @@ const FlowCanvas = ({
       const newGraphSpec = replaceTaskArgumentsInGraphSpec(
         taskId,
         graphSpec,
-        args
+        args,
       );
       updateGraphSpec(newGraphSpec);
     },
-    [graphSpec]
+    [graphSpec],
   );
 
   const onDuplicate = useCallback(
@@ -173,7 +176,7 @@ const FlowCanvas = ({
       const { updatedGraphSpec, newNodes, updatedNodes } = duplicateNodes(
         graphSpec,
         [node],
-        { selected }
+        { selected },
       );
 
       updateGraphSpec(updatedGraphSpec);
@@ -183,7 +186,7 @@ const FlowCanvas = ({
         newNodes,
       });
     },
-    [graphSpec, nodes, updateGraphSpec, updateOrAddNodes]
+    [graphSpec, nodes, updateGraphSpec, updateOrAddNodes],
   );
 
   const onUpgrade = useCallback(
@@ -196,7 +199,7 @@ const FlowCanvas = ({
       const { updatedGraphSpec, lostInputs } = replaceTaskNode(
         node,
         newComponentRef,
-        graphSpec
+        graphSpec,
       );
 
       if (!newComponentRef.digest) {
@@ -207,7 +210,7 @@ const FlowCanvas = ({
       const dialogData = getUpgradeConfirmationDetails(
         node,
         newComponentRef.digest,
-        lostInputs
+        lostInputs,
       );
 
       const confirmed = await triggerConfirmation(dialogData);
@@ -217,7 +220,7 @@ const FlowCanvas = ({
         notify("Component updated", "success");
       }
     },
-    [graphSpec, nodes, updateGraphSpec]
+    [graphSpec, nodes, updateGraphSpec],
   );
 
   const nodeData = {
@@ -235,7 +238,7 @@ const FlowCanvas = ({
       const updatedGraphSpec = handleConnection(graphSpec, connection);
       updateGraphSpec(updatedGraphSpec);
     },
-    [graphSpec, handleConnection, updateGraphSpec]
+    [graphSpec, handleConnection, updateGraphSpec],
   );
 
   /* New Tasks from the Sidebar */
@@ -251,7 +254,7 @@ const FlowCanvas = ({
 
       if (cursorPosition) {
         const hoveredNode = nodes.find((node) =>
-          isPositionInNode(node, cursorPosition)
+          isPositionInNode(node, cursorPosition),
         );
 
         if (hoveredNode?.id === replaceTarget?.id) return;
@@ -259,7 +262,7 @@ const FlowCanvas = ({
         setReplaceTarget(hoveredNode || null);
       }
     },
-    [reactFlowInstance, nodes, replaceTarget, setReplaceTarget]
+    [reactFlowInstance, nodes, replaceTarget, setReplaceTarget],
   );
 
   const onDrop = useCallback(
@@ -282,7 +285,7 @@ const FlowCanvas = ({
       if (replaceTarget) {
         if (!droppedTask) {
           console.error(
-            "Replacement by Input or Output node is currently unsupported."
+            "Replacement by Input or Output node is currently unsupported.",
           );
           return;
         }
@@ -290,13 +293,13 @@ const FlowCanvas = ({
         const { updatedGraphSpec, lostInputs, newTaskId } = replaceTaskNode(
           replaceTarget,
           droppedTask.componentRef,
-          graphSpec
+          graphSpec,
         );
 
         const dialogData = getReplaceConfirmationDetails(
           replaceTarget,
           newTaskId,
-          lostInputs
+          lostInputs,
         );
 
         const confirmed = await triggerConfirmation(dialogData);
@@ -317,7 +320,7 @@ const FlowCanvas = ({
           taskType,
           droppedTask,
           position,
-          componentSpec
+          componentSpec,
         );
 
         setComponentSpec(newComponentSpec);
@@ -331,7 +334,7 @@ const FlowCanvas = ({
       setComponentSpec,
       updateGraphSpec,
       triggerConfirmation,
-    ]
+    ],
   );
 
   const onElementsRemove = useCallback(
@@ -347,12 +350,12 @@ const FlowCanvas = ({
 
       setComponentSpec(updatedComponentSpec);
     },
-    [componentSpec, setComponentSpec]
+    [componentSpec, setComponentSpec],
   );
 
   const onRemoveNodes = useCallback(async () => {
     const confirmed = await triggerConfirmation(
-      getDeleteConfirmationDetails({ nodes: selectedNodes, edges: [] })
+      getDeleteConfirmationDetails({ nodes: selectedNodes, edges: [] }),
     );
     if (confirmed) {
       onElementsRemove(selectedElements);
@@ -361,7 +364,7 @@ const FlowCanvas = ({
 
   const handleOnNodesChange = (changes: NodeChange[]) => {
     const positionChanges = changes.filter(
-      (change) => change.type === "position" && change.dragging === false
+      (change) => change.type === "position" && change.dragging === false,
     );
 
     if (positionChanges.length > 0) {
@@ -383,7 +386,7 @@ const FlowCanvas = ({
       if (updatedNodes.length > 0) {
         const updatedComponentSpec = updateNodePositions(
           updatedNodes,
-          componentSpec
+          componentSpec,
         );
         setComponentSpec(updatedComponentSpec);
       }
@@ -398,7 +401,7 @@ const FlowCanvas = ({
     }
 
     const confirmed = await triggerConfirmation(
-      getDeleteConfirmationDetails(params)
+      getDeleteConfirmationDetails(params),
     );
     return confirmed;
   };
@@ -407,7 +410,7 @@ const FlowCanvas = ({
     const { updatedGraphSpec, newNodes, updatedNodes } = duplicateNodes(
       graphSpec,
       selectedNodes,
-      { selected: true }
+      { selected: true },
     );
 
     updateGraphSpec(updatedGraphSpec);
@@ -417,6 +420,47 @@ const FlowCanvas = ({
       newNodes,
     });
   }, [graphSpec, selectedNodes, updateGraphSpec, setNodes]);
+
+  const onUpgradeNodes = useCallback(async () => {
+    let newGraphSpec = graphSpec;
+    const allLostInputs: InputSpec[] = [];
+    const includedNodes: Node[] = [];
+    const excludedNodes: Node[] = [];
+
+    selectedNodes.forEach((node) => {
+      const taskSpec = node.data.taskSpec as TaskSpec | undefined;
+      // Custom components don't have a componentRef.url so they are currently excluded from bulk operations
+      if (taskSpec?.componentRef && taskSpec.componentRef.url) {
+        const { updatedGraphSpec, lostInputs } = replaceTaskNode(
+          node,
+          taskSpec.componentRef,
+          newGraphSpec,
+        );
+
+        if (lostInputs.length > 0) {
+          allLostInputs.push(...lostInputs);
+        }
+
+        includedNodes.push(node);
+        newGraphSpec = { ...updatedGraphSpec };
+      } else {
+        excludedNodes.push(node);
+      }
+    });
+
+    const dialogData = getBulkUpdateConfirmationDetails(
+      includedNodes,
+      excludedNodes,
+      allLostInputs,
+    );
+
+    const confirmed = await triggerConfirmation(dialogData);
+
+    if (confirmed) {
+      updateGraphSpec(newGraphSpec);
+      notify(`${includedNodes.length} nodes updated`, "success");
+    }
+  }, [graphSpec, selectedNodes, updateGraphSpec]);
 
   const handleSelectionChange = useCallback(() => {
     if (selectedNodes.length < 1) {
@@ -449,7 +493,7 @@ const FlowCanvas = ({
         return updatedNodes;
       });
     },
-    [setNodes, nodeData, replaceTarget]
+    [setNodes, nodeData, replaceTarget],
   );
 
   useEffect(() => {
@@ -505,7 +549,7 @@ const FlowCanvas = ({
           const { newNodes, updatedGraphSpec } = duplicateNodes(
             graphSpec,
             nodesToPaste,
-            { position: reactFlowCenter, connection: "internal" }
+            { position: reactFlowCenter, connection: "internal" },
           );
 
           // Deselect all existing nodes
@@ -568,6 +612,7 @@ const FlowCanvas = ({
             <SelectionToolbar
               onDelete={onRemoveNodes}
               onDuplicate={onDuplicateNodes}
+              onUpgrade={onUpgradeNodes}
             />
           </NodeToolbar>
         )}

--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -92,7 +92,7 @@ const FlowCanvas = ({
       setNodes((prev) => {
         const updated = prev.map((node) => {
           const updatedNode = updatedNodes?.find(
-            (updatedNode) => updatedNode.id === node.id,
+            (updatedNode) => updatedNode.id === node.id
           );
           return updatedNode ? { ...node, ...updatedNode } : node;
         });
@@ -104,16 +104,16 @@ const FlowCanvas = ({
         return [...updated, ...newNodes];
       });
     },
-    [setNodes],
+    [setNodes]
   );
 
   const selectedNodes = useMemo(
     () => nodes.filter((node) => node.selected),
-    [nodes],
+    [nodes]
   );
   const selectedEdges = useMemo(
     () => edges.filter((edge) => edge.selected),
-    [edges],
+    [edges]
   );
 
   const selectedElements = useMemo(
@@ -121,7 +121,7 @@ const FlowCanvas = ({
       nodes: selectedNodes,
       edges: selectedEdges,
     }),
-    [selectedNodes, selectedEdges],
+    [selectedNodes, selectedEdges]
   );
 
   const onDelete = useCallback(
@@ -129,7 +129,7 @@ const FlowCanvas = ({
       const nodeId = ids.nodeId;
       const node = nodes.find((n) => n.id === nodeId);
       const edgesToRemove = edges.filter(
-        (edge) => edge.source === nodeId || edge.target === nodeId,
+        (edge) => edge.source === nodeId || edge.target === nodeId
       );
 
       if (node) {
@@ -139,7 +139,7 @@ const FlowCanvas = ({
         } as NodesAndEdges;
 
         const confirmed = await triggerConfirmation(
-          getDeleteConfirmationDetails(params),
+          getDeleteConfirmationDetails(params)
         );
 
         if (confirmed) {
@@ -147,7 +147,7 @@ const FlowCanvas = ({
         }
       }
     },
-    [nodes, edges, componentSpec, setComponentSpec, triggerConfirmation],
+    [nodes, edges, componentSpec, setComponentSpec, triggerConfirmation]
   );
 
   const setArguments = useCallback(
@@ -156,11 +156,11 @@ const FlowCanvas = ({
       const newGraphSpec = replaceTaskArgumentsInGraphSpec(
         taskId,
         graphSpec,
-        args,
+        args
       );
       updateGraphSpec(newGraphSpec);
     },
-    [graphSpec],
+    [graphSpec]
   );
 
   const onDuplicate = useCallback(
@@ -173,7 +173,7 @@ const FlowCanvas = ({
       const { updatedGraphSpec, newNodes, updatedNodes } = duplicateNodes(
         graphSpec,
         [node],
-        { selected },
+        { selected }
       );
 
       updateGraphSpec(updatedGraphSpec);
@@ -183,7 +183,7 @@ const FlowCanvas = ({
         newNodes,
       });
     },
-    [graphSpec, nodes, updateGraphSpec, updateOrAddNodes],
+    [graphSpec, nodes, updateGraphSpec, updateOrAddNodes]
   );
 
   const onUpgrade = useCallback(
@@ -196,7 +196,7 @@ const FlowCanvas = ({
       const { updatedGraphSpec, lostInputs } = replaceTaskNode(
         node,
         newComponentRef,
-        graphSpec,
+        graphSpec
       );
 
       if (!newComponentRef.digest) {
@@ -207,7 +207,7 @@ const FlowCanvas = ({
       const dialogData = getUpgradeConfirmationDetails(
         node,
         newComponentRef.digest,
-        lostInputs,
+        lostInputs
       );
 
       const confirmed = await triggerConfirmation(dialogData);
@@ -217,7 +217,7 @@ const FlowCanvas = ({
         notify("Component updated", "success");
       }
     },
-    [graphSpec, nodes, updateGraphSpec],
+    [graphSpec, nodes, updateGraphSpec]
   );
 
   const nodeData = {
@@ -235,7 +235,7 @@ const FlowCanvas = ({
       const updatedGraphSpec = handleConnection(graphSpec, connection);
       updateGraphSpec(updatedGraphSpec);
     },
-    [graphSpec, handleConnection, updateGraphSpec],
+    [graphSpec, handleConnection, updateGraphSpec]
   );
 
   /* New Tasks from the Sidebar */
@@ -251,7 +251,7 @@ const FlowCanvas = ({
 
       if (cursorPosition) {
         const hoveredNode = nodes.find((node) =>
-          isPositionInNode(node, cursorPosition),
+          isPositionInNode(node, cursorPosition)
         );
 
         if (hoveredNode?.id === replaceTarget?.id) return;
@@ -259,7 +259,7 @@ const FlowCanvas = ({
         setReplaceTarget(hoveredNode || null);
       }
     },
-    [reactFlowInstance, nodes, replaceTarget, setReplaceTarget],
+    [reactFlowInstance, nodes, replaceTarget, setReplaceTarget]
   );
 
   const onDrop = useCallback(
@@ -282,7 +282,7 @@ const FlowCanvas = ({
       if (replaceTarget) {
         if (!droppedTask) {
           console.error(
-            "Replacement by Input or Output node is currently unsupported.",
+            "Replacement by Input or Output node is currently unsupported."
           );
           return;
         }
@@ -290,13 +290,13 @@ const FlowCanvas = ({
         const { updatedGraphSpec, lostInputs, newTaskId } = replaceTaskNode(
           replaceTarget,
           droppedTask.componentRef,
-          graphSpec,
+          graphSpec
         );
 
         const dialogData = getReplaceConfirmationDetails(
           replaceTarget,
           newTaskId,
-          lostInputs,
+          lostInputs
         );
 
         const confirmed = await triggerConfirmation(dialogData);
@@ -317,7 +317,7 @@ const FlowCanvas = ({
           taskType,
           droppedTask,
           position,
-          componentSpec,
+          componentSpec
         );
 
         setComponentSpec(newComponentSpec);
@@ -331,7 +331,7 @@ const FlowCanvas = ({
       setComponentSpec,
       updateGraphSpec,
       triggerConfirmation,
-    ],
+    ]
   );
 
   const onElementsRemove = useCallback(
@@ -347,12 +347,12 @@ const FlowCanvas = ({
 
       setComponentSpec(updatedComponentSpec);
     },
-    [componentSpec, setComponentSpec],
+    [componentSpec, setComponentSpec]
   );
 
   const onRemoveNodes = useCallback(async () => {
     const confirmed = await triggerConfirmation(
-      getDeleteConfirmationDetails({ nodes: selectedNodes, edges: [] }),
+      getDeleteConfirmationDetails({ nodes: selectedNodes, edges: [] })
     );
     if (confirmed) {
       onElementsRemove(selectedElements);
@@ -361,7 +361,7 @@ const FlowCanvas = ({
 
   const handleOnNodesChange = (changes: NodeChange[]) => {
     const positionChanges = changes.filter(
-      (change) => change.type === "position" && change.dragging === false,
+      (change) => change.type === "position" && change.dragging === false
     );
 
     if (positionChanges.length > 0) {
@@ -383,7 +383,7 @@ const FlowCanvas = ({
       if (updatedNodes.length > 0) {
         const updatedComponentSpec = updateNodePositions(
           updatedNodes,
-          componentSpec,
+          componentSpec
         );
         setComponentSpec(updatedComponentSpec);
       }
@@ -398,7 +398,7 @@ const FlowCanvas = ({
     }
 
     const confirmed = await triggerConfirmation(
-      getDeleteConfirmationDetails(params),
+      getDeleteConfirmationDetails(params)
     );
     return confirmed;
   };
@@ -407,7 +407,7 @@ const FlowCanvas = ({
     const { updatedGraphSpec, newNodes, updatedNodes } = duplicateNodes(
       graphSpec,
       selectedNodes,
-      { selected: true },
+      { selected: true }
     );
 
     updateGraphSpec(updatedGraphSpec);
@@ -449,7 +449,7 @@ const FlowCanvas = ({
         return updatedNodes;
       });
     },
-    [setNodes, nodeData, replaceTarget],
+    [setNodes, nodeData, replaceTarget]
   );
 
   useEffect(() => {
@@ -505,7 +505,7 @@ const FlowCanvas = ({
           const { newNodes, updatedGraphSpec } = duplicateNodes(
             graphSpec,
             nodesToPaste,
-            { position: reactFlowCenter, connection: "internal" },
+            { position: reactFlowCenter, connection: "internal" }
           );
 
           // Deselect all existing nodes

--- a/src/components/shared/ReactFlow/FlowCanvas/SelectionToolbar.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/SelectionToolbar.tsx
@@ -1,13 +1,18 @@
-import { Copy, Trash } from "lucide-react";
+import { CircleFadingArrowUp, Copy, Trash } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 
 interface SelectionToolbarProps {
   onDuplicate: () => void;
   onDelete: () => void;
+  onUpgrade: () => void;
 }
 
-const SelectionToolbar = ({ onDelete, onDuplicate }: SelectionToolbarProps) => {
+const SelectionToolbar = ({
+  onDelete,
+  onDuplicate,
+  onUpgrade,
+}: SelectionToolbarProps) => {
   return (
     <div
       className="flex gap-1 bg-white rounded-xs items-center justify-center"
@@ -17,6 +22,14 @@ const SelectionToolbar = ({ onDelete, onDuplicate }: SelectionToolbarProps) => {
     >
       <Button
         className="h-full aspect-square w-min rounded-sm p-1"
+        variant="ghost"
+        onClick={onUpgrade}
+        size="icon"
+      >
+        <CircleFadingArrowUp className="p-0.5" />
+      </Button>
+      <Button
+        className="cursor-pointer h-full aspect-square w-min rounded-sm p-1"
         variant="ghost"
         onClick={onDuplicate}
         size="icon"

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
@@ -126,7 +126,7 @@ const StatusIndicator = ({ status }: StatusIndicatorProps) => {
     <div
       className={cn(
         "absolute -z-1 -top-5 left-0 h-[35px] rounded-t-md px-2.5 py-1 text-[10px]",
-        style,
+        style
       )}
     >
       <div className="flex items-center gap-1 font-mono text-white">
@@ -228,7 +228,7 @@ const TaskNodeContent = ({
       className={cn(
         "rounded-2xl border-gray-200 border-2 max-w-[300px] min-w-[300px] break-words p-0 drop-shadow-none gap-2",
         selected ? "border-gray-500" : "hover:border-slate-200",
-        highlighted && "border-orange-500",
+        highlighted && "border-orange-500"
       )}
       ref={nodeRef}
       onClick={onClick}
@@ -269,7 +269,7 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
   const [isTaskDetailsSheetOpen, setIsTaskDetailsSheetOpen] = useState(false);
   const taskId = useMemo(
     () => data?.taskId as string | undefined,
-    [data?.taskId],
+    [data?.taskId]
   );
   const nodeRef = useRef<HTMLDivElement | null>(null);
   const textRef = useRef<HTMLDivElement>(null);
@@ -289,7 +289,7 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
   const isCustomComponent = !taskSpec.componentRef.url; // Custom components don't have a source url
 
   const { componentRef: mostRecentComponentRef } = useComponentFromUrl(
-    taskSpec.componentRef.url,
+    taskSpec.componentRef.url
   );
 
   const isOutdated =

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
@@ -126,7 +126,7 @@ const StatusIndicator = ({ status }: StatusIndicatorProps) => {
     <div
       className={cn(
         "absolute -z-1 -top-5 left-0 h-[35px] rounded-t-md px-2.5 py-1 text-[10px]",
-        style
+        style,
       )}
     >
       <div className="flex items-center gap-1 font-mono text-white">
@@ -228,7 +228,7 @@ const TaskNodeContent = ({
       className={cn(
         "rounded-2xl border-gray-200 border-2 max-w-[300px] min-w-[300px] break-words p-0 drop-shadow-none gap-2",
         selected ? "border-gray-500" : "hover:border-slate-200",
-        highlighted && "border-orange-500"
+        highlighted && "border-orange-500",
       )}
       ref={nodeRef}
       onClick={onClick}
@@ -269,7 +269,7 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
   const [isTaskDetailsSheetOpen, setIsTaskDetailsSheetOpen] = useState(false);
   const taskId = useMemo(
     () => data?.taskId as string | undefined,
-    [data?.taskId]
+    [data?.taskId],
   );
   const nodeRef = useRef<HTMLDivElement | null>(null);
   const textRef = useRef<HTMLDivElement>(null);
@@ -289,7 +289,7 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
   const isCustomComponent = !taskSpec.componentRef.url; // Custom components don't have a source url
 
   const { componentRef: mostRecentComponentRef } = useComponentFromUrl(
-    taskSpec.componentRef.url
+    taskSpec.componentRef.url,
   );
 
   const isOutdated =

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/replaceTaskNode.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/replaceTaskNode.ts
@@ -23,7 +23,7 @@ export const replaceTaskNode = (
   const newTaskId = getUniqueTaskName(graphSpec, taskName);
 
   const oldTaskId = nodeToReplace.data.taskId as string;
-  const oldTask = deepClone(nodeToReplace.data.taskSpec) as TaskSpec;
+  const oldTask = deepClone(updatedGraphSpec.tasks[oldTaskId]) as TaskSpec;
   const oldTaskInputs = oldTask.componentRef.spec?.inputs;
 
   // Migrate the task to the new componentRef


### PR DESCRIPTION
Continues on from #253 and #242 to allow nodes to be upgrade in bulk by selecting a group of them on the canvas and choosing the new bulk-upgrade button on the selection toolbar.

A continuation of https://github.com/Shopify/oasis-frontend/issues/74

The system will warn if some inputs may be lost, but will not list what those inputs or arguments are. Replacement logic is the same as #242.

![image](https://github.com/user-attachments/assets/aad552c2-08f6-4ea0-9cdf-b7cf6fedfda2)
![image](https://github.com/user-attachments/assets/0d14ca96-2741-4ad7-a942-63d9b5994088)
