### PR TITLE
Add Compute Resources section to Annotation Editor

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsEditor.tsx
@@ -6,6 +6,11 @@ import { Input } from "@/components/ui/input";
 import type { Annotations } from "@/types/annotations";
 import type { TaskSpec } from "@/utils/componentSpec";
 
+import {
+  COMPUTE_RESOURCES,
+  ComputeResourcesEditor,
+} from "./ComputeResourcesEditor";
+
 interface AnnotationsEditorProps {
   taskSpec: TaskSpec;
   onApply: (annotations: Annotations) => void;
@@ -26,6 +31,11 @@ export const AnnotationsEditor = ({
   // Track new rows separately until apply
   const [newRows, setNewRows] = useState<Array<{ key: string; value: string }>>(
     [],
+  );
+
+  const annotationsWithoutComputeResources = Object.entries(annotations).filter(
+    ([key]) =>
+      !COMPUTE_RESOURCES.some((resource) => resource.annotation === key),
   );
 
   const handleAddNewRow = () => {
@@ -77,54 +87,67 @@ export const AnnotationsEditor = ({
   };
 
   return (
-    <div className="h-auto flex flex-col gap-2 overflow-y-auto pr-4 overflow-visible">
-      {Object.entries(annotations).map(([key, value]) => (
-        <div key={key} className="flex items-center gap-2">
-          <span className="text-xs text-muted-foreground w-40 truncate">
-            {key}
-          </span>
-          <Input
-            value={value}
-            onChange={(e) => handleValueChange(key, e.target.value)}
-            className="flex-1"
-          />
-          {!UNREMOVABLE_ANNOTATIONS.includes(key) && (
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => handleRemove(key)}
-              title="Remove annotation"
-            >
-              <TrashIcon className="h-4 w-4 text-destructive" />
-            </Button>
-          )}
+    <>
+      <div className="h-auto flex flex-col gap-2 overflow-y-auto pr-4 py-2 overflow-visible">
+        <ComputeResourcesEditor
+          annotations={annotations}
+          onChange={handleValueChange}
+        />
+        <hr className="border-t border-dashed border-gray-200 my-4" />
+        <div className="h-auto flex flex-col gap-2">
+          <h3>Other Annotations</h3>
+          {annotationsWithoutComputeResources.map(([key, value]) => (
+            <div key={key} className="flex items-center gap-2">
+              <span className="text-xs text-muted-foreground w-40 truncate">
+                {key}
+              </span>
+              <Input
+                value={value}
+                onChange={(e) => handleValueChange(key, e.target.value)}
+                className="flex-1"
+              />
+              {!UNREMOVABLE_ANNOTATIONS.includes(key) && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => handleRemove(key)}
+                  title="Remove annotation"
+                >
+                  <TrashIcon className="h-4 w-4 text-destructive" />
+                </Button>
+              )}
+            </div>
+          ))}
+          {newRows.map((row, idx) => (
+            <div key={idx} className="flex items-center gap-2 mt-2">
+              <Input
+                placeholder="New annotation"
+                value={row.key}
+                onChange={(e) => handleNewRowChange(idx, "key", e.target.value)}
+                className="w-39 ml-1"
+                autoFocus={idx === newRows.length - 1}
+              />
+              <Input
+                placeholder="value"
+                value={row.value}
+                onChange={(e) =>
+                  handleNewRowChange(idx, "value", e.target.value)
+                }
+                className="flex-1"
+              />
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => handleRemoveNewRow(idx)}
+                title="Remove new annotation"
+              >
+                <TrashIcon className="h-4 w-4 text-destructive" />
+              </Button>
+            </div>
+          ))}
         </div>
-      ))}
-      {newRows.map((row, idx) => (
-        <div key={idx} className="flex items-center gap-2 mt-2">
-          <Input
-            placeholder="New annotation"
-            value={row.key}
-            onChange={(e) => handleNewRowChange(idx, "key", e.target.value)}
-            className="w-39 ml-1"
-            autoFocus={idx === newRows.length - 1}
-          />
-          <Input
-            placeholder="value"
-            value={row.value}
-            onChange={(e) => handleNewRowChange(idx, "value", e.target.value)}
-            className="flex-1"
-          />
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={() => handleRemoveNewRow(idx)}
-            title="Remove new annotation"
-          >
-            <TrashIcon className="h-4 w-4 text-destructive" />
-          </Button>
-        </div>
-      ))}
+      </div>
+      <hr className="border-t border-dashed border-gray-200 my-4" />
       <div className="flex gap-2 justify-end mt-4">
         <Button
           onClick={handleAddNewRow}
@@ -139,6 +162,6 @@ export const AnnotationsEditor = ({
           Apply
         </Button>
       </div>
-    </div>
+    </>
   );
 };

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/ComputeResourcesEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/ComputeResourcesEditor.tsx
@@ -1,0 +1,194 @@
+import type { ChangeEvent } from "react";
+
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { Annotations } from "@/types/annotations";
+
+const GPUs = [
+  { value: "nvidia-a100-80gb", name: "NVIDIA A100 80GB" },
+  { value: "nvidia-h100-80gb", name: "NVIDIA H100 80GB" },
+  { value: "nvidia-h100-mega-80gb", name: "NVIDIA H100 80GB MEGA" },
+  { value: "nvidia-l4", name: "NVIDIA L4" },
+  { value: "nvidia-tesla-a100", name: "NVIDIA A100 40GB" },
+  { value: "nvidia-tesla-p4", name: "NVIDIA Tesla P4" },
+  { value: "nvidia-tesla-t4", name: "NVIDIA T4" },
+  { value: "nvidia-tesla-v100", name: "NVIDIA V100" },
+];
+
+export const COMPUTE_RESOURCES = [
+  {
+    annotation: "cloud-pipelines.net/launchers/generic/resources.cpu",
+    label: "CPU",
+    unit: "cores",
+  },
+  {
+    annotation: "cloud-pipelines.net/launchers/generic/resources.memory",
+    label: "Memory",
+    unit: "GiB",
+  },
+  {
+    annotation: "cloud-pipelines.net/launchers/generic/resources.accelerators",
+    label: "GPU",
+    options: GPUs,
+    enableQuantity: true,
+  },
+];
+
+interface ComputeResourcesEditorProps {
+  annotations: Annotations;
+  onChange: (key: string, value: string) => void;
+}
+
+export const ComputeResourcesEditor = ({
+  annotations,
+  onChange,
+}: ComputeResourcesEditorProps) => {
+  const handleValueChange = (key: string, value: string) => {
+    onChange(key, value);
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <h3>Compute Resources</h3>
+      {COMPUTE_RESOURCES.map((resource) => (
+        <div key={resource.annotation} className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground w-40 truncate">
+            {resource.label} {resource.unit && `(${resource.unit})`}
+          </span>
+          {resource.enableQuantity ? (
+            <QuantityInputRow
+              resource={resource}
+              annotations={annotations}
+              onChange={handleValueChange}
+            />
+          ) : resource.options ? (
+            <Select
+              value={annotations[resource.annotation] || ""}
+              onValueChange={(value) =>
+                handleValueChange(resource.annotation, value)
+              }
+            >
+              <SelectTrigger className="flex-1">
+                <SelectValue placeholder={`Select ${resource.label}`} />
+              </SelectTrigger>
+              <SelectContent>
+                {resource.options.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : (
+            <Input
+              value={annotations[resource.annotation] || ""}
+              onChange={(e) =>
+                handleValueChange(resource.annotation, e.target.value)
+              }
+              className="flex-1"
+            />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const QuantityInputRow = ({
+  resource,
+  annotations,
+  onChange,
+}: {
+  resource: (typeof COMPUTE_RESOURCES)[number];
+  annotations: Annotations;
+  onChange: (key: string, value: string) => void;
+}) => {
+  const handleKeyInputChange = (
+    e: ChangeEvent<HTMLInputElement>,
+    resource: (typeof COMPUTE_RESOURCES)[number],
+  ) => {
+    const selectedKey = getAnnotationKey(resource.annotation, annotations);
+    if (!selectedKey) return;
+    const newObj = { [selectedKey]: e.target.value };
+    onChange(resource.annotation, JSON.stringify(newObj));
+  };
+
+  const handleValueInputChange = (
+    e: ChangeEvent<HTMLInputElement>,
+    resource: (typeof COMPUTE_RESOURCES)[number],
+  ) => {
+    const selectedKey = getAnnotationKey(resource.annotation, annotations);
+    if (!selectedKey) return;
+    const newObj = { [selectedKey]: e.target.value };
+    onChange(resource.annotation, JSON.stringify(newObj));
+  };
+
+  const handleSelectChange = (
+    selectedKey: string,
+    resource: (typeof COMPUTE_RESOURCES)[number],
+  ) => {
+    const quantity = getAnnotationValue(resource.annotation, annotations);
+    const newObj = selectedKey ? { [selectedKey]: quantity } : {};
+    onChange(resource.annotation, JSON.stringify(newObj));
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      {resource.options ? (
+        <Select
+          value={getAnnotationKey(resource.annotation, annotations)}
+          onValueChange={(selectedKey) =>
+            handleSelectChange(selectedKey, resource)
+          }
+        >
+          <SelectTrigger className="flex-1">
+            <SelectValue placeholder={`Select ${resource.label}`} />
+          </SelectTrigger>
+          <SelectContent>
+            {resource.options.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      ) : (
+        <Input
+          value={getAnnotationKey(resource.annotation, annotations)}
+          onChange={(e) => handleKeyInputChange(e, resource)}
+        />
+      )}
+      <span>x</span>
+      <Input
+        type="number"
+        value={getAnnotationValue(resource.annotation, annotations)}
+        onChange={(e) => handleValueInputChange(e, resource)}
+        className="w-16"
+      />
+    </div>
+  );
+};
+
+function getAnnotationKey(annotation: string, annotations: Annotations) {
+  try {
+    const obj = JSON.parse(annotations[annotation] || "{}");
+    return Object.keys(obj)[0] || "";
+  } catch {
+    return "";
+  }
+}
+
+function getAnnotationValue(annotation: string, annotations: Annotations) {
+  try {
+    const obj = JSON.parse(annotations[annotation] || "{}");
+    return obj[Object.keys(obj)[0]] || "";
+  } catch {
+    return "";
+  }
+}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/TaskConfigurationSheet.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/TaskConfigurationSheet.tsx
@@ -206,7 +206,7 @@ const TaskConfigurationSheet = ({
             {!readOnly && (
               <TabsContent value="annotations">
                 <p className="text-sm text-muted-foreground mb-2">
-                  Configure task annotations and custom data.
+                  Configure task annotations, resources and custom data.
                 </p>
                 <AnnotationsEditor
                   taskSpec={taskSpec}


### PR DESCRIPTION
Closes https://github.com/Cloud-Pipelines/pipeline-studio-app/issues/155

First iteration of an explicit Compute Resources section in the annotation editor.

Compute Resources will also be visible, even if empty. When a value is entered and "Apply" click it will be written to the task annotations.


This is a quick and rough first-iteration, so UX and code refinement will be needed in the future.

![image](https://github.com/user-attachments/assets/4f37dce0-693f-469f-94a6-0a7404e6832a)
