### PR TITLE
Adds local dates on the pipeline and runs list

### DIFF
--- a/src/components/Home/PipelineSection/PipelineRow/PipelineRow.tsx
+++ b/src/components/Home/PipelineSection/PipelineRow/PipelineRow.tsx
@@ -17,7 +17,7 @@ import useLoadPipelineRuns from "@/hooks/useLoadPipelineRuns";
 import { EDITOR_PATH } from "@/routes/router";
 import { deletePipeline } from "@/services/pipelineService";
 import type { ComponentReferenceWithSpec } from "@/utils/componentStore";
-import { formatDate } from "@/utils/date";
+import { convertUTCToLocalTime, formatDate } from "@/utils/date";
 
 interface PipelineRowProps {
   url?: string;
@@ -80,7 +80,11 @@ const PipelineRow = ({
           {latestRun ? (
             <div className="flex items-center gap-2">
               <StatusIcon status={latestRun.status} />
-              <span>{formatDate(latestRun.created_at)}</span>
+              <span>
+                {formatDate(
+                  convertUTCToLocalTime(latestRun.created_at).toISOString(),
+                )}
+              </span>
             </div>
           ) : (
             "-"

--- a/src/components/Home/RunSection/RunRow.tsx
+++ b/src/components/Home/RunSection/RunRow.tsx
@@ -15,7 +15,7 @@ import {
   fetchExecutionInfo,
   getRunStatus,
 } from "@/services/executionService";
-import { formatDate } from "@/utils/date";
+import { convertUTCToLocalTime, formatDate } from "@/utils/date";
 
 const RunRow = ({ run }: { run: PipelineRunResponse }) => {
   const navigate = useNavigate();
@@ -90,7 +90,9 @@ const RunRow = ({ run }: { run: PipelineRunResponse }) => {
         </HoverCard>
       </TableCell>
       <TableCell>
-        {run.created_at ? `${formatDate(run.created_at)}` : "Data not found..."}
+        {run.created_at
+          ? `${formatDate(convertUTCToLocalTime(run.created_at).toISOString())}`
+          : "Data not found..."}
       </TableCell>
       <TableCell>{run ? `${run.created_by ?? "Unknown user"}` : ""}</TableCell>
     </TableRow>

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -11,3 +11,13 @@ export const formatDate = (dateString: string, format = defaultFormat) => {
   const date = new Date(dateString);
   return date.toLocaleString("en-US", format);
 };
+
+/**
+ * Converts a UTC date string to local time
+ * @param utcDateString - The UTC date string to convert
+ * @returns Date object in local timezone
+ */
+export const convertUTCToLocalTime = (utcDateString: string): Date => {
+  const date = new Date(utcDateString);
+  return new Date(date.getTime() - date.getTimezoneOffset() * 60000);
+};


### PR DESCRIPTION
This PR adds a new date method that takes a UTC date and converts it to the local timezone. This is currently being used on the pipeline runs table as well as the "last run" column on the pipeline table.