### PR TITLE
Add the values directly on the task node

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/Handles.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/Handles.tsx
@@ -8,12 +8,14 @@ type InputHandleProps = {
   input: InputSpec;
   invalidArguments: string[];
   onClick?: (e: MouseEvent<HTMLDivElement>) => void;
+  value?: string;
 };
 
 export const InputHandle = ({
   input,
   invalidArguments,
   onClick,
+  value,
 }: InputHandleProps) => {
   const isInvalid = invalidArguments.includes(input.name);
   const missing = isInvalid ? "bg-red-700!" : "bg-gray-500!";
@@ -22,25 +24,44 @@ export const InputHandle = ({
     onClick?.(e);
   };
 
+  const hasValue = value !== undefined && value !== "" && value !== null;
+  const hasDefault = input.default !== undefined && input.default !== "";
+
   return (
-    <div className="flex flex-row items-center" key={input.name}>
+    <div
+      className="flex flex-row items-center hover:bg-gray-300 rounded-md cursor-pointer"
+      key={input.name}
+      onClick={handleClick}
+    >
       <Handle
         type="target"
         id={`input_${input.name}`}
         position={Position.Left}
         isConnectable={true}
         className={cn(
-          "relative! border-0! !w-[12px] !h-[12px] transform-none! -translate-x-6 cursor-pointer",
+          "relative! border-0! !w-[12px] !h-[12px] transform-none! -translate-x-6 ",
           missing,
         )}
-        onClick={handleClick}
-      />
 
-      <div
-        className="text-xs mr-4 text-gray-800! max-w-[250px] truncate bg-gray-200 rounded-md px-2 py-1 -translate-x-3 cursor-pointer hover:bg-gray-300"
-        onClick={handleClick}
-      >
-        {input.name.replace(/_/g, " ")}
+      />
+      <div className="flex flex-row w-[250px] gap-0.5 items-center justify-between">
+        <div
+          className={`-translate-x-3 min-w-0 ${!value ? "max-w-full" : "max-w-[75%]"} inline-block`}
+        >
+          <div className="text-xs text-gray-800! bg-gray-200 rounded-md px-2 py-1 hover:bg-gray-300 truncate">
+            {input.name.replace(/_/g, " ")}
+          </div>
+        </div>
+        {(hasValue || hasDefault) && (
+          <div
+            className={cn(
+              "max-w-[50%] min-w-0 text-xs text-gray-800! truncate inline-block text-right pr-2",
+              !hasValue && "text-gray-500!",
+            )}
+          >
+            {hasValue ? value : input.default}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNode.tsx
@@ -25,6 +25,7 @@ import type {
   OutputSpec,
   TaskSpec,
 } from "@/utils/componentSpec";
+import { getValue } from "@/utils/string";
 
 import { InputHandle, OutputHandle } from "./Handles";
 import { StatusIndicator } from "./StatusIndicator";
@@ -40,6 +41,7 @@ type TaskNodeContentProps = {
   onClick: () => void;
   highlighted?: boolean;
   onIOClick: () => void;
+  values?: Record<string, ArgumentType>;
 };
 
 const TaskNodeContent = ({
@@ -52,6 +54,7 @@ const TaskNodeContent = ({
   onClick,
   highlighted,
   onIOClick,
+  values,
 }: TaskNodeContentProps) => {
   const handleIOClicked = (e: MouseEvent<HTMLDivElement>) => {
     e.stopPropagation();
@@ -84,6 +87,7 @@ const TaskNodeContent = ({
                 input={input}
                 invalidArguments={invalidArguments}
                 onClick={handleIOClicked}
+                value={getValue(values?.[input.name])}
               />
             ))}
           </div>
@@ -200,6 +204,7 @@ const ComponentTaskNode = ({ data, selected }: NodeProps) => {
         onClick={handleClick}
         highlighted={highlighted ?? false}
         onIOClick={handleIOClick}
+        values={typedData.taskSpec?.arguments}
       />
 
       {typedData.taskId && (

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,3 +1,5 @@
+import type { ArgumentType } from "./componentSpec";
+
 const formatBytes = (bytes: number) => {
   if (bytes === 0) return "0 Bytes";
   const k = 1024;
@@ -19,4 +21,12 @@ const copyToClipboard = (text: string) => {
   navigator.clipboard.writeText(text);
 };
 
-export { copyToClipboard, formatBytes, formatJsonValue };
+const getValue = (value: string | ArgumentType | undefined) => {
+  try {
+    const parsed = typeof value === "string" ? JSON.parse(value) : value;
+    return JSON.stringify(parsed, null, 2);
+  } catch {
+    return String(value);
+  }
+};
+export { copyToClipboard, formatBytes, formatJsonValue, getValue };


### PR DESCRIPTION
This PR shows the value and default value on the task node. If we show the default value, its slightly lighter to signal to our users this is a default value.

<img width="787" alt="Screenshot 2025-05-22 at 10 15 53 AM" src="https://github.com/user-attachments/assets/fb410249-9cf8-4a83-81bb-73928572934c" />
<img width="418" alt="Screenshot 2025-05-22 at 10 16 09 AM" src="https://github.com/user-attachments/assets/ecef1d91-5c13-4103-9f63-007b703a622c" />

Name is too long

<img width="359" alt="Screenshot 2025-05-22 at 10 16 36 AM" src="https://github.com/user-attachments/assets/143c08d1-48f8-41c9-b878-fcce8789d91a" />

Value is too long

<img width="786" alt="Screenshot 2025-05-22 at 10 16 56 AM" src="https://github.com/user-attachments/assets/22354da0-70a9-4f2d-a584-bc45a7e19848" />

Both are too long
<img width="832" alt="Screenshot 2025-05-22 at 10 17 15 AM" src="https://github.com/user-attachments/assets/189af686-f779-480f-bf39-36fd2659af28" />
