### PR TITLE
WIP: Updates route for runs to include run id and execution id

### DIFF
--- a/src/components/Home/RunSection/RunRow.tsx
+++ b/src/components/Home/RunSection/RunRow.tsx
@@ -51,7 +51,7 @@ const RunRow = ({ run }: { run: PipelineRunResponse }) => {
 
   const statusCounts = countTaskStatuses(details, state);
 
-  const clickThroughUrl = `${APP_ROUTES.RUNS}/${executionId}`;
+  const clickThroughUrl = `${APP_ROUTES.RUNS}/${run.id}/${executionId}`;
 
   const LinkProps = {
     to: clickThroughUrl,
@@ -72,7 +72,7 @@ const RunRow = ({ run }: { run: PipelineRunResponse }) => {
       <TableCell className="text-sm flex items-center gap-2">
         <StatusIcon status={getRunStatus(statusCounts)} />
         <Link {...LinkProps}>{name}</Link>
-        <span>{`#${executionId}`}</span>
+        <span>{`#${run.id}`}</span>
       </TableCell>
       <TableCell>
         <HoverCard openDelay={100}>

--- a/src/components/shared/CloneRunButton.tsx
+++ b/src/components/shared/CloneRunButton.tsx
@@ -13,9 +13,9 @@ import { copyRunToPipeline } from "@/services/pipelineRunService";
 import { PipelineNameDialog } from "./Dialogs";
 
 const CloneRunButtonInner = () => {
-  const { id } = runDetailRoute.useParams() as RunDetailParams;
+  const { execution_id } = runDetailRoute.useParams() as RunDetailParams;
   const { componentSpec, isLoading: detailsLoading } =
-    useLoadComponentSpecAndDetailsFromId(id);
+    useLoadComponentSpecAndDetailsFromId(execution_id);
   const navigate = useNavigate();
 
   const handleClone = async (name: string) => {

--- a/src/components/shared/OasisSubmitter.tsx
+++ b/src/components/shared/OasisSubmitter.tsx
@@ -195,13 +195,16 @@ const OasisSubmitter = ({
     notify(message, "error");
   };
 
-  const showSuccessNotification = (runId: number) => {
+  const showSuccessNotification = (runId: number, executionId: number) => {
     const SuccessComponent = () => (
       <div className="flex flex-col gap-3 py-2">
         <div className="flex items-center gap-2">
           <span className="font-semibold">Pipeline successfully submitted</span>
         </div>
-        <Button onClick={() => handleViewRun(runId)} className="w-full">
+        <Button
+          onClick={() => handleViewRun(runId, executionId)}
+          className="w-full"
+        >
           View Run
         </Button>
       </div>
@@ -209,9 +212,9 @@ const OasisSubmitter = ({
     notify(<SuccessComponent />, "success");
   };
 
-  const handleViewRun = (runId: number) => {
+  const handleViewRun = (runId: number, executionId: number) => {
     if (runId) {
-      navigate({ to: `${APP_ROUTES.RUNS}/${runId}` });
+      navigate({ to: `${APP_ROUTES.RUNS}/${runId}/${executionId}` });
     }
   };
 
@@ -231,7 +234,7 @@ const OasisSubmitter = ({
       setIsSubmitting(false);
       onSubmitComplete?.();
 
-      showSuccessNotification(responseData.root_execution_id);
+      showSuccessNotification(responseData.id, responseData.root_execution_id);
     },
     onError: (error) => {
       console.error("Error submitting pipeline:", error);

--- a/src/components/shared/RunOverview.tsx
+++ b/src/components/shared/RunOverview.tsx
@@ -87,7 +87,7 @@ const RunOverview = ({ run, config = defaultConfig }: RunOverviewProps) => {
     <div
       onClick={(e) => {
         e.stopPropagation();
-        navigate({ to: `${APP_ROUTES.RUNS}/${executionId}` });
+        navigate({ to: `${APP_ROUTES.RUNS}/${run.id}/${executionId}` });
       }}
       className="flex flex-col p-2 text-sm hover:bg-gray-50 cursor-pointer"
     >

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -20,7 +20,7 @@ export const RUNS_BASE_PATH = "/runs";
 export const APP_ROUTES = {
   HOME: "/",
   PIPELINE_EDITOR: `${EDITOR_PATH}/$name`,
-  RUN_DETAIL: `${RUNS_BASE_PATH}/$id`,
+  RUN_DETAIL: `${RUNS_BASE_PATH}/$run_id/$execution_id`,
   RUNS: RUNS_BASE_PATH,
 };
 
@@ -45,7 +45,8 @@ export const editorRoute = createRoute({
 });
 
 export interface RunDetailParams {
-  id: string;
+  run_id: string;
+  execution_id: string;
 }
 
 export const runDetailRoute = createRoute({


### PR DESCRIPTION
This PR adds the new url structure for the runs detail page. 
Previously we were using the execution id in the url `runs/EXECUTION_ID` but now we want to use the run id and the execution id so we get both the graph data and the run data.