### PR TITLE
Adds title to the run details page

### DIFF
--- a/src/components/layout/EditorMenu.tsx
+++ b/src/components/layout/EditorMenu.tsx
@@ -1,17 +1,32 @@
 import { useLocation } from "@tanstack/react-router";
 
-import { EDITOR_PATH } from "@/routes/router";
+import { useLoadComponentSpecAndDetailsFromId } from "@/hooks/useLoadComponentSpecDetailsFromId";
+import { EDITOR_PATH, RUNS_BASE_PATH } from "@/routes/router";
 
 const EditorMenu = () => {
   const location = useLocation();
   const pathname = location.pathname;
-  const experimentName = decodeURIComponent(pathname.split("/").pop() || "");
+  const experimentNameOrRunId = decodeURIComponent(
+    pathname.split("/").pop() || "",
+  );
+  const { componentSpec, isLoading } = useLoadComponentSpecAndDetailsFromId(
+    experimentNameOrRunId,
+  );
 
-  if (!pathname.includes(EDITOR_PATH)) {
+  if (
+    !pathname.includes(EDITOR_PATH) &&
+    !pathname.includes(RUNS_BASE_PATH) &&
+    !isLoading
+  ) {
     return null;
   }
 
-  return <span className="text-white text-sm font-bold">{experimentName}</span>;
+  // IF componentSpec is defined we know its a run because we loaded it from the run id
+  const title = componentSpec?.name
+    ? `${componentSpec?.name} - #${experimentNameOrRunId}`
+    : experimentNameOrRunId;
+
+  return <span className="text-white text-sm font-bold">{title}</span>;
 };
 
 export default EditorMenu;

--- a/src/hooks/useDocumentTitle.ts
+++ b/src/hooks/useDocumentTitle.ts
@@ -6,11 +6,9 @@ type TitleConfig = {
 };
 
 const defaultTitles: TitleConfig = {
-  "/": "Oasis - Pipeline editor",
-  "/editor/$name": (params) =>
-    `Oasis - Editor - ${params.name || "New Pipeline"}`,
-  "/runs/$id": (params) => `Oasis - Run - ${params.id}`,
-  "/runs": "Oasis - Pipeline Runs",
+  "/": "Oasis - Pipeline Editor",
+  "/editor/$name": (params) => `Oasis - ${params.name || "New Pipeline"}`,
+  "/runs/$id": (params) => `Oasis - ${params.id}`,
 };
 
 /**

--- a/src/routes/PipelineRun/PipelineRun.tsx
+++ b/src/routes/PipelineRun/PipelineRun.tsx
@@ -8,6 +8,7 @@ import type {
   GetGraphExecutionStateResponse,
 } from "@/api/types.gen";
 import PipelineRunPage from "@/components/PipelineRun";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { useLoadComponentSpecAndDetailsFromId } from "@/hooks/useLoadComponentSpecDetailsFromId";
 import {
   ComponentSpecProvider,
@@ -49,6 +50,11 @@ const PipelineRun = () => {
     detailsData,
     isLoading: detailsLoading,
   } = useLoadComponentSpecAndDetailsFromId(id);
+
+  useDocumentTitle({
+    "/runs/$id": (params) =>
+      `Oasis - ${componentSpec?.name || ""} - ${params.id}`,
+  });
 
   if (detailsLoading) {
     return (


### PR DESCRIPTION
This PR cleans up the default titles for each page to make information more clear. I have also updated the `src/components/layout/EditorMenu.tsx` component to include the runs name and ID, similar to what we have on the editor

Editor:

<img width="1317" alt="Screenshot 2025-05-29 at 9 33 44 AM" src="https://github.com/user-attachments/assets/52a8947f-e2bb-4089-88d9-836e605ee698" />

Runs Details:
<img width="1170" alt="Screenshot 2025-05-29 at 9 34 46 AM" src="https://github.com/user-attachments/assets/18f6e089-923b-4d8d-b565-96d5d5d7d0cf" />
