### PR TITLE
Reverting to direct download URLs for files

### DIFF
--- a/src/utils/URL.ts
+++ b/src/utils/URL.ts
@@ -1,7 +1,5 @@
 import yaml from "js-yaml";
 
-import { GOOGLE_CLOUD_STORAGE_BROWSER_URL } from "./constants";
-
 const convertGcsUrlToBrowserUrl = (
   url: string,
   isDirectory: boolean,
@@ -10,8 +8,13 @@ const convertGcsUrlToBrowserUrl = (
     return url;
   }
 
-  const cloudConsoleUrl = `${GOOGLE_CLOUD_STORAGE_BROWSER_URL}${isDirectory ? "" : "_details/"}`;
-  return url.replace("gs://", cloudConsoleUrl);
+  if (isDirectory) {
+    return url.replace(
+      "gs://",
+      "https://console.cloud.google.com/storage/browser/",
+    );
+  }
+  return url.replace("gs://", "https://storage.cloud.google.com/");
 };
 
 import type { ComponentSpec } from "./componentSpec";

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,7 +1,4 @@
 /* Environment Config */
-export const GOOGLE_CLOUD_STORAGE_BROWSER_URL =
-  "https://console.cloud.google.com/storage/browser/";
-
 export const ABOUT_URL =
   import.meta.env.VITE_ABOUT_URL || "https://cloud-pipelines.net/";
 


### PR DESCRIPTION
For file artifacts, the URL is the direct download link again. It is more helpful for small files.