### PR TITLE
This PR merges the YAML tab into details

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/Handles.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/Handles.tsx
@@ -42,7 +42,6 @@ export const InputHandle = ({
           "relative! border-0! !w-[12px] !h-[12px] transform-none! -translate-x-6 ",
           missing,
         )}
-
       />
       <div className="flex flex-row w-[250px] gap-0.5 items-center justify-between">
         <div

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/TaskConfigurationSheet.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/TaskConfigurationSheet.tsx
@@ -1,6 +1,5 @@
 import {
   AmphoraIcon,
-  Code,
   FilePenLineIcon,
   InfoIcon,
   LogsIcon,
@@ -126,10 +125,6 @@ const TaskConfigurationSheet = ({
                 Details
               </TabsTrigger>
 
-              <TabsTrigger value="Component YAML" className="flex-1">
-                <Code className="h-4 w-4" />
-                YAML
-              </TabsTrigger>
               {readOnly && (
                 <TabsTrigger value="logs" className="flex-1">
                   <LogsIcon className="h-4 w-4" />
@@ -154,6 +149,20 @@ const TaskConfigurationSheet = ({
                 runStatus={runStatus}
                 hasDeletionConfirmation={false}
                 readOnly={readOnly}
+                additionalSection={[
+                  {
+                    title: "Component YAML",
+                    isCollapsed: true,
+                    component: (
+                      <TaskImplementation
+                        key="task-implementation"
+                        displayName={displayName}
+                        componentSpec={componentSpec}
+                        onFullscreenChange={onFullscreenChange}
+                      />
+                    ),
+                  },
+                ]}
                 actions={actions?.map((action) => (
                   <Tooltip key={action.tooltip}>
                     <TooltipTrigger asChild>
@@ -184,13 +193,6 @@ const TaskConfigurationSheet = ({
                   executionId={taskSpec.annotations?.executionId as string}
                 />
               )}
-            </TabsContent>
-            <TabsContent value="Component YAML" className="h-full">
-              <TaskImplementation
-                displayName={displayName}
-                componentSpec={componentSpec}
-                onFullscreenChange={onFullscreenChange}
-              />
             </TabsContent>
             {readOnly && (
               <TabsContent value="logs">

--- a/src/hooks/useCopyToClip.ts
+++ b/src/hooks/useCopyToClip.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef, useState } from "react";
+
+import { copyToClipboard } from "@/utils/string";
+
+export function useCopyToClipboard(text?: string | null) {
+  const [isCopied, setIsCopied] = useState(false);
+  const [isTooltipOpen, setIsTooltipOpen] = useState(false);
+  const tooltipTimerRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (tooltipTimerRef.current) clearTimeout(tooltipTimerRef.current);
+    };
+  }, []);
+
+  const handleTooltipOpen = (open: boolean) => {
+    if (!open) {
+      if (tooltipTimerRef.current) clearTimeout(tooltipTimerRef.current);
+      setIsCopied(false);
+    }
+    setIsTooltipOpen(open);
+  };
+
+  const handleCopy = () => {
+    if (!text) return;
+    copyToClipboard(text);
+    setIsCopied(true);
+    setIsTooltipOpen(true);
+
+    if (tooltipTimerRef.current) clearTimeout(tooltipTimerRef.current);
+    tooltipTimerRef.current = setTimeout(() => {
+      setIsTooltipOpen(false);
+    }, 1500);
+  };
+
+  return {
+    isCopied,
+    isTooltipOpen,
+    handleCopy,
+    handleTooltipOpen,
+  };
+}


### PR DESCRIPTION
This PR merges the YAML tab into the Details tab for both pipelines and runs. 

Rather than hard-coding each section and conditionally rendering based on various combinations of values, this PR introduces a more flexible pattern. The additionalSection prop enables:

- Modular addition of content that's not part of the core details
- Future extensibility without modifying the base component
- Cleaner separation of concerns between core and supplementary information

The Component YAML is the first implementation of this pattern, but this approach allows the component to evolve organically as new requirements emerge.

I've also made digest "click to copy" so we could truncate its long text. I had to do this because when the YAML section is open it creates a scroll bar and the digest text gets bumped to another line, pushing the content down. It wasn't a huge issue, but I would rather the content stay the same. Also, clicking to copy is a nice feature.
<img width="497" alt="Screenshot 2025-05-23 at 11 22 05 AM" src="https://github.com/user-attachments/assets/804f7c00-5b8e-4411-b377-fc29fbf3c74a" />

<img width="543" alt="Screenshot 2025-05-23 at 10 51 23 AM" src="https://github.com/user-attachments/assets/b25c5511-266d-44ab-b60a-f4ffc51ecb04" />
<img width="513" alt="Screenshot 2025-05-23 at 10 51 35 AM" src="https://github.com/user-attachments/assets/cc72ab79-1d12-41f3-b4ab-b90fb4159777" />
