### PR TITLE
Fix incorrect key for Python Code Download

### DIFF
--- a/src/components/shared/TaskDetails/Details.tsx
+++ b/src/components/shared/TaskDetails/Details.tsx
@@ -66,8 +66,11 @@ const TaskDetails = ({
     useCopyToClipboard(componentDigest);
 
   const canonicalUrl = componentSpec?.metadata?.annotations?.canonical_location;
-  const pythonOriginalCode =
-    componentSpec?.metadata?.annotations?.original_python_code || "";
+  const pythonOriginalCode = (componentSpec?.metadata?.annotations
+    ?.original_python_code ||
+    componentSpec?.metadata?.annotations?.python_original_code) as
+    | string
+    | undefined;
 
   const stringToPythonCodeDownload = () => {
     if (!pythonOriginalCode) return;


### PR DESCRIPTION
Fixes an issue where the Python download button was not appearing when it should be.

The download button will now appear for the annotation keys `original_python_code` and `python_original_code`