### PR TITLE
Fixes rendering of artifacts that are long

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/ioCell.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/ioCell.tsx
@@ -78,7 +78,7 @@ const IoCell = ({ io, artifacts }: IoCellProps) => {
     <Collapsible key={io.name}>
       <div className="flex flex-col gap-3 py-3 border rounded-md relative z-10 bg-white">
         <div className="flex justify-between px-3 gap-2">
-          <div className="flex-1 min-w-[33%] flex-shrink-0">
+          <div className="flex-1 min-w-auto flex-shrink-0">
             <Tooltip
               delayDuration={300}
               open={isTooltipOpen}


### PR DESCRIPTION
This is a fix for how the artifacts cell renders.

Before (you can see the text overflows)
<img width="544" alt="Screenshot 2025-06-09 at 2 42 28 PM" src="https://github.com/user-attachments/assets/209f2ad4-c729-4662-aecb-402fd6c8a852" />

After:
<img width="539" alt="Screenshot 2025-06-09 at 2 43 10 PM" src="https://github.com/user-attachments/assets/34d85a72-3bfd-4c3c-b51e-7edac37b944f" />

Also if the name is long
<img width="552" alt="Screenshot 2025-06-09 at 2 43 55 PM" src="https://github.com/user-attachments/assets/3a5a03fe-d8b7-401d-9e5e-51805bb83881" />

If the name is long but there is no artifact

<img width="526" alt="Screenshot 2025-06-09 at 2 46 03 PM" src="https://github.com/user-attachments/assets/2195e219-24a1-4fe6-9222-b14ae5928cab" />

If the name is long and so is the artifact
<img width="533" alt="Screenshot 2025-06-09 at 2 45 10 PM" src="https://github.com/user-attachments/assets/87da7c9e-8d8d-4427-9294-80e379d95298" />
