### PR TITLE
Prevent TaskNodes from being connected to themselves

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -277,6 +277,8 @@ const FlowCanvas = ({
 
   const onConnect = useCallback(
     (connection: Connection) => {
+      if (connection.source === connection.target) return;
+
       const updatedGraphSpec = handleConnection(graphSpec, connection);
       updateGraphSpec(updatedGraphSpec);
     },


### PR DESCRIPTION
Prevents an Input Handle from being connected to an Output Handle on the same node.

Note: only blocks drawing the connection on the graph - the user can still choose to manually enter the connection in the arguments editor