### PR TITLE
[BugFix] Can no longer delete nodes in run view

### DIFF
--- a/src/components/Editor/PipelineEditor.tsx
+++ b/src/components/Editor/PipelineEditor.tsx
@@ -58,6 +58,7 @@ const PipelineEditor = () => {
           <MiniMap position="bottom-left" pannable />
           <FlowControls
             style={{ marginLeft: "224px", marginBottom: "24px" }}
+            config={flowConfig}
             updateConfig={updateFlowConfig}
             showInteractive
           />

--- a/src/components/PipelineRun/PipelineRunPage.tsx
+++ b/src/components/PipelineRun/PipelineRunPage.tsx
@@ -12,7 +12,7 @@ const PipelineRunPage = () => {
     snapToGrid: true,
     panOnDrag: true,
     selectionOnDrag: false,
-    nodesDraggable: false,
+    nodesDraggable: true,
     fitView: true,
   });
 
@@ -33,6 +33,7 @@ const PipelineRunPage = () => {
           <MiniMap position="bottom-left" pannable />
           <FlowControls
             style={{ marginLeft: "224px", marginBottom: "24px" }}
+            config={flowConfig}
             updateConfig={updateFlowConfig}
             showInteractive={false}
           />

--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -516,6 +516,10 @@ const FlowCanvas = ({
   };
 
   const handleBeforeDelete = async (params: NodesAndEdges) => {
+    if (readOnly) {
+      return false;
+    }
+
     if (params.nodes.length === 0 && params.edges.length === 0) {
       return false;
     }

--- a/src/components/shared/ReactFlow/FlowControls/FlowControls.tsx
+++ b/src/components/shared/ReactFlow/FlowControls/FlowControls.tsx
@@ -14,15 +14,17 @@ import { useCallback, useState } from "react";
 import { cn } from "@/lib/utils";
 
 interface FlowControlsProps extends ControlProps {
+  config: ReactFlowProps;
   updateConfig: (config: Partial<ReactFlowProps>) => void;
 }
 
 export default function FlowControls({
+  config,
   updateConfig,
   ...props
 }: FlowControlsProps) {
   const [multiSelectActive, setMultiSelectActive] = useState(false);
-  const [lockActive, setLockActive] = useState(true);
+  const [lockActive, setLockActive] = useState(!config.nodesDraggable);
 
   const onClickMultiSelect = useCallback(() => {
     updateConfig({

--- a/src/providers/ComponentSpecProvider.tsx
+++ b/src/providers/ComponentSpecProvider.tsx
@@ -52,11 +52,13 @@ export const ComponentSpecProvider = ({
   experimentName,
   spec,
   initialTaskStatusMap,
+  readOnly = false,
   children,
 }: {
   experimentName?: string;
   spec?: ComponentSpec;
   initialTaskStatusMap?: Map<string, string>;
+  readOnly?: boolean;
   children: ReactNode;
 }) => {
   const [componentSpec, setComponentSpec] = useState<ComponentSpec>(
@@ -113,6 +115,10 @@ export const ComponentSpecProvider = ({
 
   const saveComponentSpec = useCallback(
     async (name: string) => {
+      if (readOnly) {
+        return;
+      }
+
       componentSpec.name = name;
 
       const componentText = componentSpecToYaml(componentSpec);


### PR DESCRIPTION
## Description

Noticed today I can delete nodes in run view. Also switched the default interactive state to true for runs, so you can move nodes right off the bat.

## Related Issue and Pull requests

n/a

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
