### PR TITLE
Remove unneeded Delete Component button

### DIFF
--- a/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
@@ -1,4 +1,3 @@
-import { useQueryClient } from "@tanstack/react-query";
 import { File } from "lucide-react";
 import type { DragEvent } from "react";
 import { useCallback, useMemo } from "react";
@@ -13,12 +12,9 @@ import {
 } from "@/components/ui/tooltip";
 import useComponentFromUrl from "@/hooks/useComponentFromUrl";
 import { cn } from "@/lib/utils";
-import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
 import { EMPTY_GRAPH_COMPONENT_SPEC } from "@/providers/ComponentSpecProvider";
 import { type ComponentItemFromUrlProps } from "@/types/componentLibrary";
 import type { ComponentReference, TaskSpec } from "@/utils/componentSpec";
-import { deleteComponentFileFromList } from "@/utils/componentStore";
-import { USER_COMPONENTS_LIST_NAME } from "@/utils/constants";
 import { getComponentName } from "@/utils/getComponentName";
 
 interface ComponentMarkupProps {
@@ -32,15 +28,7 @@ const ComponentMarkup = ({
   isLoading,
   error,
 }: ComponentMarkupProps) => {
-  const { checkIfUserComponent } = useComponentLibrary();
-  const queryClient = useQueryClient();
-
-  const { name: fileName, spec, digest, url } = component;
-
-  const isUserComponent = useMemo(
-    () => checkIfUserComponent(component),
-    [component, checkIfUserComponent],
-  );
+  const { spec, digest, url } = component;
 
   const displayName = useMemo(
     () => getComponentName({ spec, url }),
@@ -70,19 +58,6 @@ const ComponentMarkup = ({
     },
     [component],
   );
-
-  // Delete User Components
-  const handleDelete = useCallback(async () => {
-    try {
-      await deleteComponentFileFromList(
-        USER_COMPONENTS_LIST_NAME,
-        fileName ?? "",
-      );
-      queryClient.invalidateQueries({ queryKey: ["userComponents"] });
-    } catch (error) {
-      console.error("Error deleting component:", error);
-    }
-  }, [fileName, queryClient]);
 
   return (
     <Tooltip delayDuration={500}>
@@ -122,7 +97,6 @@ const ComponentMarkup = ({
                   <ComponentDetailsDialog
                     displayName={displayName}
                     component={component}
-                    onDelete={isUserComponent ? handleDelete : undefined}
                   />
                 </div>
               </div>


### PR DESCRIPTION
## Description

User components are now removed via the "unstar" feature so the delete button in the modal is no longer needed.

## Related Issue and Pull requests

Closes https://github.com/Cloud-Pipelines/pipeline-studio-app/issues/311

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

n/a

## Additional Comments

n/a
