### PR TITLE
Makes artifacts link open in new tab

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/ioCell.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/ioCell.tsx
@@ -105,7 +105,9 @@ const IoCell = ({ io, artifacts }: IoCellProps) => {
                 <>
                   <Link
                     href={transformGcsUrl(artifacts?.artifact_data?.uri || "")}
-                    className="font-mono break-all text-[10px] text-blue-600 hover:text-blue-800 hover:underline"
+                    external
+                    iconClassName="h-2.5 w-2.5"
+                    className="font-mono break-all text-[10px] text-blue-600 hover:text-blue-800 hover:underline flex gap-1"
                   >
                     Link
                   </Link>

--- a/src/components/ui/link.tsx
+++ b/src/components/ui/link.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   external?: boolean;
   download?: boolean;
+  iconClassName?: string;
 }
 
 function Link({
@@ -13,6 +14,7 @@ function Link({
   children,
   className,
   download,
+  iconClassName,
   ...props
 }: LinkProps) {
   const target = external || download ? "_blank" : undefined;
@@ -26,8 +28,8 @@ function Link({
       className={cn("items-center inline-flex", className)}
     >
       {children}
-      {external && <ExternalLink className="h-4" />}
-      {download && <DownloadIcon className="h-4" />}
+      {external && <ExternalLink className={cn("h-4", iconClassName)} />}
+      {download && <DownloadIcon className={cn("h-4", iconClassName)} />}
     </a>
   );
 }


### PR DESCRIPTION
The links in the artifacts ioCell now link externally. Because the text is so small I had to update the link component so you can adjust the icon class names from the parent.

<img width="275" alt="Screenshot 2025-05-22 at 10 56 02 AM" src="https://github.com/user-attachments/assets/de1e64b7-1283-4f9f-a93a-5942141a512d" />
