### PR TITLE
Quick fixes to TaskCard UX

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeInputs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeInputs.tsx
@@ -34,10 +34,6 @@ export function TaskNodeInputs({
       "taskOutput" in (values[input.name] as object),
   );
 
-  if (inputsWithTaskOutput.length === 0) {
-    inputsWithTaskOutput.push(inputs[0]);
-  }
-
   const handleBackgroundClick = useCallback(
     (e: MouseEvent) => {
       if (condensed && onBackgroundClick) {
@@ -50,7 +46,14 @@ export function TaskNodeInputs({
 
   if (!inputs.length) return null;
 
+  if (inputsWithTaskOutput.length === 0) {
+    inputsWithTaskOutput.push(inputs[0]);
+  }
+
   const hiddenInputs = inputs.length - inputsWithTaskOutput.length;
+  if (hiddenInputs < 1) {
+    condensed = false;
+  }
 
   const hiddenInvalidArguments = invalidArguments.filter(
     (invalidArgument) =>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeOutputs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeOutputs.tsx
@@ -29,10 +29,6 @@ export function TaskNodeOutputs({
     ),
   );
 
-  if (outputsWithTaskInput.length === 0) {
-    outputsWithTaskInput.push(outputs[0]);
-  }
-
   const handleBackgroundClick = useCallback(
     (e: MouseEvent) => {
       if (condensed && onBackgroundClick) {
@@ -45,7 +41,14 @@ export function TaskNodeOutputs({
 
   if (!outputs.length) return null;
 
+  if (outputsWithTaskInput.length === 0) {
+    outputsWithTaskInput.push(outputs[0]);
+  }
+
   const hiddenOutputs = outputs.length - outputsWithTaskInput.length;
+  if (hiddenOutputs < 1) {
+    condensed = false;
+  }
 
   return (
     <div


### PR DESCRIPTION
Two super-quick fixes to task cards:

1. fixes for app crash when a card has no inputs of outputs
2. fixes a card being expandable when all fields are already displayed