### PR TITLE
Convert GhostNodes into TaskNodes when dropped

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/utils/addAndConnectNode.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/addAndConnectNode.ts
@@ -1,0 +1,159 @@
+import type { Connection, Handle } from "@xyflow/react";
+
+import type {
+  ComponentReference,
+  ComponentSpec,
+  TaskSpec,
+  TypeSpecType,
+} from "@/utils/componentSpec";
+import { DEFAULT_NODE_DIMENSIONS } from "@/utils/constants";
+import {
+  inputNameToNodeId,
+  nodeIdToTaskId,
+  outputNameToNodeId,
+  taskIdToNodeId,
+} from "@/utils/nodes/nodeIdUtils";
+
+import addTask from "./addTask";
+import { handleConnection } from "./handleConnection";
+
+type AddAndConnectNodeParams = {
+  componentRef: ComponentReference;
+  fromHandle: Handle | null;
+  position: { x: number; y: number };
+  componentSpec: ComponentSpec;
+};
+
+export function addAndConnectNode({
+  componentRef,
+  fromHandle,
+  position,
+  componentSpec,
+}: AddAndConnectNodeParams): ComponentSpec {
+  // 1. Add the new node
+  const taskSpec: TaskSpec = {
+    annotations: {},
+    componentRef: { ...componentRef },
+  };
+
+  if (!("graph" in componentSpec.implementation)) {
+    return componentSpec;
+  }
+
+  const oldGraphSpec = componentSpec.implementation.graph;
+
+  const fromHandleId = fromHandle?.id;
+  const fromHandleType = fromHandleId?.startsWith("input") ? "input" : "output";
+
+  const adjustedPosition =
+    fromHandleType === "input"
+      ? { ...position, x: position.x - DEFAULT_NODE_DIMENSIONS.w }
+      : position;
+
+  const newComponentSpec = addTask(
+    "task",
+    taskSpec,
+    adjustedPosition,
+    componentSpec,
+  );
+
+  // 2. Find the new node
+  if (!("graph" in newComponentSpec.implementation)) {
+    return newComponentSpec;
+  }
+
+  const graphSpec = newComponentSpec.implementation.graph;
+
+  const newTaskId = Object.keys(graphSpec.tasks).find(
+    (key) => !(key in oldGraphSpec.tasks),
+  );
+
+  if (!newTaskId) {
+    return newComponentSpec;
+  }
+
+  const newNodeId = taskIdToNodeId(newTaskId);
+
+  // 3. Determine the connection data type and find the first matching handle on the new node
+  if (!fromHandle) {
+    return newComponentSpec;
+  }
+
+  const fromTaskId = nodeIdToTaskId(fromHandle.nodeId);
+
+  const fromTaskSpec = graphSpec.tasks[fromTaskId];
+  const fromComponentSpec = fromTaskSpec?.componentRef.spec;
+
+  const fromNodeId = fromHandle.nodeId;
+
+  const fromHandleName = fromHandleId?.replace(`${fromHandleType}_`, "");
+
+  let connectionType: TypeSpecType | undefined;
+  if (fromHandleType === "input") {
+    connectionType = fromComponentSpec?.inputs?.find(
+      (io) => io.name === fromHandleName,
+    )?.type;
+  } else if (fromHandleType === "output") {
+    connectionType = fromComponentSpec?.outputs?.find(
+      (io) => io.name === fromHandleName,
+    )?.type;
+  }
+
+  // Find the first matching handle on the new node
+  const toHandleType = fromHandleType === "input" ? "output" : "input";
+
+  let targetHandleId: string | undefined;
+
+  if (toHandleType === "input") {
+    const handleName = componentRef.spec?.inputs?.find(
+      (io) => io.type === connectionType,
+    )?.name;
+    if (!handleName) {
+      return newComponentSpec;
+    }
+
+    targetHandleId = inputNameToNodeId(handleName);
+  } else if (toHandleType === "output") {
+    const handleName = componentRef.spec?.outputs?.find(
+      (io) => io.type === connectionType,
+    )?.name;
+    if (!handleName) {
+      return newComponentSpec;
+    }
+
+    targetHandleId = outputNameToNodeId(handleName);
+  }
+
+  // 4. Build a Connection object and use handleConnection to add the edge
+  if (fromNodeId && fromHandleId && targetHandleId) {
+    const isReversedConnection =
+      fromHandleType === "input" && toHandleType === "output";
+    const connection: Connection = isReversedConnection
+      ? // Drawing from an input handle to a new output handle
+        {
+          source: newNodeId,
+          sourceHandle: targetHandleId,
+          target: fromNodeId,
+          targetHandle: fromHandleId,
+        }
+      : // Drawing from an output handle to a new input handle
+        {
+          source: fromNodeId,
+          sourceHandle: fromHandleId,
+          target: newNodeId,
+          targetHandle: targetHandleId,
+        };
+
+    const updatedGraphSpec = handleConnection(graphSpec, connection);
+
+    return {
+      ...newComponentSpec,
+      implementation: {
+        ...newComponentSpec.implementation,
+        graph: updatedGraphSpec,
+      },
+    };
+  }
+
+  return newComponentSpec;
+}

