### PR TITLE
Scaffold pipeline details

### DIFF
--- a/src/components/Editor/PipelineDetails.tsx
+++ b/src/components/Editor/PipelineDetails.tsx
@@ -1,0 +1,106 @@
+import { Frown, Network } from "lucide-react";
+
+import { Spinner } from "@/components/ui/spinner";
+import type { ComponentSpec } from "@/utils/componentSpec";
+
+import RenamePipeline from "./RenamePipeline";
+
+type PipelineDetailsProps = {
+  componentSpec: ComponentSpec;
+  isLoading?: boolean;
+};
+
+export const PipelineDetails = ({
+  componentSpec,
+  isLoading,
+}: PipelineDetailsProps) => {
+  if (!componentSpec) {
+    <div className="flex flex-col gap-8 items-center justify-center h-full">
+      <Frown className="w-12 h-12 text-gray-500" />
+      <div className="text-gray-500">Error loading pipeline details.</div>
+    </div>;
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <Spinner className="mr-2" />
+        <p className="text-gray-500">Loading pipeline details...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-2">
+      <div className="flex items-center gap-2 mb-8">
+        <Network className="w-6 h-6 text-gray-500 rotate-270" />
+        <h2 className="text-lg font-semibold">
+          {componentSpec.name ?? "Unnamed Pipeline"}
+        </h2>
+        <RenamePipeline componentSpec={componentSpec} />
+      </div>
+      <div className="flex flex-col gap-4 px-2">
+        {componentSpec.description && (
+          <div>
+            <h3 className="text-md font-medium mb-1">Description</h3>
+            <div className="text-sm text-gray-700 whitespace-pre-line">
+              {componentSpec.description}
+            </div>
+          </div>
+        )}
+        <div>
+          <h3 className="text-md font-medium mb-1">Inputs</h3>
+          {componentSpec.inputs && componentSpec.inputs.length > 0 ? (
+            <ul className="list-disc list-inside text-sm text-gray-800">
+              {componentSpec.inputs.map((input) => (
+                <li key={input.name}>
+                  <span className="font-semibold">{input.name}</span>
+                  {input.type && (
+                    <span className="ml-2 text-gray-500">
+                      ({typeof input.type === "string" ? input.type : "object"})
+                    </span>
+                  )}
+                  {input.description && (
+                    <div className="text-xs text-gray-500 ml-4">
+                      {input.description}
+                    </div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="text-xs text-gray-400">No inputs</div>
+          )}
+        </div>
+        <div>
+          <h3 className="text-md font-medium mb-1">Outputs</h3>
+          {componentSpec.outputs && componentSpec.outputs.length > 0 ? (
+            <ul className="list-disc list-inside text-sm text-gray-800">
+              {componentSpec.outputs.map((output) => (
+                <li key={output.name}>
+                  <span className="font-semibold">{output.name}</span>
+                  {output.type && (
+                    <span className="ml-2 text-gray-500">
+                      (
+                      {typeof output.type === "string" ? output.type : "object"}
+                      )
+                    </span>
+                  )}
+                  {output.description && (
+                    <div className="text-xs text-gray-500 ml-4">
+                      {output.description}
+                    </div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="text-xs text-gray-400">No outputs</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PipelineDetails;

--- a/src/components/Editor/PipelineEditor.tsx
+++ b/src/components/Editor/PipelineEditor.tsx
@@ -24,11 +24,12 @@ import { ContextPanelProvider } from "@/providers/ContextPanelProvider";
 import { savePipelineSpecToSessionStorage } from "@/utils/storage";
 
 import { ContextPanel } from "../shared/ContextPanel/ContextPanel";
+import PipelineDetails from "./PipelineDetails";
 
 const GRID_SIZE = 10;
 
 const PipelineEditor = () => {
-  const { componentSpec } = useComponentSpec();
+  const { componentSpec, isLoading } = useComponentSpec();
   const nodes = useStore((store) => store.nodes);
 
   const [flowConfig, setFlowConfig] = useState<ReactFlowProps>({
@@ -59,7 +60,11 @@ const PipelineEditor = () => {
   }, [componentSpec, nodes]);
 
   return (
-    <ContextPanelProvider>
+    <ContextPanelProvider
+      defaultContent={
+        <PipelineDetails componentSpec={componentSpec} isLoading={isLoading} />
+      }
+    >
       <ComponentLibraryProvider>
         <FlowSidebar />
         <ResizablePanelGroup direction="horizontal">

--- a/src/components/Editor/RenamePipeline.tsx
+++ b/src/components/Editor/RenamePipeline.tsx
@@ -2,28 +2,24 @@ import { useLocation, useNavigate } from "@tanstack/react-router";
 import { Edit3 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { useLoadComponentSpecAndDetailsFromId } from "@/hooks/useLoadComponentSpecDetailsFromId";
 import useToastNotification from "@/hooks/useToastNotification";
-import { APP_ROUTES, EDITOR_PATH, RUNS_BASE_PATH } from "@/routes/router";
+import { APP_ROUTES } from "@/routes/router";
+import type { ComponentSpec } from "@/utils/componentSpec";
 import { renameComponentFileInList } from "@/utils/componentStore";
 import { USER_PIPELINES_LIST_NAME } from "@/utils/constants";
 
 import { PipelineNameDialog } from "../shared/Dialogs";
 
-const EditorMenu = () => {
+type RenamePipelineProps = {
+  componentSpec: ComponentSpec;
+};
+
+export const RenamePipeline = ({ componentSpec }: RenamePipelineProps) => {
   const notify = useToastNotification();
   const navigate = useNavigate();
 
   const location = useLocation();
   const pathname = location.pathname;
-  const { componentSpec, isLoading } = useLoadComponentSpecAndDetailsFromId();
-
-  const isEditor = pathname.includes(EDITOR_PATH);
-  const isRun = pathname.includes(RUNS_BASE_PATH);
-
-  if (!isEditor && !isRun && !isLoading) {
-    return null;
-  }
 
   const title = componentSpec?.name;
 
@@ -51,25 +47,20 @@ const EditorMenu = () => {
   };
 
   return (
-    <div className="flex items-center gap-1">
-      <span className="text-white text-sm font-bold">{title}</span>
-      {isEditor && (
-        <PipelineNameDialog
-          trigger={
-            <Button>
-              <Edit3 />
-            </Button>
-          }
-          title="Name Pipeline"
-          description="Unsaved pipeline changes will be lost."
-          initialName={title ?? ""}
-          onSubmit={handleTitleUpdate}
-          submitButtonText="Update Title"
-          isSubmitDisabled={isSubmitDisabled}
-        />
-      )}
-    </div>
+    <PipelineNameDialog
+      trigger={
+        <Button variant="ghost">
+          <Edit3 />
+        </Button>
+      }
+      title="Name Pipeline"
+      description="Unsaved pipeline changes will be lost."
+      initialName={title ?? ""}
+      onSubmit={handleTitleUpdate}
+      submitButtonText="Update Title"
+      isSubmitDisabled={isSubmitDisabled}
+    />
   );
 };
 
-export default EditorMenu;
+export default RenamePipeline;

--- a/src/components/PipelineRun/PipelineRunPage.tsx
+++ b/src/components/PipelineRun/PipelineRunPage.tsx
@@ -8,13 +8,17 @@ import {
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
 import { ComponentLibraryProvider } from "@/providers/ComponentLibraryProvider";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { ContextPanelProvider } from "@/providers/ContextPanelProvider";
 
 import { ContextPanel } from "../shared/ContextPanel/ContextPanel";
+import RunDetails from "./RunDetails";
 
 const GRID_SIZE = 10;
 
 const PipelineRunPage = () => {
+  const { runId } = useComponentSpec();
+
   const [flowConfig, setFlowConfig] = useState<ReactFlowProps>({
     snapGrid: [GRID_SIZE, GRID_SIZE],
     snapToGrid: true,
@@ -34,7 +38,7 @@ const PipelineRunPage = () => {
   );
 
   return (
-    <ContextPanelProvider>
+    <ContextPanelProvider defaultContent={<RunDetails runId={runId} />}>
       <ComponentLibraryProvider>
         <ResizablePanelGroup direction="horizontal">
           <ResizablePanel>

--- a/src/components/PipelineRun/RunDetails.tsx
+++ b/src/components/PipelineRun/RunDetails.tsx
@@ -1,0 +1,130 @@
+import { Frown, Videotape } from "lucide-react";
+
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  countTaskStatuses,
+  fetchExecutionInfo,
+  getRunStatus,
+} from "@/services/executionService";
+
+import { StatusIcon } from "../shared/Status";
+
+type RunDetailsProps = {
+  runId?: string;
+};
+
+export const RunDetails = ({ runId = "" }: RunDetailsProps) => {
+  const { data, isLoading, error } = fetchExecutionInfo(runId);
+  const { details, state } = data;
+
+  const componentSpec = details?.task_spec?.componentRef?.spec;
+
+  if (error || !details || !state || !componentSpec) {
+    return (
+      <div className="flex flex-col gap-8 items-center justify-center h-full">
+        <Frown className="w-12 h-12 text-gray-500" />
+        <div className="text-gray-500">Error loading run details.</div>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <Spinner className="mr-2" />
+        <p className="text-gray-500">Loading run details...</p>
+      </div>
+    );
+  }
+
+  const statusCounts = countTaskStatuses(details, state);
+  const runStatus = getRunStatus(statusCounts);
+
+  return (
+    <div className="p-2">
+      <div className="flex items-center gap-2 mb-8">
+        <Videotape className="w-6 h-6 text-gray-500" />
+        <h2 className="text-lg font-semibold">
+          {componentSpec.name ?? "Unnamed Pipeline"}
+        </h2>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span>
+              <StatusIcon status={runStatus} />
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>
+            <span>{`Run ${runStatus.toLowerCase()}`}</span>
+          </TooltipContent>
+        </Tooltip>
+      </div>
+      <div className="flex flex-col gap-4 px-2">
+        {componentSpec.description && (
+          <div>
+            <h3 className="text-md font-medium mb-1">Description</h3>
+            <div className="text-sm text-gray-700 whitespace-pre-line">
+              {componentSpec.description}
+            </div>
+          </div>
+        )}
+        <div>
+          <h3 className="text-md font-medium mb-1">Inputs</h3>
+          {componentSpec.inputs && componentSpec.inputs.length > 0 ? (
+            <ul className="list-disc list-inside text-sm text-gray-800">
+              {componentSpec.inputs.map((input) => (
+                <li key={input.name}>
+                  <span className="font-semibold">{input.name}</span>
+                  {input.type && (
+                    <span className="ml-2 text-gray-500">
+                      ({typeof input.type === "string" ? input.type : "object"})
+                    </span>
+                  )}
+                  {input.description && (
+                    <div className="text-xs text-gray-500 ml-4">
+                      {input.description}
+                    </div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="text-xs text-gray-400">No inputs</div>
+          )}
+        </div>
+        <div>
+          <h3 className="text-md font-medium mb-1">Outputs</h3>
+          {componentSpec.outputs && componentSpec.outputs.length > 0 ? (
+            <ul className="list-disc list-inside text-sm text-gray-800">
+              {componentSpec.outputs.map((output) => (
+                <li key={output.name}>
+                  <span className="font-semibold">{output.name}</span>
+                  {output.type && (
+                    <span className="ml-2 text-gray-500">
+                      (
+                      {typeof output.type === "string" ? output.type : "object"}
+                      )
+                    </span>
+                  )}
+                  {output.description && (
+                    <div className="text-xs text-gray-500 ml-4">
+                      {output.description}
+                    </div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="text-xs text-gray-400">No outputs</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RunDetails;

--- a/src/components/layout/AppMenu.tsx
+++ b/src/components/layout/AppMenu.tsx
@@ -2,11 +2,14 @@ import { Link } from "@tanstack/react-router";
 
 import CloneRunButton from "@/components/shared/CloneRunButton";
 import ImportPipeline from "@/components/shared/ImportPipeline";
+import { useLoadComponentSpecAndDetailsFromId } from "@/hooks/useLoadComponentSpecDetailsFromId";
 
 import NewPipelineButton from "../shared/NewPipelineButton";
-import EditorMenu from "./EditorMenu";
 
 const AppMenu = () => {
+  const { componentSpec } = useLoadComponentSpecAndDetailsFromId();
+  const title = componentSpec?.name;
+
   return (
     <div className="w-full bg-stone-900 p-2">
       <div className="flex justify-between items-center w-3/4 mx-auto">
@@ -18,7 +21,7 @@ const AppMenu = () => {
               className="w-10 h-10 filter invert cursor-pointer"
             />
           </Link>
-          <EditorMenu />
+          <span className="text-white text-sm font-bold">{title}</span>
         </div>
         <div className="flex flex-row gap-2 items-center">
           <CloneRunButton />

--- a/src/providers/ContextPanelProvider.tsx
+++ b/src/providers/ContextPanelProvider.tsx
@@ -1,4 +1,10 @@
-import { createContext, type ReactNode, useContext, useState } from "react";
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
 
 type ContextPanelContextType = {
   content: ReactNode;
@@ -40,6 +46,10 @@ export const ContextPanelProvider = ({
       setKey(DEFAULT_KEY);
     }
   };
+
+  useEffect(() => {
+    setContentState(defaultContent);
+  }, [defaultContent]);
 
   return (
     <ContextPanelContext.Provider

--- a/src/routes/Editor/Editor.tsx
+++ b/src/routes/Editor/Editor.tsx
@@ -1,18 +1,17 @@
 import "@/styles/editor.css";
 
 import { DndContext } from "@dnd-kit/core";
-import { useLocation } from "@tanstack/react-router";
 import { ReactFlowProvider } from "@xyflow/react";
 
 import PipelineEditor from "@/components/Editor/PipelineEditor";
+import { useLoadComponentSpecAndDetailsFromId } from "@/hooks/useLoadComponentSpecDetailsFromId";
 import { ComponentSpecProvider } from "@/providers/ComponentSpecProvider";
 
 const Editor = () => {
-  const location = useLocation();
-  const experimentName = location.pathname.split("/").pop() || "";
+  const { componentSpec } = useLoadComponentSpecAndDetailsFromId();
 
   return (
-    <ComponentSpecProvider experimentName={experimentName}>
+    <ComponentSpecProvider spec={componentSpec}>
       <div className="dndflow">
         <DndContext>
           <ReactFlowProvider>

--- a/src/routes/PipelineRun/PipelineRun.tsx
+++ b/src/routes/PipelineRun/PipelineRun.tsx
@@ -78,7 +78,7 @@ const PipelineRun = () => {
   );
 
   return (
-    <ComponentSpecProvider spec={componentSpecWithExecutionIds}>
+    <ComponentSpecProvider spec={componentSpecWithExecutionIds} runId={id}>
       <div className="dndflow">
         <DndContext>
           <ReactFlowProvider>


### PR DESCRIPTION
## Description

Behind-the-scenes work and scaffolding of a basic details panel for the Pipeline Editor and Runs page.

Edit Pipeline name functionality moved to the PipelineDetails panel.
Run status indicator shown in RunDetails panel.

## Related Issue and Pull requests

Follows https://github.com/Cloud-Pipelines/pipeline-studio-app/pull/355

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

Pipeline Editor:
![image](https://github.com/user-attachments/assets/974d8662-fb97-44db-94f9-a2f984ff6aab)

Run Page:
![image](https://github.com/user-attachments/assets/675dbb9e-4d52-457b-9794-e1341491cb03)


## Additional Comments

Issues will be created to outline the full set of content desired in each of the two new details panels.
