### PR TITLE
Add TAB HintNode when dragging new Edges

### DIFF
--- a/src/components/Editor/PipelineEditor.tsx
+++ b/src/components/Editor/PipelineEditor.tsx
@@ -4,7 +4,7 @@ import {
   Background,
   MiniMap,
   type ReactFlowProps,
-  useStore,
+  useStoreApi,
 } from "@xyflow/react";
 import { useCallback, useEffect, useState } from "react";
 
@@ -30,7 +30,7 @@ const GRID_SIZE = 10;
 
 const PipelineEditor = () => {
   const { componentSpec, isLoading } = useComponentSpec();
-  const nodes = useStore((store) => store.nodes);
+  const store = useStoreApi();
 
   const [flowConfig, setFlowConfig] = useState<ReactFlowProps>({
     snapGrid: [GRID_SIZE, GRID_SIZE],
@@ -54,10 +54,14 @@ const PipelineEditor = () => {
   useEffect(() => {
     // Fixing issue where a React error would cause all node positions to be recorded as undefined (`!<tag:yaml.org,2002:js/undefined>`)
     // nodes should never be undefined in normal situation.
-    if (nodes !== undefined && nodes.length > 0) {
-      savePipelineSpecToSessionStorage(componentSpec, nodes);
+    const currentNodes = store
+      .getState()
+      .nodes.filter((node) => node.type === "task");
+
+    if (currentNodes !== undefined && currentNodes.length > 0) {
+      savePipelineSpecToSessionStorage(componentSpec, currentNodes);
     }
-  }, [componentSpec, nodes]);
+  }, [componentSpec]);
 
   return (
     <ContextPanelProvider

--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -18,6 +18,7 @@ import useComponentSpecToEdges from "@/hooks/useComponentSpecToEdges";
 import useComponentUploader from "@/hooks/useComponentUploader";
 import useConfirmationDialog from "@/hooks/useConfirmationDialog";
 import { useCopyPaste } from "@/hooks/useCopyPaste";
+import { useHintNode } from "@/hooks/useHintNode";
 import useToastNotification from "@/hooks/useToastNotification";
 import { cn } from "@/lib/utils";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
@@ -39,6 +40,7 @@ import { getDeleteConfirmationDetails } from "./ConfirmationDialogs/DeleteConfir
 import { getReplaceConfirmationDetails } from "./ConfirmationDialogs/ReplaceConfirmation";
 import { getUpgradeConfirmationDetails } from "./ConfirmationDialogs/UpgradeComponent";
 import SmoothEdge from "./Edges/SmoothEdge";
+import HintNode from "./GhostNode/HintNode";
 import SelectionToolbar from "./SelectionToolbar";
 import TaskNode from "./TaskNode/TaskNode";
 import type { NodesAndEdges } from "./types";
@@ -57,6 +59,7 @@ import { updateNodePositions } from "./utils/updateNodePosition";
 
 const nodeTypes: Record<string, ComponentType<any>> = {
   task: TaskNode,
+  hint: HintNode,
 };
 const edgeTypes: Record<string, ComponentType<any>> = {
   customEdge: SmoothEdge,
@@ -72,6 +75,15 @@ const FlowCanvas = ({
     useComponentSpec();
   const { edges, onEdgesChange } = useComponentSpecToEdges(componentSpec);
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
+
+  const tabHintNode = useHintNode({
+    key: "TAB",
+    hint: "cycle valid components",
+  });
+
+  const allNodes = useMemo(() => {
+    return tabHintNode ? [...nodes, tabHintNode] : nodes;
+  }, [nodes, tabHintNode]);
 
   const {
     handlers: confirmationHandlers,
@@ -141,7 +153,7 @@ const FlowCanvas = ({
   );
 
   const selectedNodes = useMemo(
-    () => nodes.filter((node) => node.selected),
+    () => nodes.filter((node) => node.selected && node.type === "task"),
     [nodes],
   );
   const selectedEdges = useMemo(
@@ -717,7 +729,7 @@ const FlowCanvas = ({
     <>
       <ReactFlow
         {...rest}
-        nodes={nodes}
+        nodes={allNodes}
         edges={edges}
         minZoom={0.01}
         maxZoom={3}

--- a/src/components/shared/ReactFlow/FlowCanvas/GhostNode/HintNode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/GhostNode/HintNode.tsx
@@ -1,0 +1,71 @@
+import { type NodeProps, useReactFlow } from "@xyflow/react";
+import { memo, type PropsWithChildren, useMemo } from "react";
+
+import { cn } from "@/lib/utils";
+import type { HintNodeData } from "@/types/hintNode";
+
+const HintNode = ({ data }: NodeProps) => {
+  const { getZoom } = useReactFlow();
+  const typedData = useMemo(() => data as HintNodeData, [data]);
+
+  const zoom = getZoom();
+
+  const baseOffsetX = 12;
+  const baseOffsetY = -12;
+
+  const minScale = 0.8;
+  const maxScale = 10;
+  const scaleMultiplier = 1.2;
+
+  const scale = Math.min(maxScale, Math.max(minScale, scaleMultiplier / zoom));
+
+  const transformOrigin =
+    typedData.side === "left" ? "center right" : "center left";
+
+  const offsetX =
+    (typedData.side === "left" ? -baseOffsetX : baseOffsetX) * scale;
+  const offsetY = baseOffsetY; // No scaling needed for Y because the transformY origin is set to center
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 opacity-90 select-none pointer-events-none",
+        typedData.side === "left" ? "-translate-x-full" : "",
+      )}
+      style={{
+        transform: `translate(${offsetX}px, ${offsetY}px) scale(${scale})`,
+        transformOrigin,
+      }}
+    >
+      <KeyboardKey>{typedData.key}</KeyboardKey>
+      <div className="text-gray-600/60 text-xs font-normal select-none opacity-70">
+        {typedData.hint}
+      </div>
+    </div>
+  );
+};
+
+export default memo(HintNode);
+
+const KeyboardKey = ({ children }: PropsWithChildren) => {
+  return (
+    <div
+      className="
+      px-2 py-1 
+      border border-gray-300/60 
+      rounded-md 
+      shadow-md 
+      backdrop-blur-sm
+      text-gray-700/80
+      text-xs 
+      font-medium 
+      select-none
+      bg-gradient-to-br
+      from-white/80
+      to-gray-100/70
+      "
+    >
+      {children}
+    </div>
+  );
+};

--- a/src/components/shared/ReactFlow/FlowSidebar/sections/SettingsAndActions.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/SettingsAndActions.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "@tanstack/react-router";
-import { useStore } from "@xyflow/react";
+import { useStoreApi } from "@xyflow/react";
 import { FileDownIcon, FileUpIcon, Save, SaveAll } from "lucide-react";
 import { useEffect, useMemo, useRef } from "react";
 
@@ -26,7 +26,8 @@ const SettingsAndActions = ({ isOpen }: { isOpen: boolean }) => {
   const { savePipeline } = useSavePipeline(componentSpec);
   const notify = useToastNotification();
   const navigate = useNavigate();
-  const nodes = useStore((store) => store.nodes);
+  const store = useStoreApi();
+  const nodes = store.getState().nodes.filter((node) => node.type === "task");
 
   const notifyPipelineSaved = (name: string) => {
     notify(`Pipeline saved as "${name}"`, "success");
@@ -60,7 +61,14 @@ const SettingsAndActions = ({ isOpen }: { isOpen: boolean }) => {
 
   const componentText = useMemo(() => {
     try {
-      if (!componentSpecRef.current || !nodes.length) {
+      if (
+        !componentSpecRef.current ||
+        !nodes.length ||
+        !("graph" in componentSpecRef.current.implementation) ||
+        !componentSpecRef.current?.implementation?.graph?.tasks ||
+        Object.keys(componentSpecRef.current?.implementation?.graph?.tasks)
+          .length !== nodes.length
+      ) {
         return "";
       }
 

--- a/src/hooks/useHintNode.ts
+++ b/src/hooks/useHintNode.ts
@@ -1,0 +1,73 @@
+import type { Node } from "@xyflow/react";
+import { useConnection } from "@xyflow/react";
+import { useMemo } from "react";
+
+import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
+import type { HintNodeData } from "@/types/hintNode";
+
+const HINT_NODE_ID = "hint-node";
+
+export const useHintNode = ({ key, hint }: { key: string; hint: string }) => {
+  const connectionTo = useConnection((connection) => connection.to);
+  const connectionToHandle = useConnection((connection) => connection.toHandle);
+  const connectionFromHandle = useConnection(
+    (connection) => connection.fromHandle,
+  );
+  const connectionInProgress = useConnection(
+    (connection) => connection.inProgress,
+  );
+
+  const { searchResult } = useComponentLibrary();
+
+  const hasResults = useMemo(
+    () =>
+      searchResult &&
+      (searchResult.components.standard.length > 0 ||
+        searchResult.components.user.length > 0),
+    [searchResult],
+  );
+
+  const isOverValidTarget = useMemo(
+    () => connectionInProgress && connectionToHandle !== null,
+    [connectionInProgress, connectionToHandle],
+  );
+
+  const shouldShowHint = useMemo(
+    () => connectionInProgress && hasResults && !isOverValidTarget,
+    [connectionInProgress, hasResults, isOverValidTarget],
+  );
+
+  const hintNode = useMemo((): Node<HintNodeData> | null => {
+    if (!shouldShowHint || !connectionTo) {
+      return null;
+    }
+
+    const side = connectionFromHandle?.id?.includes("input") ? "left" : "right";
+
+    return {
+      id: HINT_NODE_ID + "-" + key,
+      type: "hint",
+      position: connectionTo,
+      data: {
+        key,
+        hint,
+        side,
+      },
+      draggable: false,
+      selectable: false,
+      deletable: false,
+      connectable: false,
+      focusable: false,
+      zIndex: 1000,
+    };
+  }, [
+    shouldShowHint,
+    connectionTo?.x,
+    connectionTo?.y,
+    connectionFromHandle,
+    key,
+    hint,
+  ]);
+
+  return hintNode;
+};

--- a/src/types/hintNode.ts
+++ b/src/types/hintNode.ts
@@ -1,0 +1,5 @@
+export interface HintNodeData extends Record<string, unknown> {
+  key: string;
+  hint: string;
+  side: "left" | "right";
+}


### PR DESCRIPTION
Follows #315 as a step toward adding new components when dragging edges.

Adds a new HintNode type that appears when dragging an edge. The `key` and `hint` text can be customized via a new useHintNode hook.

This PR utilizes it to add a little "tab" key indicator next to the cursor when the user is dragging an edge and the handle they dragged from has produced search results. The intent in a future PR is to allow the user to press tab to cycle through these results and create a node on the spot when they release the edge. 

Since this currently isn't implement an override has been added to hide the Tab Indicator for now. So, essentially this PR just lays some groundwork for future implementation.


https://github.com/user-attachments/assets/05715dee-20ec-4148-9d9a-626972e6b16a

