### PR TITLE
This PR fixes the full screen code viewer so it immediately becomes scrollable

### DIFF
--- a/src/components/shared/CodeViewer.tsx
+++ b/src/components/shared/CodeViewer.tsx
@@ -99,13 +99,13 @@ const CodeViewer = ({
   language = "yaml",
   title = "Code Implementation",
   filename = "",
-  onFullscreenChange,
+  onFullscreenChange = () => {},
 }: CodeViewerProps) => {
   const { openFullscreen } = useFullscreen();
 
   const handleEnterFullscreen = useCallback(() => {
     openFullscreen({ code, language, title });
-    onFullscreenChange?.(true);
+    onFullscreenChange(true);
   }, [code, language, title, openFullscreen, onFullscreenChange]);
 
   return (
@@ -155,7 +155,7 @@ const FullscreenView = ({ content, onClose }: FullscreenViewProps) => {
 
   return createPortal(
     <div
-      className="fixed inset-0 z-[9999] bg-black/95 flex flex-col"
+      className="fixed inset-0 z-[999999] bg-black/95 flex flex-col"
       onClick={(e) => e.target === e.currentTarget && onClose()}
     >
       <div className="flex justify-between items-center p-4 bg-slate-800">

--- a/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
+++ b/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
@@ -49,6 +49,12 @@ const ComponentDetails = ({
     }
   };
 
+  const onFullscreenChange = (isFullscreen: boolean) => {
+    if (!isFullscreen) {
+      onClose?.();
+    }
+  };
+
   return (
     <Dialog modal={!isAnyFullscreen} onOpenChange={onOpenChange}>
       <DialogTrigger asChild>{dialogTriggerButton}</DialogTrigger>
@@ -105,6 +111,7 @@ const ComponentDetails = ({
               <TaskImplementation
                 displayName={displayName}
                 componentSpec={componentSpec}
+                onFullscreenChange={onFullscreenChange}
               />
             </TabsContent>
           </div>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/TaskConfigurationSheet.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/TaskConfigurationSheet.tsx
@@ -1,4 +1,10 @@
-import { Code, InfoIcon, LogsIcon, Parentheses } from "lucide-react";
+import {
+  AmphoraIcon,
+  Code,
+  InfoIcon,
+  LogsIcon,
+  Parentheses,
+} from "lucide-react";
 import { type ReactNode } from "react";
 
 import {
@@ -73,6 +79,11 @@ const TaskConfigurationSheet = ({
 
   const displayName = getComponentName(taskSpec.componentRef);
 
+  const onFullscreenChange = (isFullscreen: boolean) => {
+    if (isFullscreen) {
+      onOpenChange(false);
+    }
+  };
   return (
     <Sheet open={isOpen} onOpenChange={onOpenChange}>
       <SheetTrigger asChild>{trigger}</SheetTrigger>
@@ -98,13 +109,17 @@ const TaskConfigurationSheet = ({
                 <InfoIcon className="h-4 w-4" />
                 Details
               </TabsTrigger>
-              <TabsTrigger value="arguments" className="flex-1">
-                <Parentheses className="w-4 h-4" />
-                Arguments
+              <TabsTrigger value="io" className="flex-1">
+                {readOnly ? (
+                  <AmphoraIcon className="w-4 h-4" />
+                ) : (
+                  <Parentheses className="w-4 h-4" />
+                )}
+                {readOnly ? "Artifacts" : "Inputs/Outputs"}
               </TabsTrigger>
-              <TabsTrigger value="implementation" className="flex-1">
+              <TabsTrigger value="Component YAML" className="flex-1">
                 <Code className="h-4 w-4" />
-                Implementation
+                Component YAML
               </TabsTrigger>
               {readOnly && (
                 <TabsTrigger value="logs" className="flex-1">
@@ -134,7 +149,7 @@ const TaskConfigurationSheet = ({
                 ))}
               />
             </TabsContent>
-            <TabsContent value="arguments" className="h-full">
+            <TabsContent value="io" className="h-full">
               <h2>Arguments</h2>
               {!readOnly && (
                 <>
@@ -155,16 +170,18 @@ const TaskConfigurationSheet = ({
                 />
               )}
             </TabsContent>
-            <TabsContent value="implementation" className="h-full">
+            <TabsContent value="Component YAML" className="h-full">
               <TaskImplementation
                 displayName={displayName}
                 componentSpec={componentSpec}
+                onFullscreenChange={onFullscreenChange}
               />
             </TabsContent>
             {readOnly && (
               <TabsContent value="logs">
                 <Logs
                   executionId={taskSpec.annotations?.executionId as string}
+                  onFullscreenChange={onFullscreenChange}
                 />
               </TabsContent>
             )}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/logs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/logs.tsx
@@ -5,8 +5,10 @@ import CodeViewer from "@/components/shared/CodeViewer";
 import { API_URL } from "@/utils/constants";
 
 const LogDisplay = ({
+  onFullscreenChange,
   logs,
 }: {
+  onFullscreenChange: (isFullscreen: boolean) => void;
   logs: {
     log_text?: string;
     system_error_exception_full?: string;
@@ -24,6 +26,7 @@ const LogDisplay = ({
           language="text"
           title="Logs"
           filename="logs"
+          onFullscreenChange={onFullscreenChange}
         />
       )}
       {logs?.system_error_exception_full && (
@@ -32,6 +35,7 @@ const LogDisplay = ({
           language="text"
           title="Logs"
           filename="error"
+          onFullscreenChange={onFullscreenChange}
         />
       )}
     </>
@@ -45,7 +49,7 @@ const getLogs = async (executionId: string) => {
   return response.json();
 };
 
-const Logs = ({ executionId }: { executionId?: string | number }) => {
+const Logs = ({ executionId, onFullscreenChange }: { executionId?: string | number, onFullscreenChange: (isFullscreen: boolean) => void }) => {
   const [logs, setLogs] = useState<{
     log_text?: string;
     system_error_exception_full?: string;
@@ -81,7 +85,7 @@ const Logs = ({ executionId }: { executionId?: string | number }) => {
   return (
     <div className="space-y-4">
       <div className="font-mono text-sm whitespace-pre-wrap bg-gray-50 p-4 rounded-lg">
-        {logs && <LogDisplay logs={logs} />}
+        {logs && <LogDisplay logs={logs} onFullscreenChange={onFullscreenChange} />}
       </div>
     </div>
   );

--- a/src/components/shared/TaskDetails/Implementation.tsx
+++ b/src/components/shared/TaskDetails/Implementation.tsx
@@ -7,11 +7,13 @@ import { getComponentFilename } from "@/utils/getComponentFilename";
 interface TaskImplementationProps {
   displayName: string;
   componentSpec: ComponentSpec;
+  onFullscreenChange: (isFullscreen: boolean) => void;
 }
 
 const TaskImplementation = ({
   displayName,
   componentSpec,
+  onFullscreenChange = () => {},
 }: TaskImplementationProps) => {
   const filename = getComponentFilename(componentSpec);
 
@@ -19,7 +21,7 @@ const TaskImplementation = ({
     <>
       {componentSpec?.implementation ? (
         <CodeViewer
-          code={yaml.dump(componentSpec?.implementation, {
+          code={yaml.dump(componentSpec, {
             lineWidth: 80,
             noRefs: true,
             indent: 2,
@@ -27,6 +29,7 @@ const TaskImplementation = ({
           language="yaml"
           title={`${displayName} Implementation (read-only)`}
           filename={filename}
+          onFullscreenChange={onFullscreenChange}
         />
       ) : (
         <div className="text-sm text-gray-500 p-4 border rounded-md">


### PR DESCRIPTION
Previously, you had to click the code once it was in full screen mode to make it scrollable. this resolves that by closing the side pane allowing the browser to scroll the full screen code. I have also updated the name of the arguments depending on if its a run or a pipeline.