--- a/src/hooks/useTaskNodeDimensions.ts
+++ b/src/hooks/useTaskNodeDimensions.ts
@@ -2,8 +2,8 @@ import { useMemo } from "react";
 
 import type { TaskNodeDimensions } from "@/types/taskNode";
 import type { TaskSpec } from "@/utils/componentSpec";
+import { DEFAULT_NODE_DIMENSIONS } from "@/utils/constants";
 
-const DEFAULT_DIMENSIONS = { w: 300, h: undefined };
 const MIN_WIDTH = 150;
 const MIN_HEIGHT = 100;
 
@@ -43,13 +43,14 @@ export function useTaskNodeDimensions(taskSpec: TaskSpec): TaskNodeDimensions {
     return annotatedDimensions
       ? {
           w: Math.max(
-            parseInt(annotatedDimensions.width ?? "") || DEFAULT_DIMENSIONS.w,
+            parseInt(annotatedDimensions.width ?? "") ||
+              DEFAULT_NODE_DIMENSIONS.w,
             MIN_WIDTH,
           ),
           h:
             Math.max(parseInt(annotatedDimensions.height ?? ""), MIN_HEIGHT) ||
-            DEFAULT_DIMENSIONS.h,
+            DEFAULT_NODE_DIMENSIONS.h,
         }
-      : DEFAULT_DIMENSIONS;
+      : DEFAULT_NODE_DIMENSIONS;
   }, [taskSpec]);
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -45,6 +45,8 @@ export const USER_COMPONENTS_LIST_NAME = "user_components";
 export const TOP_NAV_HEIGHT = 56; // px
 export const BOTTOM_FOOTER_HEIGHT = 30; // px
 
+export const DEFAULT_NODE_DIMENSIONS = { w: 300, h: undefined };
+
 export enum ComponentSearchFilter {
   NAME = "Name",
   INPUTNAME = "Input Name",


### PR DESCRIPTION
## Description

Final PR in the UX Quest to add TaskNodes while dragging edges.

This PR adds a new method `addAndConnectNode` that adds a new node to the canvas and connects it to a given handle. This is used to implement the ability for Ghost Nodes to become fully functional Task Nodes when dropped on the canvas.

## Related Issue and Pull requests

Follows #342

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)


https://github.com/user-attachments/assets/a365f736-7351-4336-9588-7bdd03a53efa

https://github.com/user-attachments/assets/9c165cac-74b5-422f-9402-e1d1156d140a


## Additional Comments

There will be a followup PR somewhere in the future where the ghost node is positioned with the edge pointing into the correct handle, rather than the top left/right.
