### PR TITLE
Minor Arguments cleanup

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentsEditorDialog.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentsEditorDialog.tsx
@@ -14,6 +14,7 @@ import type { ArgumentInput } from "@/types/arguments";
 import type { ArgumentType, TaskSpec } from "@/utils/componentSpec";
 
 import { ArgumentsEditor } from "./ArgumentsEditor";
+import { getArgumentInputs } from "./utils";
 
 interface ArgumentsEditorDialogProps {
   initialPosition?: { x: number; y: number };
@@ -36,34 +37,7 @@ const ArgumentsEditorDialog = ({
 }: ArgumentsEditorDialogProps) => {
   const componentSpec = taskSpec.componentRef.spec;
 
-  const argumentInputs =
-    componentSpec?.inputs?.map((input) => {
-      /*
-        * Some notes on the logic of the ArgumentInput:
-        * [key] - This is used internally by React to keep track of the Input Component. Must be unique.
-        * [value] - This is the value of the argument. It cannot be undefined due to React's rules around controlled components.
-        * [initialValue] - This is the initial value of the argument when the Editor is opened. Immutable. It is used to determine if the argument has been changed during the current editing session.
-        * [inputSpec] - These are some general constants for the argument. Immutable. It is used to display the argument name and type in the UI.
-        * [isRemoved] - This is used to remove unwanted arguments from the Task Spec, as specified by the user. This is essentially used in place of an "undefined" input, since React requires an empty string for controlled components.
-
-        * Note that "undefined" and "empty string" are treated differently in the task spec, but we can only use "empty string" in the UI due to React's rules around controlled components.
-        * The difference is best seen in a required argument with a linked node:
-        *   - The connection will disappear and the connection point turn red when the node is removed, since it is required. This is what the "Remove" button is for.
-        *   - An empty string is a valid input and will result in the connection being severed, but the connection point will not turn red. This is what the "Reset to Default" button is for.
-        *   - A severed connection cannot be reconnected in the argument editor once applied and must be redrawn on the graph.
-      */
-
-      const existingArgument = taskSpec.arguments?.[input.name];
-      const initialValue = existingArgument ?? input.default;
-
-      return {
-        key: input.name,
-        value: initialValue ?? "",
-        initialValue: initialValue ?? "",
-        inputSpec: input,
-        isRemoved: initialValue === undefined,
-      } as ArgumentInput;
-    }) ?? [];
+  const argumentInputs = getArgumentInputs(taskSpec);
 
   const [currentArguments, setCurrentArguments] =
     useState<ArgumentInput[]>(argumentInputs);

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentsSection.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentsSection.tsx
@@ -6,6 +6,7 @@ import type { ArgumentInput } from "@/types/arguments";
 import type { ArgumentType, TaskSpec } from "@/utils/componentSpec";
 
 import { ArgumentsEditor } from "../ArgumentsEditor";
+import { getArgumentInputs } from "./utils";
 
 interface ArgumentsSectionProps {
   taskSpec: TaskSpec;
@@ -20,19 +21,7 @@ const ArgumentsSection = ({
 }: ArgumentsSectionProps) => {
   const componentSpec = taskSpec.componentRef.spec;
 
-  const argumentInputs =
-    componentSpec?.inputs?.map((input) => {
-      const existingArgument = taskSpec.arguments?.[input.name];
-      const initialValue = existingArgument ?? input.default;
-
-      return {
-        key: input.name,
-        value: initialValue ?? "",
-        initialValue: initialValue ?? "",
-        inputSpec: input,
-        isRemoved: initialValue === undefined,
-      } as ArgumentInput;
-    }) ?? [];
+  const argumentInputs = getArgumentInputs(taskSpec);
 
   const [currentArguments, setCurrentArguments] =
     useState<ArgumentInput[]>(argumentInputs);

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/utils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/utils.ts
@@ -1,0 +1,37 @@
+import type { ArgumentInput } from "@/types/arguments";
+import type { TaskSpec } from "@/utils/componentSpec";
+
+export const getArgumentInputs = (taskSpec: TaskSpec) => {
+  const componentSpec = taskSpec.componentRef.spec;
+
+  const argumentInputs =
+    componentSpec?.inputs?.map((input) => {
+      const existingArgument = taskSpec.arguments?.[input.name];
+      const initialValue = existingArgument ?? input.default;
+
+      /*
+        * Some notes on the logic of the ArgumentInput:
+        * [key] - This is used internally by React to keep track of the Input Component. Must be unique.
+        * [value] - This is the value of the argument. It cannot be undefined due to React's rules around controlled components.
+        * [initialValue] - This is the initial value of the argument when the Editor is opened. Immutable. It is used to determine if the argument has been changed during the current editing session.
+        * [inputSpec] - These are some general constants for the argument. Immutable. It is used to display the argument name and type in the UI.
+        * [isRemoved] - This is used to remove unwanted arguments from the Task Spec, as specified by the user. This is essentially used in place of an "undefined" input, since React requires an empty string for controlled components.
+
+        * Note that "undefined" and "empty string" are treated differently in the task spec, but we can only use "empty string" in the UI due to React's rules around controlled components.
+        * The difference is best seen in a required argument with a linked node:
+        *   - The connection will disappear and the connection point turn red when the node is removed, since it is required. This is what the "Remove" button is for.
+        *   - An empty string is a valid input and will result in the connection being severed, but the connection point will not turn red. This is what the "Reset to Default" button is for.
+        *   - A severed connection cannot be reconnected in the argument editor once applied and must be redrawn on the graph.
+      */
+
+      return {
+        key: input.name,
+        value: initialValue ?? "",
+        initialValue: initialValue ?? "",
+        inputSpec: input,
+        isRemoved: initialValue === undefined,
+      } as ArgumentInput;
+    }) ?? [];
+
+  return argumentInputs;
+};

--- a/src/services/pipelineRunService.ts
+++ b/src/services/pipelineRunService.ts
@@ -42,9 +42,12 @@ export const copyRunToPipeline = async (
   }
 
   try {
-    const cleanComponentSpec = JSON.parse(JSON.stringify(componentSpec));
+    const cleanComponentSpec = structuredClone(componentSpec);
 
-    if (cleanComponentSpec.implementation?.graph?.tasks) {
+    if (
+      "graph" in cleanComponentSpec.implementation &&
+      cleanComponentSpec.implementation?.graph?.tasks
+    ) {
       Object.values(cleanComponentSpec.implementation.graph.tasks).forEach(
         (task: any) => {
           if (task.annotations && "status" in task.annotations) {


### PR DESCRIPTION
Duplicate tasks using `structuredClone` instead of JSON transform.
ArgumentsSection and ArgumentsEditorDialog now organize argument info in the same way via a shared utility.

No change to app functionality