### PR TITLE
Move Sidebar to left of Screen

### DIFF
--- a/src/components/Editor/PipelineEditor.tsx
+++ b/src/components/Editor/PipelineEditor.tsx
@@ -51,6 +51,7 @@ const PipelineEditor = () => {
 
   return (
     <ComponentLibraryProvider>
+      <FlowSidebar />
       <div className="reactflow-wrapper">
         <FlowCanvas {...flowConfig}>
           <MiniMap position="bottom-left" pannable />
@@ -61,7 +62,6 @@ const PipelineEditor = () => {
           <Background gap={GRID_SIZE} className="bg-slate-50!" />
         </FlowCanvas>
       </div>
-      <FlowSidebar />
     </ComponentLibraryProvider>
   );
 };

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsInput.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsInput.tsx
@@ -80,7 +80,7 @@ export const AnnotationsInput = ({
           config?.enableQuantity ? handleQuantitySelectChange : onChange
         }
       >
-        <SelectTrigger className={cn("w-40 min-w-fit", className)}>
+        <SelectTrigger className={cn("w-24 max-24", className)}>
           <SelectValue placeholder={"Select " + placeholder} />
         </SelectTrigger>
         <SelectContent>
@@ -143,6 +143,7 @@ export const AnnotationsInput = ({
         <QuantityInput
           annotation={config.annotation}
           annotations={annotations}
+          disabled={!getAnnotationKey(config.annotation, annotations)}
           onChange={onChange}
         />
       )}
@@ -158,10 +159,12 @@ export const AnnotationsInput = ({
 const QuantityInput = ({
   annotation,
   annotations,
+  disabled,
   onChange,
 }: {
   annotation: string;
   annotations: Annotations;
+  disabled: boolean;
   onChange: (value: string) => void;
 }) => {
   const handleValueInputChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -178,7 +181,8 @@ const QuantityInput = ({
         type="number"
         value={getAnnotationValue(annotation, annotations)}
         onChange={handleValueInputChange}
-        className="w-16"
+        className="w-12 [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+        disabled={disabled}
       />
     </div>
   );

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/TaskConfigurationSheet.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfigurationSheet/TaskConfigurationSheet.tsx
@@ -80,7 +80,7 @@ const TaskConfigurationSheet = ({
       <SheetTrigger asChild>{trigger}</SheetTrigger>
       <SheetContent
         side="right"
-        className="!w-[528px] !max-w-[528px] shadow-none"
+        className="!w-[512px] !max-w-[512px] shadow-none"
         style={{
           top: TOP_NAV_HEIGHT + "px",
           height: sheetHeight + "px",

--- a/src/components/shared/ReactFlow/FlowSidebar/FlowSidebar.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/FlowSidebar.tsx
@@ -6,7 +6,7 @@ import SettingsAndActions from "./sections/SettingsAndActions";
 
 const FlowSidebar = () => {
   return (
-    <Sidebar side="right" className="mt-[56px] h-[calc(100vh-56px)]">
+    <Sidebar side="left" className="mt-[56px] h-[calc(100vh-56px)]">
       <SidebarContent className="gap-0">
         <SettingsAndActions />
         <RunsAndSubmission />

--- a/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
@@ -88,8 +88,8 @@ const ComponentMarkup = ({
             <div className="flex-1 flex">
               <div className="flex gap-2 w-full items-center">
                 <File className="h-4 w-4 text-gray-400 flex-shrink-0" />
-                <div className="flex flex-col">
-                  <span className="truncate text-xs text-gray-800 max-w-[200px]">
+                <div className="flex flex-col w-[160px]">
+                  <span className="truncate text-xs text-gray-800">
                     {displayName}
                   </span>
                   <span className="truncate text-[10px] text-gray-500 max-w-[100px] font-mono">

--- a/src/components/shared/ReactFlow/FlowSidebar/components/ImportComponent.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ImportComponent.tsx
@@ -123,7 +123,7 @@ const ImportComponent = () => {
           <div className="w-full">
             <SidebarMenuButton className="cursor-pointer w-full">
               <Component />
-              <span className="font-normal">Import Component</span>
+              <span className="font-normal text-xs">Import Component</span>
             </SidebarMenuButton>
           </div>
         </DialogTrigger>

--- a/src/components/shared/ReactFlow/FlowSidebar/components/UserComponentItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/UserComponentItem.tsx
@@ -73,11 +73,11 @@ const UserComponentItem = ({
       draggable
       onDragStart={onDragStart}
     >
-      <div className="flex-1 flex">
-        <div className="flex gap-2 w-full">
+      <div className="flex-1 flex w-full">
+        <div className="flex gap-2 w-fit">
           <File className="h-4 w-4 text-gray-400 flex-shrink-0" />
-          <div className="flex flex-col">
-            <span className="truncate text-xs text-gray-800 max-w-[200px]">
+          <div className="flex flex-col w-[160px]">
+            <span className="truncate text-xs text-gray-800">
               {displayName}
             </span>
             <span className="truncate text-[10px] text-gray-500 max-w-[100px] font-mono">

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -24,8 +24,8 @@ import { cn } from "@/lib/utils";
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
-const SIDEBAR_WIDTH = "20rem";
-const SIDEBAR_WIDTH_MOBILE = "18rem";
+const SIDEBAR_WIDTH = "16rem";
+const SIDEBAR_WIDTH_MOBILE = "12rem";
 const SIDEBAR_WIDTH_ICON = "3rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "b";
 


### PR DESCRIPTION
Moves the Sidebar to the left of the screen and resizes it to make it a little narrower. The TaskConfigSheet is also made narrower so that together both components don't consume too much screen space.

Further follow-ups will be needed to refine some internal component sizes, such as the annotation editor input boxes.
Also, a follow-up will be needed to turn the ConfigSheet into a more permanent right-side sidebar that holds element/node/spec context.

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/71617e9e-16b8-4ec3-b8ac-530682de60de" />
