### PR TITLE
Don't fetch runs when home page is refocused

### DIFF
--- a/src/components/Home/RunSection/RunSection.tsx
+++ b/src/components/Home/RunSection/RunSection.tsx
@@ -33,6 +33,7 @@ export const RunSection = () => {
 
   const { data, isLoading, refetch } = useQuery<ListPipelineJobsResponse>({
     queryKey: ["runs", pageToken],
+    refetchOnWindowFocus: false,
     queryFn: async () => {
       const pageTokenParam = pageToken ? `?page_token=${pageToken}` : "";
       const url = `${API_URL}/api/pipeline_runs/${pageTokenParam}${filter}`;

--- a/src/services/executionService.ts
+++ b/src/services/executionService.ts
@@ -35,6 +35,7 @@ export const fetchExecutionInfo = (executionId: string) => {
     error: detailsError,
   } = useQuery<GetExecutionInfoResponse>({
     queryKey: ["pipeline-run-details", executionId],
+    refetchOnWindowFocus: false,
     queryFn: fetchDetails,
   });
 
@@ -44,6 +45,7 @@ export const fetchExecutionInfo = (executionId: string) => {
     error: stateError,
   } = useQuery<GetGraphExecutionStateResponse>({
     queryKey: ["pipeline-run-state", executionId],
+    refetchOnWindowFocus: false,
     queryFn: () => fetchExecutionState(executionId),
   });
 


### PR DESCRIPTION
When we tab back to the home page we re-fetch our data. We don't want this because it can lead to some ugly UI. This resolves that.