### PR TITLE
Add Simple Annotation Editor to Task Nodes

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -19,6 +19,7 @@ import useConfirmationDialog from "@/hooks/useConfirmationDialog";
 import { useCopyPaste } from "@/hooks/useCopyPaste";
 import useToastNotification from "@/hooks/useToastNotification";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+import type { Annotations } from "@/types/annotations";
 import type { NodeAndTaskId } from "@/types/taskNode";
 import type {
   ArgumentType,
@@ -45,6 +46,7 @@ import { handleConnection } from "./utils/handleConnection";
 import { isPositionInNode } from "./utils/isPositionInNode";
 import { removeEdge } from "./utils/removeEdge";
 import { removeNode } from "./utils/removeNode";
+import replaceTaskAnnotationsInGraphSpec from "./utils/replaceTaskAnnotationsInGraphSpec";
 import replaceTaskArgumentsInGraphSpec from "./utils/replaceTaskArgumentsInGraphSpec";
 import { replaceTaskNode } from "./utils/replaceTaskNode";
 import { updateNodePositions } from "./utils/updateNodePosition";
@@ -166,6 +168,19 @@ const FlowCanvas = ({
     [graphSpec],
   );
 
+  const setAnnotations = useCallback(
+    (ids: NodeAndTaskId, annotations: Annotations) => {
+      const taskId = ids.taskId;
+      const newGraphSpec = replaceTaskAnnotationsInGraphSpec(
+        taskId,
+        graphSpec,
+        annotations,
+      );
+      updateGraphSpec(newGraphSpec);
+    },
+    [graphSpec],
+  );
+
   const onDuplicate = useCallback(
     (ids: NodeAndTaskId, selected = true) => {
       const nodeId = ids.nodeId;
@@ -228,6 +243,7 @@ const FlowCanvas = ({
     nodeCallbacks: {
       onDelete,
       setArguments,
+      setAnnotations,
       onDuplicate,
       onUpgrade,
     },

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsEditor.tsx
@@ -1,0 +1,144 @@
+import { PlusCircleIcon, TrashIcon } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { Annotations } from "@/types/annotations";
+import type { TaskSpec } from "@/utils/componentSpec";
+
+interface AnnotationsEditorProps {
+  taskSpec: TaskSpec;
+  onApply: (annotations: Annotations) => void;
+}
+
+const UNREMOVABLE_ANNOTATIONS = ["editor.position"];
+
+export const AnnotationsEditor = ({
+  taskSpec,
+  onApply,
+}: AnnotationsEditorProps) => {
+  const rawAnnotations = (taskSpec.annotations || {}) as Annotations;
+
+  const [annotations, setAnnotations] = useState<Annotations>({
+    ...rawAnnotations,
+  });
+
+  // Track new rows separately until apply
+  const [newRows, setNewRows] = useState<Array<{ key: string; value: string }>>(
+    [],
+  );
+
+  const handleAddNewRow = () => {
+    setNewRows((rows) => [...rows, { key: "", value: "" }]);
+  };
+
+  const handleNewRowChange = (
+    idx: number,
+    field: "key" | "value",
+    value: string,
+  ) => {
+    setNewRows((rows) => {
+      const updated = [...rows];
+      updated[idx] = { ...updated[idx], [field]: value };
+      return updated;
+    });
+  };
+
+  const handleRemoveNewRow = (idx: number) => {
+    setNewRows((rows) => rows.filter((_, i) => i !== idx));
+  };
+
+  const handleValueChange = (key: string, value: string) => {
+    setAnnotations((prev) => ({
+      ...prev,
+      [key]: value,
+    }));
+  };
+
+  const handleRemove = (key: string) => {
+    const { [key]: _, ...rest } = annotations;
+    setAnnotations(rest);
+  };
+
+  const handleApply = () => {
+    // Merge valid new rows into annotations
+    const validNewRows = newRows.filter(
+      (row) => row.key && row.value && !(row.key in annotations),
+    );
+    const merged = {
+      ...annotations,
+      ...Object.fromEntries(validNewRows.map((row) => [row.key, row.value])),
+    };
+    setAnnotations(merged);
+    setNewRows([]);
+    if (onApply) {
+      onApply(merged);
+    }
+  };
+
+  return (
+    <div className="h-auto flex flex-col gap-2 overflow-y-auto pr-4 overflow-visible">
+      {Object.entries(annotations).map(([key, value]) => (
+        <div key={key} className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground w-40 truncate">
+            {key}
+          </span>
+          <Input
+            value={value}
+            onChange={(e) => handleValueChange(key, e.target.value)}
+            className="flex-1"
+          />
+          {!UNREMOVABLE_ANNOTATIONS.includes(key) && (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => handleRemove(key)}
+              title="Remove annotation"
+            >
+              <TrashIcon className="h-4 w-4 text-destructive" />
+            </Button>
+          )}
+        </div>
+      ))}
+      {newRows.map((row, idx) => (
+        <div key={idx} className="flex items-center gap-2 mt-2">
+          <Input
+            placeholder="New annotation"
+            value={row.key}
+            onChange={(e) => handleNewRowChange(idx, "key", e.target.value)}
+            className="w-39 ml-1"
+            autoFocus={idx === newRows.length - 1}
+          />
+          <Input
+            placeholder="value"
+            value={row.value}
+            onChange={(e) => handleNewRowChange(idx, "value", e.target.value)}
+            className="flex-1"
+          />
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => handleRemoveNewRow(idx)}
+            title="Remove new annotation"
+          >
+            <TrashIcon className="h-4 w-4 text-destructive" />
+          </Button>
+        </div>
+      ))}
+      <div className="flex gap-2 justify-end mt-4">
+        <Button
+          onClick={handleAddNewRow}
+          variant="ghost"
+          className="w-fit"
+          type="button"
+        >
+          <PlusCircleIcon className="h-4 w-4" />
+          New
+        </Button>
+        <Button className="w-fit" onClick={handleApply}>
+          Apply
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/TaskConfigurationSheet.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/TaskConfigurationSheet.tsx
@@ -1,6 +1,7 @@
 import {
   AmphoraIcon,
   Code,
+  FilePenLineIcon,
   InfoIcon,
   LogsIcon,
   Parentheses,
@@ -27,10 +28,12 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import type { Annotations } from "@/types/annotations";
 import type { ArgumentType, TaskSpec } from "@/utils/componentSpec";
 import { TOP_NAV_HEIGHT } from "@/utils/constants";
 import { getComponentName } from "@/utils/getComponentName";
 
+import { AnnotationsEditor } from "../AnnotationsEditor/AnnotationsEditor";
 import ArgumentsSection from "../ArgumentsEditor/ArgumentsSection";
 import Io from "./io";
 import Logs from "./logs";
@@ -47,6 +50,7 @@ interface TaskConfigurationSheetProps {
   disabled?: boolean;
   onOpenChange: (isOpen: boolean) => void;
   setArguments: (args: Record<string, ArgumentType>) => void;
+  setAnnotations: (annotations: Annotations) => void;
   onDelete?: () => void;
   readOnly?: boolean;
   runStatus?: ContainerExecutionStatus;
@@ -61,6 +65,7 @@ const TaskConfigurationSheet = ({
   disabled = false,
   onOpenChange,
   setArguments,
+  setAnnotations,
   onDelete,
   readOnly = false,
   runStatus,
@@ -121,12 +126,18 @@ const TaskConfigurationSheet = ({
 
               <TabsTrigger value="Component YAML" className="flex-1">
                 <Code className="h-4 w-4" />
-                Component YAML
+                YAML
               </TabsTrigger>
               {readOnly && (
                 <TabsTrigger value="logs" className="flex-1">
                   <LogsIcon className="h-4 w-4" />
                   Logs
+                </TabsTrigger>
+              )}
+              {!readOnly && (
+                <TabsTrigger value="annotations" className="flex-1">
+                  <FilePenLineIcon className="h-4 w-4" />
+                  Annotations
                 </TabsTrigger>
               )}
             </TabsList>
@@ -184,6 +195,17 @@ const TaskConfigurationSheet = ({
                   executionId={taskSpec.annotations?.executionId as string}
                   onFullscreenChange={onFullscreenChange}
                   status={runStatus}
+                />
+              </TabsContent>
+            )}
+            {!readOnly && (
+              <TabsContent value="annotations">
+                <p className="text-sm text-muted-foreground mb-2">
+                  Configure task annotations and custom data.
+                </p>
+                <AnnotationsEditor
+                  taskSpec={taskSpec}
+                  onApply={setAnnotations}
                 />
               </TabsContent>
             )}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
@@ -19,6 +19,7 @@ import useToastNotification from "@/hooks/useToastNotification";
 import { cn } from "@/lib/utils";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { inputsWithInvalidArguments } from "@/services/componentService";
+import type { Annotations } from "@/types/annotations";
 import type { TaskNodeData } from "@/types/taskNode";
 import type {
   ArgumentType,
@@ -292,6 +293,11 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
     notify("Arguments updated", "success");
   };
 
+  const handleSetAnnotations = (annotations: Annotations) => {
+    typedData.callbacks?.setAnnotations(annotations);
+    notify("Annotations updated", "success");
+  };
+
   const handleDeleteTaskNode = () => {
     typedData.callbacks?.onDelete();
   };
@@ -359,6 +365,7 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
               },
             ]}
             setArguments={handleSetArguments}
+            setAnnotations={handleSetAnnotations}
             disabled={!!runStatus}
           />
         </>

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/replaceTaskAnnotationsInGraphSpec.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/replaceTaskAnnotationsInGraphSpec.ts
@@ -1,0 +1,27 @@
+import type { Annotations } from "@/types/annotations";
+import type { GraphSpec } from "@/utils/componentSpec";
+
+const replaceTaskAnnotationsInGraphSpec = (
+  taskId: string,
+  graphSpec: GraphSpec,
+  taskAnnotations: Annotations,
+) => {
+  if (!taskAnnotations) {
+    return graphSpec;
+  }
+
+  const newGraphSpec: GraphSpec = {
+    ...graphSpec,
+    tasks: {
+      ...graphSpec.tasks,
+      [taskId]: {
+        ...graphSpec.tasks[taskId],
+        annotations: taskAnnotations,
+      },
+    },
+  };
+
+  return newGraphSpec;
+};
+
+export default replaceTaskAnnotationsInGraphSpec;

--- a/src/types/annotations.ts
+++ b/src/types/annotations.ts
@@ -1,0 +1,1 @@
+export type Annotations = Record<string, string>;

--- a/src/types/taskNode.ts
+++ b/src/types/taskNode.ts
@@ -4,6 +4,8 @@ import type {
   TaskSpec,
 } from "@/utils/componentSpec";
 
+import type { Annotations } from "./annotations";
+
 export interface TaskNodeData extends Record<string, unknown> {
   taskSpec?: TaskSpec;
   taskId?: string;
@@ -23,6 +25,7 @@ export type TaskType = "task" | "input" | "output";
 /* Note: Optional callbacks will cause TypeScript to break when applying the callbacks to the Nodes. */
 export interface TaskNodeCallbacks {
   setArguments: (args: Record<string, ArgumentType>) => void;
+  setAnnotations: (annotations: Annotations) => void;
   onDelete: () => void;
   onDuplicate: (selected?: boolean) => void;
   onUpgrade: (newComponentRef: ComponentReference) => void;

--- a/src/utils/nodes/createNodesFromComponentSpec.test.ts
+++ b/src/utils/nodes/createNodesFromComponentSpec.test.ts
@@ -15,6 +15,7 @@ describe("createNodesFromComponentSpec", () => {
   const mockNodeCallbacks = {
     onDelete: vi.fn(),
     setArguments: vi.fn(),
+    setAnnotations: vi.fn(),
     onDuplicate: vi.fn(),
     onUpgrade: vi.fn(),
   };


### PR DESCRIPTION
Adds a simple annotation editor to the TaskNode config sheet via a new "Annotations" tab.

Works similar to the argument editor, but allows custom string fields to be added as annotations in the TaskSpec.

Annotations can also be removed (except `editor.position` since this is used to position the node on the canvas).

Changes to the annotations are committed once "Apply" is clicked. Once applied an annotation's key cannot be changed, but its value can still be edited.

![image](https://github.com/user-attachments/assets/d7da6abb-de8f-4437-9893-b1110ff87715)
