### PR TITLE
Dropped components yaml now appear on canvas

### DIFF
--- a/src/hooks/useComponentUploader.tsx
+++ b/src/hooks/useComponentUploader.tsx
@@ -4,12 +4,16 @@ import useImportComponent from "@/hooks/useImportComponent";
 import useToastNotification from "@/hooks/useToastNotification";
 
 interface useComponentUploaderProps {
-  onImportSuccess?: (content: string) => void;
+  onImportSuccess?: (
+    content: string,
+    dropEvent?: DragEvent<HTMLDivElement>,
+  ) => void;
 }
 
-const useComponentUploader = ({
-  onImportSuccess,
-}: useComponentUploaderProps) => {
+const useComponentUploader = (
+  readOnly = false,
+  { onImportSuccess }: useComponentUploaderProps,
+) => {
   const notify = useToastNotification();
 
   const { onImportFromFile } = useImportComponent({
@@ -21,7 +25,10 @@ const useComponentUploader = ({
     },
   });
 
-  const handleFileUpload = async (file: File) => {
+  const handleFileUpload = async (
+    file: File,
+    dropEvent?: DragEvent<HTMLDivElement>,
+  ) => {
     if (!file.name.endsWith(".yaml")) {
       notify("Only YAML files are supported", "error");
       return;
@@ -37,7 +44,7 @@ const useComponentUploader = ({
 
       try {
         await onImportFromFile(content as string);
-        onImportSuccess?.(content as string);
+        onImportSuccess?.(content as string, dropEvent);
       } catch (error) {
         notify((error as Error).message, "error");
       }
@@ -50,9 +57,15 @@ const useComponentUploader = ({
     event.preventDefault();
     const files = event.dataTransfer?.files;
     if (files && files.length > 0) {
-      handleFileUpload(files[0]);
+      handleFileUpload(files[0], event);
     }
   };
+
+  if (readOnly) {
+    return {
+      handleDrop: () => {},
+    };
+  }
 
   return {
     handleDrop,

--- a/src/hooks/useImportComponent.ts
+++ b/src/hooks/useImportComponent.ts
@@ -2,13 +2,13 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
 
 import {
-  addComponentToListByText,
+  addComponentToListByTextWithDuplicateCheck,
   addComponentToListByUrl,
 } from "@/utils/componentStore";
 import { USER_COMPONENTS_LIST_NAME } from "@/utils/constants";
 
 interface ImportComponentProps {
-  successCallback?: () => void;
+  successCallback?: (wasExisting?: boolean) => void;
   errorCallback?: (error: Error) => void;
 }
 
@@ -60,16 +60,16 @@ const useImportComponent = ({
           throw new Error("No file content provided");
         }
 
-        // Use the existing addComponentToListByText function
-        const componentFileEntry = await addComponentToListByText(
+        await addComponentToListByTextWithDuplicateCheck(
           USER_COMPONENTS_LIST_NAME,
           fileContent,
         );
+
         // Invalidate the userComponents query to refresh the sidebar
         queryClient.invalidateQueries({ queryKey: ["userComponents"] });
 
         successCallback?.();
-        return componentFileEntry;
+        return;
       } catch (error) {
         console.error("Error importing component from file:", error);
         errorCallback?.(new Error("Error importing component from file"));


### PR DESCRIPTION
When a user drops a component.yaml on the canvas we now add the component to the canvas as well.

Some of the code lives in the FlowCanvas.tsx file, which will be moved out in a later effort to clean up that file.

Note: There will be another PR that checks if the node shares a name, but not the exact content, with another and prompts the user to replace, create new, or cancel. 


https://github.com/user-attachments/assets/186f035c-3ba8-4324-8b9d-ab6e9ef4e558

