### PR TITLE
Add Pipeline Details to Pipeline Editor Context Panel

### DIFF
--- a/src/components/layout/AppFooter.tsx
+++ b/src/components/layout/AppFooter.tsx
@@ -1,5 +1,6 @@
 import {
   ABOUT_URL,
+  BOTTOM_FOOTER_HEIGHT,
   GIT_COMMIT,
   GIT_REPO_URL,
   GIVE_FEEDBACK_URL,
@@ -8,7 +9,10 @@ import {
 
 function AppFooter() {
   return (
-    <footer className="footer w-full h-[30px] p-1 text-center bg-gray-50">
+    <footer
+      className="footer w-full p-1 text-center bg-gray-50"
+      style={{ height: `${BOTTOM_FOOTER_HEIGHT}px` }}
+    >
       <div className="inline-block">
         <a
           href={ABOUT_URL}

--- a/src/components/layout/AppMenu.tsx
+++ b/src/components/layout/AppMenu.tsx
@@ -3,6 +3,7 @@ import { Link } from "@tanstack/react-router";
 import CloneRunButton from "@/components/shared/CloneRunButton";
 import ImportPipeline from "@/components/shared/ImportPipeline";
 import { useLoadComponentSpecAndDetailsFromId } from "@/hooks/useLoadComponentSpecDetailsFromId";
+import { TOP_NAV_HEIGHT } from "@/utils/constants";
 
 import NewPipelineButton from "../shared/NewPipelineButton";
 
@@ -11,7 +12,10 @@ const AppMenu = () => {
   const title = componentSpec?.name;
 
   return (
-    <div className="w-full bg-stone-900 p-2">
+    <div
+      className="w-full bg-stone-900 p-2"
+      style={{ height: `${TOP_NAV_HEIGHT}px` }}
+    >
       <div className="flex justify-between items-center w-3/4 mx-auto">
         <div className="flex flex-row gap-2 items-center">
           <Link to="/">

--- a/src/components/shared/CodeViewer.tsx
+++ b/src/components/shared/CodeViewer.tsx
@@ -150,6 +150,18 @@ const CodeViewer = ({
     onFullscreenChange(true);
   }, [code, language, title, openFullscreen, onFullscreenChange]);
 
+  const syntaxHighlighter = useMemo(
+    () => (
+      <CodeSyntaxHighlighter
+        code={code}
+        language={language}
+        height="calc(100% - 48px)"
+        fontSize="0.75rem"
+      />
+    ),
+    [code, language],
+  );
+
   return (
     <div className="border rounded-md h-full overflow-hidden hide-scrollbar bg-slate-900">
       <div className="flex justify-between items-center p-2 sticky top-0 z-10 bg-slate-800">
@@ -166,12 +178,7 @@ const CodeViewer = ({
           <Maximize2 className="size-4" />
         </Button>
       </div>
-      <CodeSyntaxHighlighter
-        code={code}
-        language={language}
-        height="calc(100% - 48px)"
-        fontSize="0.75rem"
-      />
+      {syntaxHighlighter}
     </div>
   );
 };

--- a/src/components/shared/ContextPanel/ContextPanel.tsx
+++ b/src/components/shared/ContextPanel/ContextPanel.tsx
@@ -1,6 +1,16 @@
 import { useContextPanel } from "@/providers/ContextPanelProvider";
+import { BOTTOM_FOOTER_HEIGHT, TOP_NAV_HEIGHT } from "@/utils/constants";
 
 export const ContextPanel = () => {
   const { content } = useContextPanel();
-  return <div className="h-full p-2">{content}</div>;
+  return (
+    <div
+      className="h-full p-2 bg-sidebar text-sidebar-foreground overflow-y-auto"
+      style={{
+        maxHeight: `calc(100vh - ${TOP_NAV_HEIGHT}px - ${BOTTOM_FOOTER_HEIGHT}px)`,
+      }}
+    >
+      {content}
+    </div>
+  );
 };

--- a/src/components/shared/ReactFlow/FlowSidebar/sections/RunsAndSubmission.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/RunsAndSubmission.tsx
@@ -33,7 +33,7 @@ const RunsAndSubmission = ({ isOpen }: { isOpen: boolean }) => {
             showExecutionId: false,
             showCreatedAt: true,
             showTaskStatusBar: true,
-            showStatusCounts: true,
+            showStatusCounts: "shorthand",
           }}
         />
       )),

--- a/src/components/shared/Status/StatusText.tsx
+++ b/src/components/shared/Status/StatusText.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@/lib/utils";
 import type { TaskStatusCounts } from "@/services/executionService";
 
 const StatusText = ({
@@ -8,7 +9,12 @@ const StatusText = ({
   shorthand?: boolean;
 }) => {
   return (
-    <div className="text-xs text-gray-500 mt-1">
+    <div
+      className={cn(
+        "text-xs text-gray-500 items-center",
+        !shorthand && "flex gap-2",
+      )}
+    >
       {Object.entries(statusCounts).map(([key, count]) => {
         if (key === "total") return;
 
@@ -39,7 +45,7 @@ const StatusText = ({
           );
         }
         return (
-          <span key={key} className="flex items-center gap-1">
+          <span key={key} className="flex items-center">
             <span className={statusColor}>
               {count} {statusText.trim()}
             </span>

--- a/src/components/shared/TaskDetails/Implementation.tsx
+++ b/src/components/shared/TaskDetails/Implementation.tsx
@@ -1,4 +1,5 @@
 import yaml from "js-yaml";
+import { useMemo } from "react";
 
 import CodeViewer from "@/components/shared/CodeViewer";
 import type { ComponentSpec } from "@/utils/componentSpec";
@@ -17,15 +18,19 @@ const TaskImplementation = ({
 }: TaskImplementationProps) => {
   const filename = getComponentFilename(componentSpec);
 
+  const code = useMemo(() => {
+    return yaml.dump(componentSpec, {
+      lineWidth: 80,
+      noRefs: true,
+      indent: 2,
+    });
+  }, [componentSpec]);
+
   return (
     <>
       {componentSpec?.implementation ? (
         <CodeViewer
-          code={yaml.dump(componentSpec, {
-            lineWidth: 80,
-            noRefs: true,
-            indent: 2,
-          })}
+          code={code}
           language="yaml"
           title={`${displayName} Implementation (read-only)`}
           filename={filename}

--- a/src/hooks/useExecutionStatusQuery.ts
+++ b/src/hooks/useExecutionStatusQuery.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchExecutionStatus } from "@/services/executionService";
+
+export function useExecutionStatusQuery(executionId: string) {
+  return useQuery({
+    queryKey: ["executionStatus", executionId],
+    queryFn: () => fetchExecutionStatus(executionId),
+    staleTime: 60 * 1000, // 1 minute
+    enabled: !!executionId,
+  });
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -43,6 +43,7 @@ export const PIPELINE_RUNS_STORE_NAME = "pipeline_runs";
 export const USER_COMPONENTS_LIST_NAME = "user_components";
 
 export const TOP_NAV_HEIGHT = 56; // px
+export const BOTTOM_FOOTER_HEIGHT = 30; // px
 
 export enum ComponentSearchFilter {
   NAME = "Name",


### PR DESCRIPTION
## Description

Populates the right-side context panel in the Pipeline Editor with pipeline details such as file metadata, digest, annotations, execution history and YAML.

Also includes minor updates to the RunOverview and Status update components.

## Related Issue and Pull requests

Follows #402 

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/63efd151-bbba-46c0-8103-90dc2eb46f49)


## Additional Comments

Note this is a detailed outline of content that could be in the panel. As we refine what we want in there the design will improve and we will likely start breaking sections out into their own component. This will also present the opportunity to clean up some of the AI-generated html.

Note: in future, we may want to consider the merit of having run submission details still in the left sidebar now that we have them on the right & have more space there.

Second note: this introduce a potential performance/network issue which will be addressed as a priority in a followup. See  https://github.com/Shopify/oasis-frontend/issues/111
