### PR TITLE
Add Toggle for MultiSelection on the Canvas

### DIFF
--- a/src/components/Editor/PipelineEditor.tsx
+++ b/src/components/Editor/PipelineEditor.tsx
@@ -1,21 +1,43 @@
 import "@/styles/editor.css";
 
-import { Background, Controls, MiniMap, useStore } from "@xyflow/react";
-import { useEffect } from "react";
+import {
+  Background,
+  MiniMap,
+  type ReactFlowProps,
+  useStore,
+} from "@xyflow/react";
+import { useCallback, useEffect, useState } from "react";
 
-import { FlowCanvas, FlowSidebar } from "@/components/shared/ReactFlow";
+import {
+  FlowCanvas,
+  FlowControls,
+  FlowSidebar,
+} from "@/components/shared/ReactFlow";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { savePipelineSpecToSessionStorage } from "@/utils/storage";
 
 const GRID_SIZE = 10;
 
-// Auto-saver is extracted to its own child component since useStoreState in the parent causes infinite re-rendering
-// (each render of GraphComponentSpecFlow seems to change the Redux store).
-// This component seems to be triggered for every node movement, so even pure layout changes are saved.
-
 const PipelineEditor = () => {
   const { componentSpec } = useComponentSpec();
   const nodes = useStore((store) => store.nodes);
+
+  const [flowConfig, setFlowConfig] = useState<ReactFlowProps>({
+    snapGrid: [GRID_SIZE, GRID_SIZE],
+    snapToGrid: true,
+    panOnDrag: true,
+    selectionOnDrag: false,
+  });
+
+  const updateFlowConfig = useCallback(
+    (updatedConfig: Partial<ReactFlowProps>) => {
+      setFlowConfig((prevConfig) => ({
+        ...prevConfig,
+        ...updatedConfig,
+      }));
+    },
+    [],
+  );
 
   // Auto-save the PipelineSpec to session storage
   useEffect(() => {
@@ -29,9 +51,12 @@ const PipelineEditor = () => {
   return (
     <>
       <div className="reactflow-wrapper">
-        <FlowCanvas snapGrid={[GRID_SIZE, GRID_SIZE]} snapToGrid>
+        <FlowCanvas {...flowConfig}>
           <MiniMap position="bottom-left" pannable />
-          <Controls style={{ marginLeft: "224px", marginBottom: "36px" }} />
+          <FlowControls
+            style={{ marginLeft: "224px", marginBottom: "24px" }}
+            updateConfig={updateFlowConfig}
+          />
           <Background gap={GRID_SIZE} className="bg-slate-50!" />
         </FlowCanvas>
       </div>

--- a/src/components/PipelineRun/PipelineRunPage.tsx
+++ b/src/components/PipelineRun/PipelineRunPage.tsx
@@ -1,21 +1,38 @@
-import { Background, Controls, MiniMap } from "@xyflow/react";
+import { Background, MiniMap, type ReactFlowProps } from "@xyflow/react";
+import { useCallback, useState } from "react";
 
-import { FlowCanvas } from "@/components/shared/ReactFlow";
+import { FlowCanvas, FlowControls } from "@/components/shared/ReactFlow";
 
 const GRID_SIZE = 10;
 
 const PipelineRunPage = () => {
+  const [flowConfig, setFlowConfig] = useState<ReactFlowProps>({
+    snapGrid: [GRID_SIZE, GRID_SIZE],
+    snapToGrid: true,
+    panOnDrag: true,
+    selectionOnDrag: false,
+    nodesDraggable: false,
+    fitView: true,
+  });
+
+  const updateFlowConfig = useCallback(
+    (updatedConfig: Partial<ReactFlowProps>) => {
+      setFlowConfig((prevConfig) => ({
+        ...prevConfig,
+        ...updatedConfig,
+      }));
+    },
+    [],
+  );
+
   return (
     <div className="reactflow-wrapper h-full w-full">
-      <FlowCanvas
-        snapToGrid={true}
-        snapGrid={[GRID_SIZE, GRID_SIZE]}
-        nodesDraggable={false}
-        fitView
-        readOnly
-      >
+      <FlowCanvas {...flowConfig} readOnly>
         <MiniMap position="bottom-left" pannable />
-        <Controls style={{ marginLeft: "224px", marginBottom: "36px" }} />
+        <FlowControls
+          style={{ marginLeft: "224px", marginBottom: "24px" }}
+          updateConfig={updateFlowConfig}
+        />
         <Background gap={GRID_SIZE} className="bg-slate-50!" />
       </FlowCanvas>
     </div>

--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -18,6 +18,7 @@ import useComponentSpecToEdges from "@/hooks/useComponentSpecToEdges";
 import useConfirmationDialog from "@/hooks/useConfirmationDialog";
 import { useCopyPaste } from "@/hooks/useCopyPaste";
 import useToastNotification from "@/hooks/useToastNotification";
+import { cn } from "@/lib/utils";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import type { NodeAndTaskId } from "@/types/taskNode";
 import type {
@@ -76,6 +77,29 @@ const FlowCanvas = ({
 
   const [showToolbar, setShowToolbar] = useState(false);
   const [replaceTarget, setReplaceTarget] = useState<Node | null>(null);
+  const [shiftKeyPressed, setShiftKeyPressed] = useState(false);
+
+  const handleKeyDown = useCallback((event: KeyboardEvent) => {
+    if (event.key === "Shift") {
+      setShiftKeyPressed(true);
+    }
+  }, []);
+
+  const handleKeyUp = useCallback((event: KeyboardEvent) => {
+    if (event.key === "Shift") {
+      setShiftKeyPressed(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("keyup", handleKeyUp);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("keyup", handleKeyUp);
+    };
+  }, [handleKeyDown, handleKeyUp]);
 
   const [reactFlowInstance, setReactFlowInstance] =
     useState<ReactFlowInstance>();
@@ -600,6 +624,9 @@ const FlowCanvas = ({
         nodesDraggable={!readOnly}
         nodesConnectable={!readOnly}
         connectOnClick={!readOnly}
+        className={cn(
+          (rest.selectionOnDrag || shiftKeyPressed) && "cursor-crosshair",
+        )}
       >
         {!readOnly && (
           <NodeToolbar

--- a/src/components/shared/ReactFlow/FlowControls/FlowControls.tsx
+++ b/src/components/shared/ReactFlow/FlowControls/FlowControls.tsx
@@ -1,0 +1,40 @@
+import {
+  ControlButton,
+  type ControlProps,
+  Controls,
+  type ReactFlowProps,
+} from "@xyflow/react";
+import { SquareDashedMousePointerIcon } from "lucide-react";
+import { useCallback, useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+interface FlowControlsProps extends ControlProps {
+  updateConfig: (config: Partial<ReactFlowProps>) => void;
+}
+
+export default function FlowControls({
+  updateConfig,
+  ...props
+}: FlowControlsProps) {
+  const [multiSelectActive, setMultiSelectActive] = useState(false);
+
+  const onClickMultiSelect = useCallback(() => {
+    updateConfig({
+      selectionOnDrag: !multiSelectActive,
+      panOnDrag: multiSelectActive,
+    });
+    setMultiSelectActive(!multiSelectActive);
+  }, [multiSelectActive, updateConfig]);
+
+  return (
+    <Controls {...props}>
+      <ControlButton
+        onClick={onClickMultiSelect}
+        className={cn(multiSelectActive && "bg-gray-100!")}
+      >
+        <SquareDashedMousePointerIcon />
+      </ControlButton>
+    </Controls>
+  );
+}

--- a/src/components/shared/ReactFlow/FlowControls/index.ts
+++ b/src/components/shared/ReactFlow/FlowControls/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./FlowControls";

--- a/src/components/shared/ReactFlow/index.ts
+++ b/src/components/shared/ReactFlow/index.ts
@@ -1,2 +1,3 @@
 export { default as FlowCanvas } from "./FlowCanvas";
+export { default as FlowControls } from "./FlowControls";
 export { default as FlowSidebar } from "./FlowSidebar";

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -64,6 +64,10 @@ details > * {
   visibility: hidden;
 }
 
+.react-flow.cursor-crosshair .react-flow__pane {
+  cursor: crosshair;
+}
+
 .dndflow .reactflow-wrapper {
   flex-grow: 1;
   height: 100%;


### PR DESCRIPTION
Adds a button to the Canvas toolbar to toggle the selection mode in and out of multi select. When in multi-select mode the cursor will change to a crosshair and behave the same as if shift was being held down (i.e. click and drag will create a selection toolbox)

![image](https://github.com/user-attachments/assets/5a562969-1f4d-4573-9ab0-ae63561761f7)
