### PR TITLE
Highlight Input/Output Handles

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
@@ -168,6 +168,7 @@ const TaskNodeCard = ({
           <TaskNodeInputs
             inputs={inputs}
             invalidArguments={invalidArguments}
+            taskId={taskId}
             values={values}
             condensed={condensed}
             expanded={expandedInputs}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeOutputs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeOutputs.tsx
@@ -65,6 +65,7 @@ export function TaskNodeOutputs({
         outputsWithTaskInput.map((output, i) => (
           <OutputHandle
             key={output.name}
+            nodeId={nodeId}
             output={output}
             value={
               outputs.length > 1 && i === 0
@@ -78,8 +79,9 @@ export function TaskNodeOutputs({
           {outputs.map((output) => (
             <OutputHandle
               key={output.name}
+              nodeId={nodeId}
               output={output}
-              onClick={handleIOClicked}
+              onLabelClick={handleIOClicked}
             />
           ))}
           {condensed && (


### PR DESCRIPTION
Makes I/O handles (the circles) selectable and implements a framework to trigger a callback when selected (currently no callback is given). When selected the handle and label will highlight blue. Note that clicking on the label will open the argument editor as per existing behaviour.

Additionally, introduces an `active` state to Handles, making them highlight when an active connection is being made involving them.

Finally, fixes a big that led to inconsistent behaviour when clicking on Inputs vs Outputs.

This PR is intended to be a stepping stone that follows #299, with the intention of eventually allowing the component library to be filtered when a node is selected or active.

![image](https://github.com/user-attachments/assets/64c1d49e-e013-4e6e-8dc4-8e254fa58155)


https://github.com/user-attachments/assets/1fe4e2d6-b187-498d-a0f7-0cd16ed8b248

