### PR TITLE
Users can update pipeline inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,9 +86,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",
-    "@testing-library/react": "^16.3.0",
-    "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^24.0.13",
     "@types/react": "^19.0.8",

--- a/src/components/Editor/InputValueEditor/FormFields/FormFields.test.tsx
+++ b/src/components/Editor/InputValueEditor/FormFields/FormFields.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { deselectAllNodes } from "@/utils/flowUtils";
+
+type MockNode = {
+  id: string;
+  selected: boolean;
+  position: { x: number; y: number };
+  data: Record<string, unknown>;
+};
+
+const makeNode = (id: string, selected: boolean = false): MockNode => ({
+  id,
+  selected,
+  position: { x: 0, y: 0 },
+  data: {},
+});
+
+describe("deselectAllNodes", () => {
+  it("deselects all nodes when all are selected", () => {
+    const nodes = [makeNode("1", true), makeNode("2", true)];
+    const result = deselectAllNodes(nodes);
+    expect(result.every((node) => node.selected === false)).toBe(true);
+  });
+
+  it("deselects all nodes when some are selected", () => {
+    const nodes = [makeNode("1", true), makeNode("2", false)];
+    const result = deselectAllNodes(nodes as any);
+    expect(result.every((node) => node.selected === false)).toBe(true);
+  });
+
+  it("leaves all nodes unselected if none are selected", () => {
+    const nodes = [makeNode("1", false), makeNode("2", false)];
+    const result = deselectAllNodes(nodes as any);
+    expect(result.every((node) => node.selected === false)).toBe(true);
+  });
+
+  it("returns an empty array if given an empty array", () => {
+    const result = deselectAllNodes([]);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/components/Editor/InputValueEditor/FormFields/FormFields.tsx
+++ b/src/components/Editor/InputValueEditor/FormFields/FormFields.tsx
@@ -1,0 +1,123 @@
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+
+const FormField = ({
+  label,
+  id,
+  children,
+}: {
+  label: string;
+  id: string;
+  children: React.ReactNode;
+}) => (
+  <div className="flex flex-col">
+    <label htmlFor={id} className="text-xs text-muted-foreground mb-1">
+      {label}
+    </label>
+    {children}
+  </div>
+);
+
+const NameField = ({
+  inputName,
+  onNameChange,
+  error,
+  disabled,
+}: {
+  inputName: string;
+  onNameChange: (value: string) => void;
+  error?: string | null;
+  disabled?: boolean;
+}) => (
+  <FormField label="Name" id={`input-name-${inputName}`}>
+    <Input
+      id={`input-name-${inputName}`}
+      disabled={disabled}
+      type="text"
+      value={inputName}
+      onChange={(e) => onNameChange(e.target.value)}
+      className={`text-sm ${error ? "border-red-500 focus:border-red-500" : ""}`}
+    />
+    {error && <div className="text-xs text-red-500 mt-1">{error}</div>}
+  </FormField>
+);
+
+const TextField = ({
+  inputValue,
+  onInputChange,
+  placeholder,
+  disabled,
+  inputName,
+}: {
+  inputValue: string;
+  onInputChange: (value: string) => void;
+  placeholder: string;
+  disabled: boolean;
+  inputName: string;
+}) => (
+  <FormField label="Default Value" id={`input-value-${inputName}`}>
+    <Textarea
+      id={`input-value-${inputName}`}
+      value={inputValue}
+      onChange={(e) => onInputChange(e.target.value)}
+      placeholder={placeholder}
+      disabled={disabled}
+      className="text-sm"
+    />
+  </FormField>
+);
+
+const OptionalField = ({
+  inputName,
+  onInputChange,
+  disabled = false,
+  inputValue,
+}: {
+  inputName: string;
+  onInputChange: (checked: boolean) => void;
+  disabled?: boolean;
+  inputValue: boolean;
+}) => (
+  <div className="flex items-center gap-2 mt-2">
+    <Checkbox
+      id={`input-optional-${inputName}`}
+      checked={inputValue}
+      onCheckedChange={onInputChange}
+      disabled={disabled}
+      className="h-5 w-5 border-gray-300 focus:ring-2 focus:ring-primary-500 transition-colors"
+    />
+    <label
+      htmlFor={`input-optional-${inputName}`}
+      className="text-sm text-muted-foreground cursor-pointer select-none"
+    >
+      Set as optional
+    </label>
+  </div>
+);
+
+const TypeField = ({
+  inputValue,
+  onInputChange,
+  placeholder,
+  disabled,
+  inputName,
+}: {
+  inputValue: string;
+  onInputChange: (value: string) => void;
+  placeholder: string;
+  disabled?: boolean;
+  inputName: string;
+}) => (
+  <FormField label="Type" id={`input-type-${inputName}`}>
+    <Input
+      id={`input-type-${inputName}`}
+      value={inputValue}
+      onChange={(e) => onInputChange(e.target.value)}
+      placeholder={placeholder}
+      disabled={disabled}
+      className="text-sm"
+    />
+  </FormField>
+);
+export { NameField, OptionalField, TextField, TypeField };

--- a/src/components/Editor/InputValueEditor/FormFields/index.ts
+++ b/src/components/Editor/InputValueEditor/FormFields/index.ts
@@ -1,0 +1,2 @@
+export { NameField, OptionalField, TextField, TypeField } from "./FormFields";
+export { checkNameCollision } from "./utils";

--- a/src/components/Editor/InputValueEditor/FormFields/utils.ts
+++ b/src/components/Editor/InputValueEditor/FormFields/utils.ts
@@ -1,0 +1,15 @@
+import { type ComponentSpec } from "@/utils/componentSpec";
+
+export const checkNameCollision = (
+  newName: string,
+  currentOutputName: string,
+  componentSpec: ComponentSpec,
+  type: "inputs" | "outputs",
+) => {
+  if (!componentSpec[type]) return false;
+
+  // Check if any other output (not the current one) has the same name
+  return componentSpec[type].some(
+    (output) => output.name === newName && output.name !== currentOutputName,
+  );
+};

--- a/src/components/Editor/InputValueEditor/InputValueEditor.test.tsx
+++ b/src/components/Editor/InputValueEditor/InputValueEditor.test.tsx
@@ -1,0 +1,117 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { InputSpec } from "@/utils/componentSpec";
+
+import { InputValueEditor } from "./InputValueEditor";
+
+// Mock the ComponentSpecProvider
+vi.mock("@/providers/ComponentSpecProvider", () => ({
+  useComponentSpec: () => ({
+    componentSpec: {
+      inputs: [
+        { name: "TestInput", type: "String" },
+        { name: "ExistingInput", type: "String" },
+      ],
+      implementation: {
+        container: {
+          image: "test-image",
+        },
+      },
+    },
+    setComponentSpec: vi.fn(),
+  }),
+}));
+
+describe("InputValueEditor", () => {
+  const mockInput: InputSpec = {
+    name: "TestInput",
+    type: "String",
+    description: "A test input",
+    default: "default value",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("displays input description", () => {
+    render(<InputValueEditor input={mockInput} />);
+
+    const descriptionElements = screen.getAllByText("A test input");
+    expect(descriptionElements.length).toBeGreaterThan(0);
+    expect(descriptionElements[0]).toBeInTheDocument();
+  });
+
+  it("calls onChange when input value changes", () => {
+    render(<InputValueEditor input={mockInput} />);
+
+    const valueInput = screen.getByLabelText(
+      "Default Value",
+    ) as HTMLTextAreaElement;
+    fireEvent.change(valueInput, { target: { value: "new value" } });
+    fireEvent.blur(valueInput);
+  });
+
+  it("calls onNameChange when input name changes", () => {
+    render(<InputValueEditor input={mockInput} />);
+    const nameInput = screen.getAllByRole("textbox")[0] as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: "NewName" } });
+    fireEvent.blur(nameInput);
+  });
+
+  it("shows validation error when renaming to existing input name", () => {
+    render(<InputValueEditor input={mockInput} />);
+
+    const nameInput = screen.getAllByRole("textbox")[0] as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: "ExistingInput" } });
+
+    // Should show error message
+    expect(
+      screen.getByText("An input with this name already exists"),
+    ).toBeDefined();
+
+    // Input should have red border
+    expect(nameInput.className).toContain("border-red-500");
+  });
+
+  it("clears validation error when renaming to unique name", () => {
+    render(<InputValueEditor input={mockInput} />);
+
+    const nameInput = screen.getAllByRole("textbox")[0] as HTMLInputElement;
+
+    // First, create a collision
+    fireEvent.change(nameInput, { target: { value: "ExistingInput" } });
+    expect(
+      screen.getByText("An input with this name already exists"),
+    ).toBeDefined();
+
+    // Then, change to unique name
+    fireEvent.change(nameInput, { target: { value: "UniqueName" } });
+    expect(
+      screen.queryByText("An input with this name already exists"),
+    ).toBeNull();
+    expect(nameInput.className).not.toContain("border-red-500");
+  });
+
+  it("shows placeholder when no default value", () => {
+    const inputWithoutDefault: InputSpec = {
+      name: "NoDefaultInput",
+      type: "String",
+    };
+
+    render(<InputValueEditor input={inputWithoutDefault} />);
+
+    const valueInput = screen.getAllByRole("textbox")[1] as HTMLInputElement;
+    expect(valueInput.getAttribute("placeholder")).toBe(
+      "Enter NoDefaultInput...",
+    );
+  });
+
+  it("shows default value as placeholder when available", () => {
+    render(<InputValueEditor input={mockInput} />);
+
+    const valueInput = screen.getAllByRole("textbox")[1] as HTMLInputElement;
+    expect(valueInput.getAttribute("placeholder")).toBe("default value");
+  });
+});

--- a/src/components/Editor/InputValueEditor/InputValueEditor.tsx
+++ b/src/components/Editor/InputValueEditor/InputValueEditor.tsx
@@ -1,0 +1,179 @@
+import { useMemo, useState } from "react";
+
+import { updateInputNameOnComponentSpec } from "@/components/shared/ReactFlow/FlowCanvas/utils/updateInputNameOnComponentSpec";
+import { Button } from "@/components/ui/button";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+import { type InputSpec } from "@/utils/componentSpec";
+import { checkInputConnectionToRequiredFields } from "@/utils/inputConnectionUtils";
+
+import { checkNameCollision } from "./FormFields";
+import {
+  NameField,
+  OptionalField,
+  TextField,
+  TypeField,
+} from "./FormFields/FormFields";
+
+interface InputValueEditorProps {
+  input: InputSpec;
+  onSave?: () => void;
+  onCancel?: () => void;
+  disabled?: boolean;
+}
+
+export const InputValueEditor = ({
+  input,
+  onSave,
+  onCancel,
+  disabled = false,
+}: InputValueEditorProps) => {
+  const [inputValue, setInputValue] = useState(input.value || "");
+  const [inputName, setInputName] = useState(input.name);
+  const [inputType, setInputType] = useState(input.type?.toString() || "any");
+  const [inputOptional, setInputOptional] = useState(input.optional ?? true);
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const { componentSpec, setComponentSpec } = useComponentSpec();
+
+  // Check if this input is connected to any required fields
+  const { isConnectedToRequired, connectedFields } = useMemo(() => {
+    return checkInputConnectionToRequiredFields(input.name, componentSpec);
+  }, [input.name, componentSpec]);
+
+  // If connected to required fields, force optional to false and disable the field
+  const isOptionalDisabled = isConnectedToRequired || disabled;
+  const effectiveOptionalValue = isConnectedToRequired ? false : inputOptional;
+
+  const handleInputChange = (
+    oldName: string,
+    value: string,
+    newName: string,
+    optional: boolean,
+    type: string,
+  ) => {
+    if (!componentSpec.inputs) return;
+
+    const updatedInputs = componentSpec.inputs.map((componentInput) => {
+      if (componentInput.name === oldName) {
+        return {
+          ...componentInput,
+          value,
+          default: value,
+          name: newName,
+          optional,
+          type,
+        };
+      }
+      return componentInput;
+    });
+
+    const updatedComponentSpecValues = {
+      ...componentSpec,
+      inputs: updatedInputs,
+    };
+
+    return updateInputNameOnComponentSpec(
+      updatedComponentSpecValues,
+      oldName,
+      newName,
+    );
+  };
+
+  const handleValueChange = (value: string) => {
+    setInputValue(value);
+  };
+
+  const handleOptionalChange = (checked: boolean) => {
+    if (isConnectedToRequired) {
+      return;
+    }
+    setInputOptional(checked);
+  };
+
+  const handleTypeChange = (value: string) => {
+    setInputType(value);
+  };
+
+  const handleNameChange = (newName: string) => {
+    setInputName(newName);
+
+    if (checkNameCollision(newName, input.name, componentSpec, "inputs")) {
+      setValidationError("An input with this name already exists");
+      return;
+    }
+
+    setValidationError(null);
+  };
+  const handleSave = () => {
+    const updatedComponentSpecWithValues = handleInputChange(
+      input.name,
+      inputValue,
+      inputName,
+      effectiveOptionalValue,
+      inputType as string,
+    );
+
+    if (updatedComponentSpecWithValues) {
+      setComponentSpec(updatedComponentSpecWithValues);
+    }
+    onSave?.();
+  };
+
+  const placeholder = input.default || `Enter ${input.name}...`;
+
+  const handleCancel = () => {
+    onCancel?.();
+  };
+
+  return (
+    <div className="flex flex-col gap-3 p-4">
+      <div className="flex flex-col gap-3">
+        <h3 className="text-lg font-bold">{input.name}</h3>
+        <p className="text-sm text-gray-500">{input.description}</p>
+      </div>
+      <NameField
+        inputName={inputName}
+        onNameChange={handleNameChange}
+        error={validationError}
+        disabled={disabled}
+      />
+
+      <TextField
+        inputValue={inputValue}
+        onInputChange={handleValueChange}
+        placeholder={placeholder}
+        disabled={disabled}
+        inputName={input.name}
+      />
+
+      <TypeField
+        inputValue={inputType}
+        onInputChange={handleTypeChange}
+        placeholder="Type: Any"
+        disabled={disabled}
+        inputName={input.name}
+      />
+
+      <OptionalField
+        inputName={input.name}
+        onInputChange={handleOptionalChange}
+        inputValue={effectiveOptionalValue}
+        disabled={isOptionalDisabled}
+      />
+      {isConnectedToRequired && (
+        <div className="text-xs text-amber-600 bg-amber-50 p-2 rounded">
+          This input is connected to required fields:{" "}
+          {connectedFields.join(", ")}
+        </div>
+      )}
+
+      <div className="flex justify-end gap-2">
+        <Button variant="outline" onClick={handleCancel}>
+          Cancel
+        </Button>
+        <Button onClick={handleSave} disabled={!!validationError || disabled}>
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Editor/OutputNameEditor/OutputNameEditor.tsx
+++ b/src/components/Editor/OutputNameEditor/OutputNameEditor.tsx
@@ -1,0 +1,110 @@
+import { useCallback, useState } from "react";
+
+import { type OutputConnectedDetails } from "@/components/shared/ReactFlow/FlowCanvas/utils/getOutputConnectedDetails";
+import { updateOutputNameOnComponentSpec } from "@/components/shared/ReactFlow/FlowCanvas/utils/updateOutputNameOnComponentSpec";
+import { Button } from "@/components/ui/button";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+import { type OutputSpec } from "@/utils/componentSpec";
+
+import { checkNameCollision } from "../InputValueEditor/FormFields";
+import {
+  NameField,
+  TypeField,
+} from "../InputValueEditor/FormFields/FormFields";
+
+interface OutputNameEditorProps {
+  output: OutputSpec;
+  onNameChange?: (oldName: string, newName: string) => void;
+  onTypeChange?: (name: string, newType: string) => void;
+  onSave?: () => void;
+  connectedDetails: OutputConnectedDetails;
+  disabled?: boolean;
+  onCancel?: () => void;
+}
+
+export const OutputNameEditor = ({
+  output,
+  onSave,
+  onCancel,
+  disabled,
+  connectedDetails,
+}: OutputNameEditorProps) => {
+  const { setComponentSpec, componentSpec } = useComponentSpec();
+  const [outputName, setOutputName] = useState(output.name);
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const handleOutputNameChange = useCallback(
+    (oldName: string, newName: string) => {
+      if (!componentSpec.outputs) return null;
+
+      const updatedComponentSpec = updateOutputNameOnComponentSpec(
+        componentSpec,
+        oldName,
+        newName,
+      );
+
+      return updatedComponentSpec;
+    },
+    [componentSpec, setComponentSpec],
+  );
+
+  const handleNameChange = (value: string) => {
+    setOutputName(value);
+
+    if (checkNameCollision(value, output.name, componentSpec, "outputs")) {
+      setValidationError("An output with this name already exists");
+      return;
+    }
+
+    setValidationError(null);
+  };
+  const handleSave = () => {
+    const updatedComponentSpecWithValues = handleOutputNameChange(
+      output.name,
+      outputName,
+    );
+
+    if (updatedComponentSpecWithValues) {
+      setComponentSpec(updatedComponentSpecWithValues);
+    }
+    onSave?.();
+  };
+
+  return (
+    <div className="flex flex-col gap-3 p-4">
+      <div className="flex flex-col gap-3">
+        <h3 className="text-lg font-bold">{output.name}</h3>
+        {output.description && (
+          <p className="text-sm text-gray-500">{output.description}</p>
+        )}
+      </div>
+      <div className="flex gap-4">
+        <div className="flex-1">
+          <NameField
+            inputName={outputName}
+            onNameChange={handleNameChange}
+            disabled={disabled}
+            error={validationError}
+          />
+        </div>
+        <div className="w-36">
+          <TypeField
+            inputValue={connectedDetails.outputType || "Any"}
+            onInputChange={() => {}}
+            placeholder="Any"
+            disabled
+            inputName={output.name}
+          />
+        </div>
+      </div>
+      <div className="flex justify-end gap-2">
+        <Button variant="outline" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button onClick={handleSave} disabled={!!validationError || disabled}>
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Editor/OutputNameEditor/index.ts
+++ b/src/components/Editor/OutputNameEditor/index.ts
@@ -1,0 +1,1 @@
+export { OutputNameEditor } from "./OutputNameEditor";

--- a/src/components/PipelineRun/components/CancelPipelineRunButton.test.tsx
+++ b/src/components/PipelineRun/components/CancelPipelineRunButton.test.tsx
@@ -50,7 +50,7 @@ describe("<CancelPipelineRunButton/>", () => {
       renderWithQueryClient(<CancelPipelineRunButton runId={null} />);
 
       const button = screen.getByTestId("cancel-pipeline-run-button");
-      expect(button).toBeInTheDocument();
+      expect(button).toBeDefined();
     });
   });
 
@@ -64,14 +64,12 @@ describe("<CancelPipelineRunButton/>", () => {
       await act(() => fireEvent.click(button));
 
       // assert
-      expect(
-        screen.getByRole("heading", { name: "Cancel run" }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "Cancel run" })).toBeDefined();
       expect(
         screen.getByText(
           "The run will be scheduled for cancellation. This action cannot be undone.",
         ),
-      ).toBeInTheDocument();
+      ).toBeDefined();
     });
 
     test("closes confirmation dialog when cancel is clicked", async () => {
@@ -81,17 +79,13 @@ describe("<CancelPipelineRunButton/>", () => {
 
       // act
       await act(() => fireEvent.click(button));
-      expect(
-        screen.getByRole("heading", { name: "Cancel run" }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "Cancel run" })).toBeDefined();
 
       const cancelButton = screen.getByRole("button", { name: "Cancel" });
       await act(() => fireEvent.click(cancelButton));
 
       // assert
-      expect(
-        screen.queryByRole("heading", { name: "Cancel run" }),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByRole("heading", { name: "Cancel run" })).toBeNull();
     });
   });
 

--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -46,6 +46,7 @@ import { getUpgradeConfirmationDetails } from "./ConfirmationDialogs/UpgradeComp
 import SmoothEdge from "./Edges/SmoothEdge";
 import GhostNode from "./GhostNode/GhostNode";
 import HintNode from "./GhostNode/HintNode";
+import IONode from "./IONode/IONode";
 import SelectionToolbar from "./SelectionToolbar";
 import TaskNode from "./TaskNode/TaskNode";
 import type { NodesAndEdges } from "./types";
@@ -67,6 +68,8 @@ const nodeTypes: Record<string, ComponentType<any>> = {
   task: TaskNode,
   hint: HintNode,
   ghost: GhostNode,
+  input: IONode,
+  output: IONode,
 };
 const edgeTypes: Record<string, ComponentType<any>> = {
   customEdge: SmoothEdge,

--- a/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
@@ -1,0 +1,165 @@
+import { useLocation } from "@tanstack/react-router";
+import { Handle, Position, useReactFlow } from "@xyflow/react";
+import { memo, useCallback, useEffect } from "react";
+
+import { InputValueEditor } from "@/components/Editor/InputValueEditor/InputValueEditor";
+import { OutputNameEditor } from "@/components/Editor/OutputNameEditor";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+import { useContextPanel } from "@/providers/ContextPanelProvider";
+import { deselectAllNodes } from "@/utils/flowUtils";
+
+import { getOutputConnectedDetails } from "../utils/getOutputConnectedDetails";
+
+interface IONodeProps {
+  type: "input" | "output";
+  data: {
+    label: string;
+    value?: string;
+    default?: string;
+    type?: string;
+  };
+  selected: boolean;
+  deletable: boolean;
+}
+
+const IONode = ({ type, data, selected = false }: IONodeProps) => {
+  const { setNodes } = useReactFlow();
+  const location = useLocation();
+  const { graphSpec, componentSpec } = useComponentSpec();
+  const { setContent, clearContent } = useContextPanel();
+
+  const isPipelineEditor = location.pathname.includes("/editor");
+
+  const handleType = type === "input" ? "source" : "target";
+  const handlePosition = type === "input" ? Position.Right : Position.Left;
+  const selectedBorderColor =
+    type === "input"
+      ? "border-blue-500 bg-blue-100"
+      : "border-violet-500 bg-violet-100";
+  const defaultBorderColor =
+    type === "input"
+      ? "border-blue-300 bg-blue-100"
+      : "border-violet-300 bg-violet-100";
+  const borderColor = selected ? selectedBorderColor : defaultBorderColor;
+
+  const input = componentSpec.inputs?.find(
+    (input) => input.name === data.label,
+  );
+
+  const output = componentSpec.outputs?.find(
+    (output) => output.name === data.label,
+  );
+
+  const deselectNode = useCallback(() => {
+    setNodes(deselectAllNodes);
+    clearContent();
+  }, [setNodes]);
+
+  useEffect(() => {
+    if (selected) {
+      if (input && type === "input") {
+        setContent(
+          <InputValueEditor
+            input={input}
+            key={input.name}
+            onSave={deselectNode}
+            disabled={!isPipelineEditor}
+            onCancel={deselectNode}
+          />,
+        );
+      }
+
+      if (output && type === "output") {
+        const outputConnectedDetails = getOutputConnectedDetails(
+          graphSpec,
+          output.name,
+        );
+        setContent(
+          <OutputNameEditor
+            output={output}
+            connectedDetails={outputConnectedDetails}
+            key={output.name}
+            onSave={deselectNode}
+            disabled={!isPipelineEditor}
+            onCancel={deselectNode}
+          />,
+        );
+      }
+    }
+  }, [selected]);
+
+  const {
+    outputName: outputConnectedValue,
+    outputType: outputConnectedType,
+    taskId: outputConnectedTaskId,
+  } = getOutputConnectedDetails(graphSpec, data.label);
+
+  const handleDefaultClassName =
+    "!w-[12px] !h-[12px] !border-0! !w-[12px] !h-[12px] transform-none! cursor-pointer bg-gray-500! border-none!";
+
+  const handleClassName =
+    type === "input" ? "translate-x-1.5" : "-translate-x-1.5";
+
+  return (
+    <Card
+      className={`rounded-2xl ${borderColor} border-2 max-w-[300px] break-words p-0 drop-shadow-none gap-2`}
+    >
+      <CardHeader className="border-b border-slate-200 px-2 py-2.5">
+        <CardTitle className="max-w-[300px] break-words text-left text-xs text-slate-900">
+          {data.label}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-2 flex flex-col gap-2">
+        {/* type */}
+        <div className="text-xs text-slate-700 font-mono truncate max-w-[250px]">
+          <span className="font-bold text-slate-700">Type:</span>{" "}
+          {outputConnectedType || data.type || "Any"}
+        </div>
+
+        <span className="font-bold text-slate-700">
+          {outputConnectedTaskId}
+        </span>
+
+        {/* value */}
+        <div className={cn("flex flex-col gap-3 p-2 bg-white rounded-lg")}>
+          {type === "input" && (
+            <div
+              className={cn(
+                "text-xs text-slate-700 font-mono truncate max-w-[250px]",
+                {
+                  "text-red-500":
+                    type === "input" && !data.value && !data.default,
+                },
+              )}
+            >
+              <span className="font-bold text-slate-700">Value:</span>{" "}
+              {data.value || data.default || "No value"}
+            </div>
+          )}
+          {type === "output" && (
+            <div
+              className={cn(
+                "text-xs text-slate-700 font-mono truncate max-w-[250px]",
+                {
+                  "text-red-500": type === "output" && !outputConnectedValue,
+                },
+              )}
+            >
+              <span className="font-bold text-slate-700">From:</span>{" "}
+              {outputConnectedValue || "Not connected"}
+            </div>
+          )}
+          <Handle
+            type={handleType}
+            position={handlePosition}
+            className={cn(handleDefaultClassName, handleClassName)}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default memo(IONode);

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
@@ -58,6 +58,12 @@ const TaskNodeCard = () => {
     [nodeId, callbacks.onDuplicate, callbacks.onUpgrade, isCustomComponent],
   );
 
+  useEffect(() => {
+    if (selected) {
+      setContent(taskConfigMarkup);
+    }
+  }, [selected, taskConfigMarkup]);
+
   const handleInputSectionClick = useCallback(() => {
     setExpandedInputs((prev) => !prev);
   }, []);

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/getArgumentsFromInputs.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/getArgumentsFromInputs.ts
@@ -1,0 +1,24 @@
+import type { ComponentSpec } from "@/utils/componentSpec";
+
+/**
+ * Generates arguments object from component spec inputs that have values
+ * @param componentSpec - The component specification containing inputs
+ * @returns Object with input names as keys and their values as values
+ */
+export const getArgumentsFromInputs = (
+  componentSpec: ComponentSpec,
+): Record<string, string> => {
+  const args: Record<string, string> = {};
+
+  if (!componentSpec.inputs) {
+    return args;
+  }
+
+  for (const input of componentSpec.inputs) {
+    if (input.value !== undefined && input.value !== null) {
+      args[input.name] = input.value;
+    }
+  }
+
+  return args;
+};

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/getOutputConnectedDetails.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/getOutputConnectedDetails.ts
@@ -1,0 +1,40 @@
+/**
+ * Returns the connected output value (outputName) for a given output name from a graphSpec's outputValues.
+ * Returns undefined if not connected.
+ */
+export interface OutputConnectedDetails {
+  outputName: string;
+  outputType: string;
+  taskId: string;
+}
+
+export function getOutputConnectedDetails(
+  graphSpec: any,
+  outputName: string,
+): OutputConnectedDetails {
+  if (graphSpec?.outputValues) {
+    const outputValue = graphSpec.outputValues[outputName];
+    if (
+      outputValue &&
+      typeof outputValue === "object" &&
+      "taskOutput" in outputValue
+    ) {
+      const type =
+        graphSpec.tasks[
+          outputValue.taskOutput.taskId
+        ]?.componentRef?.spec?.outputs?.find(
+          (output: any) => output.name === outputValue.taskOutput.outputName,
+        )?.type || "Any";
+      return {
+        outputName: outputValue.taskOutput.outputName,
+        outputType: type,
+        taskId: outputValue.taskOutput.taskId,
+      };
+    }
+  }
+  return {
+    outputName: "Not connected",
+    outputType: "Any",
+    taskId: "",
+  };
+}

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/setGraphOutputValue.test.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/setGraphOutputValue.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import type { GraphSpec, TaskOutputArgument } from "@/utils/componentSpec";
+
+import { setGraphOutputValue } from "./setGraphOutputValue";
+
+describe("setGraphOutputValue", () => {
+  const mockGraphSpec: GraphSpec = {
+    tasks: {},
+    outputValues: {
+      existingOutput: {
+        taskOutput: {
+          taskId: "task1",
+          outputName: "output1",
+        },
+      },
+    },
+  };
+
+  it("should set a new output value", () => {
+    const newOutputValue: TaskOutputArgument = {
+      taskOutput: {
+        taskId: "task2",
+        outputName: "output2",
+      },
+    };
+
+    const result = setGraphOutputValue(
+      mockGraphSpec,
+      "newOutput",
+      newOutputValue,
+    );
+
+    expect(result.outputValues).toEqual({
+      existingOutput: {
+        taskOutput: {
+          taskId: "task1",
+          outputName: "output1",
+        },
+      },
+      newOutput: newOutputValue,
+    });
+  });
+
+  it("should update an existing output value", () => {
+    const updatedOutputValue: TaskOutputArgument = {
+      taskOutput: {
+        taskId: "task3",
+        outputName: "output3",
+      },
+    };
+
+    const result = setGraphOutputValue(
+      mockGraphSpec,
+      "existingOutput",
+      updatedOutputValue,
+    );
+
+    expect(result.outputValues).toEqual({
+      existingOutput: updatedOutputValue,
+    });
+  });
+
+  it("should remove an output value when outputValue is undefined", () => {
+    const result = setGraphOutputValue(
+      mockGraphSpec,
+      "existingOutput",
+      undefined,
+    );
+
+    expect(result.outputValues).toEqual({});
+  });
+
+  it("should handle removing a non-existent output value", () => {
+    const result = setGraphOutputValue(
+      mockGraphSpec,
+      "nonExistentOutput",
+      undefined,
+    );
+
+    expect(result.outputValues).toEqual({
+      existingOutput: {
+        taskOutput: {
+          taskId: "task1",
+          outputName: "output1",
+        },
+      },
+    });
+  });
+
+  it("should handle empty outputValues", () => {
+    const emptyGraphSpec: GraphSpec = {
+      tasks: {},
+      outputValues: {},
+    };
+
+    const result = setGraphOutputValue(emptyGraphSpec, "someOutput", undefined);
+
+    expect(result.outputValues).toEqual({});
+  });
+
+  it("should handle undefined outputValues", () => {
+    const undefinedGraphSpec: GraphSpec = {
+      tasks: {},
+      outputValues: undefined,
+    };
+
+    const result = setGraphOutputValue(
+      undefinedGraphSpec,
+      "someOutput",
+      undefined,
+    );
+
+    expect(result.outputValues).toEqual({});
+  });
+});

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/setGraphOutputValue.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/setGraphOutputValue.ts
@@ -5,11 +5,20 @@ export const setGraphOutputValue = (
   outputName: string,
   outputValue?: TaskOutputArgument,
 ) => {
-  const nonNullOutputObject = outputValue ? { [outputName]: outputValue } : {};
-  const newGraphOutputValues = {
-    ...graphSpec.outputValues,
-    ...nonNullOutputObject,
-  };
+  let newGraphOutputValues;
+
+  if (outputValue) {
+    newGraphOutputValues = {
+      ...graphSpec.outputValues,
+      [outputName]: outputValue,
+    };
+  } else {
+    // Remove the output value (for edge deletion)
+    const { [outputName]: removed, ...remaining } =
+      graphSpec.outputValues || {};
+    newGraphOutputValues = remaining;
+  }
+
   const newGraphSpec = { ...graphSpec, outputValues: newGraphOutputValues };
 
   return newGraphSpec;

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/updateInputNameOnComponentSpec.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/updateInputNameOnComponentSpec.ts
@@ -1,0 +1,95 @@
+import type {
+  ArgumentType,
+  ComponentSpec,
+  GraphInputArgument,
+  GraphSpec,
+  TaskSpec,
+} from "@/utils/componentSpec";
+
+/**
+ * Type guard to check if argument is a GraphInputArgument
+ */
+const isGraphInputArgument = (
+  argument: ArgumentType,
+): argument is GraphInputArgument => {
+  return typeof argument !== "string" && "graphInput" in argument;
+};
+
+/**
+ * Updates a single task's arguments to use the new input name
+ */
+const updateTaskArguments = (
+  task: TaskSpec,
+  oldName: string,
+  newName: string,
+): TaskSpec => {
+  if (!task.arguments) return task;
+
+  const updatedArguments = { ...task.arguments };
+
+  Object.entries(updatedArguments).forEach(([inputName, argument]) => {
+    if (
+      isGraphInputArgument(argument) &&
+      argument.graphInput.inputName === oldName
+    ) {
+      updatedArguments[inputName] = {
+        ...argument,
+        graphInput: {
+          ...argument.graphInput,
+          inputName: newName,
+        },
+      };
+    }
+  });
+
+  return { ...task, arguments: updatedArguments };
+};
+
+/**
+ * Updates all tasks in a graph spec to use the new input name
+ */
+const updateGraphTasks = (
+  graphSpec: GraphSpec,
+  oldName: string,
+  newName: string,
+): GraphSpec => {
+  const updatedTasks = { ...graphSpec.tasks };
+
+  Object.keys(updatedTasks).forEach((taskId) => {
+    updatedTasks[taskId] = updateTaskArguments(
+      updatedTasks[taskId],
+      oldName,
+      newName,
+    );
+  });
+
+  return { ...graphSpec, tasks: updatedTasks };
+};
+
+/**
+ * Renames an input in a component spec, updating both the inputs array
+ * and all graph spec references that use the old input name.
+ */
+export const updateInputNameOnComponentSpec = (
+  componentSpec: ComponentSpec,
+  oldName: string,
+  newName: string,
+): ComponentSpec => {
+  const updatedInputs = componentSpec.inputs?.map((input) =>
+    input.name === oldName ? { ...input, name: newName } : input,
+  );
+
+  const updatedComponentSpec = {
+    ...componentSpec,
+    inputs: updatedInputs,
+  };
+
+  // Update graph spec if it exists
+  if ("graph" in updatedComponentSpec.implementation) {
+    const graphSpec = updatedComponentSpec.implementation.graph;
+    const updatedGraphSpec = updateGraphTasks(graphSpec, oldName, newName);
+    updatedComponentSpec.implementation.graph = updatedGraphSpec;
+  }
+
+  return updatedComponentSpec;
+};

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/updateOutputNameOnComponentSpec.test.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/updateOutputNameOnComponentSpec.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+
+import type { ComponentSpec } from "@/utils/componentSpec";
+import { isGraphImplementation } from "@/utils/componentSpec";
+
+import { updateOutputNameOnComponentSpec } from "./updateOutputNameOnComponentSpec";
+
+describe("updateOutputNameOnComponentSpec", () => {
+  it("should update output name in outputs array", () => {
+    const componentSpec: ComponentSpec = {
+      name: "test",
+      implementation: {
+        graph: {
+          tasks: {},
+          outputValues: {},
+        },
+      },
+      outputs: [
+        { name: "oldOutput", type: "string" },
+        { name: "otherOutput", type: "number" },
+      ],
+    };
+
+    const result = updateOutputNameOnComponentSpec(
+      componentSpec,
+      "oldOutput",
+      "newOutput",
+    );
+
+    expect(result.outputs).toEqual([
+      { name: "newOutput", type: "string" },
+      { name: "otherOutput", type: "number" },
+    ]);
+  });
+
+  it("should update outputValues in graph spec when output is connected", () => {
+    const componentSpec: ComponentSpec = {
+      name: "test",
+      implementation: {
+        graph: {
+          tasks: {
+            task1: {
+              componentRef: {
+                spec: {
+                  name: "task1",
+                  implementation: {
+                    container: { image: "test-image" },
+                  },
+                },
+              },
+            },
+          },
+          outputValues: {
+            oldOutput: {
+              taskOutput: {
+                taskId: "task1",
+                outputName: "taskOutput1",
+              },
+            },
+          },
+        },
+      },
+      outputs: [{ name: "oldOutput", type: "string" }],
+    };
+
+    const result = updateOutputNameOnComponentSpec(
+      componentSpec,
+      "oldOutput",
+      "newOutput",
+    );
+
+    if (isGraphImplementation(result.implementation)) {
+      expect(result.implementation.graph.outputValues).toEqual({
+        newOutput: {
+          taskOutput: {
+            taskId: "task1",
+            outputName: "taskOutput1",
+          },
+        },
+      });
+      expect(
+        result.implementation.graph.outputValues?.oldOutput,
+      ).toBeUndefined();
+    } else {
+      throw new Error("Expected graph implementation");
+    }
+  });
+
+  it("should not update outputValues when output is not connected", () => {
+    const componentSpec: ComponentSpec = {
+      name: "test",
+      implementation: {
+        graph: {
+          tasks: {},
+          outputValues: {},
+        },
+      },
+      outputs: [{ name: "oldOutput", type: "string" }],
+    };
+
+    const result = updateOutputNameOnComponentSpec(
+      componentSpec,
+      "oldOutput",
+      "newOutput",
+    );
+
+    if (isGraphImplementation(result.implementation)) {
+      expect(result.implementation.graph.outputValues).toEqual({});
+    } else {
+      throw new Error("Expected graph implementation");
+    }
+  });
+
+  it("should not update outputValues when oldName equals newName", () => {
+    const componentSpec: ComponentSpec = {
+      name: "test",
+      implementation: {
+        graph: {
+          tasks: {},
+          outputValues: {
+            oldOutput: {
+              taskOutput: {
+                taskId: "task1",
+                outputName: "taskOutput1",
+              },
+            },
+          },
+        },
+      },
+      outputs: [{ name: "oldOutput", type: "string" }],
+    };
+
+    const result = updateOutputNameOnComponentSpec(
+      componentSpec,
+      "oldOutput",
+      "oldOutput",
+    );
+
+    if (isGraphImplementation(result.implementation)) {
+      expect(result.implementation.graph.outputValues).toEqual({
+        oldOutput: {
+          taskOutput: {
+            taskId: "task1",
+            outputName: "taskOutput1",
+          },
+        },
+      });
+    } else {
+      throw new Error("Expected graph implementation");
+    }
+  });
+
+  it("should handle component spec without graph implementation", () => {
+    const componentSpec: ComponentSpec = {
+      name: "test",
+      implementation: {
+        container: {
+          image: "test-image",
+        },
+      },
+      outputs: [{ name: "oldOutput", type: "string" }],
+    };
+
+    const result = updateOutputNameOnComponentSpec(
+      componentSpec,
+      "oldOutput",
+      "newOutput",
+    );
+
+    expect(result.outputs).toEqual([{ name: "newOutput", type: "string" }]);
+    expect(result.implementation).toEqual({
+      container: {
+        image: "test-image",
+      },
+    });
+  });
+});

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/updateOutputNameOnComponentSpec.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/updateOutputNameOnComponentSpec.ts
@@ -1,0 +1,39 @@
+import type { ComponentSpec } from "@/utils/componentSpec";
+
+/**
+ * Renames an output in a component spec, updating both the outputs array
+ * and all graph spec references that use the old output name.
+ */
+export const updateOutputNameOnComponentSpec = (
+  componentSpec: ComponentSpec,
+  oldName: string,
+  newName: string,
+): ComponentSpec => {
+  const updatedOutputs = componentSpec.outputs?.map((output) =>
+    output.name === oldName ? { ...output, name: newName } : output,
+  );
+
+  const updatedComponentSpec = {
+    ...componentSpec,
+    outputs: updatedOutputs,
+  };
+
+  // Update graph spec if it exists
+  if ("graph" in updatedComponentSpec.implementation && oldName !== newName) {
+    const graphSpec = updatedComponentSpec.implementation.graph;
+    const updatedOutputValues = { ...graphSpec.outputValues };
+
+    // Remove the old output name and add the new one with the same value
+    if (updatedOutputValues[oldName]) {
+      updatedOutputValues[newName] = updatedOutputValues[oldName];
+      delete updatedOutputValues[oldName];
+    }
+
+    updatedComponentSpec.implementation.graph = {
+      ...graphSpec,
+      outputValues: updatedOutputValues,
+    };
+  }
+
+  return updatedComponentSpec;
+};

--- a/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
@@ -131,4 +131,45 @@ const ComponentItemFromUrl = ({ url }: ComponentItemFromUrlProps) => {
   );
 };
 
+interface IONodeSidebarItemProps {
+  nodeType: "input" | "output";
+}
+
+export const IONodeSidebarItem = ({ nodeType }: IONodeSidebarItemProps) => {
+  const onDragStart = useCallback(
+    (event: DragEvent) => {
+      event.dataTransfer.setData(
+        "application/reactflow",
+        JSON.stringify({ [nodeType]: null }),
+      );
+      event.dataTransfer.setData(
+        "DragStart.offset",
+        JSON.stringify({
+          offsetX: event.nativeEvent.offsetX,
+          offsetY: event.nativeEvent.offsetY,
+        }),
+      );
+      event.dataTransfer.effectAllowed = "move";
+    },
+    [nodeType],
+  );
+
+  return (
+    <SidebarMenuItem
+      className={cn(
+        "pl-2 py-1.5 cursor-grab hover:bg-gray-100 active:bg-gray-200",
+      )}
+      draggable
+      onDragStart={onDragStart}
+    >
+      <div className="flex items-center gap-2">
+        <File className="h-4 w-4 text-gray-400 flex-shrink-0" />
+        <span className="truncate text-xs text-gray-800">
+          {nodeType === "input" ? "Input Node" : "Output Node"}
+        </span>
+      </div>
+    </SidebarMenuItem>
+  );
+};
+
 export { ComponentItemFromUrl, ComponentMarkup };

--- a/src/components/shared/ReactFlow/FlowSidebar/components/FolderItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/FolderItem.tsx
@@ -4,7 +4,12 @@ import {
   Folder,
   type LucideProps,
 } from "lucide-react";
-import { type JSXElementConstructor, type MouseEvent, useState } from "react";
+import {
+  isValidElement,
+  type JSXElementConstructor,
+  type MouseEvent,
+  useState,
+} from "react";
 
 import { type FolderItemProps } from "@/types/componentLibrary";
 
@@ -52,13 +57,16 @@ const FolderItem = ({ folder, icon }: FolderItemProps) => {
         <div className="pl-3">
           {hasComponents && folder.components && (
             <div>
-              {folder.components.map((component) => {
-                const key = `${folder.name}-component-${component.name || component?.spec?.name || component.url}`;
+              {folder.components.map((component, idx) => {
+                // If the component is a valid React element, render it directly (for special folders)
+                if (isValidElement(component)) {
+                  return component;
+                }
+                const key = `${folder.name}-component-${component.name || component?.spec?.name || component.url || idx}`;
                 // If the component has a spec render the component, otherwise, render using URL
                 if (component.spec) {
                   return <ComponentMarkup key={key} component={component} />;
                 }
-
                 return <ComponentItemFromUrl key={key} url={component.url} />;
               })}
             </div>

--- a/src/components/shared/ReactFlow/FlowSidebar/sections/GraphComponents.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/GraphComponents.tsx
@@ -1,4 +1,4 @@
-import { LayoutGrid, PackagePlus, Puzzle } from "lucide-react";
+import { Folder, LayoutGrid, PackagePlus, Puzzle } from "lucide-react";
 import { type ChangeEvent, useCallback, useMemo } from "react";
 
 import {
@@ -13,6 +13,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
+import type { UIComponentFolder } from "@/types/componentLibrary";
 
 import {
   EmptyState,
@@ -23,6 +24,7 @@ import {
   SearchInput,
   SearchResults,
 } from "../components";
+import { IONodeSidebarItem } from "../components/ComponentItem";
 
 const GraphComponents = ({ isOpen }: { isOpen: boolean }) => {
   const {
@@ -81,7 +83,6 @@ const GraphComponents = ({ isOpen }: { isOpen: boolean }) => {
             icon={LayoutGrid}
           />
         )}
-
         {hasFavouriteComponents && (
           <FolderItem
             key="my-components-folder"
@@ -89,7 +90,20 @@ const GraphComponents = ({ isOpen }: { isOpen: boolean }) => {
             icon={Puzzle}
           />
         )}
-
+        <FolderItem
+          key="graph-inputs-outputs-folder"
+          folder={
+            {
+              name: "Inputs & Outputs",
+              components: [
+                <IONodeSidebarItem key="input" nodeType="input" />,
+                <IONodeSidebarItem key="output" nodeType="output" />,
+              ],
+              folders: [],
+            } as UIComponentFolder
+          }
+          icon={Folder}
+        />
         {componentLibrary.folders.map((folder) => (
           <FolderItem key={folder.name} folder={folder} />
         ))}

--- a/src/providers/PipelineRunsProvider.tsx
+++ b/src/providers/PipelineRunsProvider.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 
 import type { BodyCreateApiPipelineRunsPost } from "@/api/types.gen";
+import { getArgumentsFromInputs } from "@/components/shared/ReactFlow/FlowCanvas/utils/getArgumentsFromInputs";
 import {
   countTaskStatuses,
   fetchExecutionDetails,
@@ -22,7 +23,10 @@ import {
   savePipelineRun,
 } from "@/services/pipelineRunService";
 import type { PipelineRun } from "@/types/pipelineRun";
-import type { ComponentReference, ComponentSpec } from "@/utils/componentSpec";
+import {
+  type ComponentReference,
+  type ComponentSpec,
+} from "@/utils/componentSpec";
 
 type PipelineRunsContextType = {
   runs: PipelineRun[];
@@ -127,11 +131,14 @@ export const PipelineRunsProvider = ({
             options?.onError?.(error as Error);
           },
         );
+        const argumentsFromInputs = getArgumentsFromInputs(fullyLoadedSpec);
+
         const payload = {
           root_task: {
             componentRef: {
               spec: fullyLoadedSpec,
             },
+            ...(argumentsFromInputs ? { arguments: argumentsFromInputs } : {}),
           },
         };
 

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -144,3 +144,19 @@ details > * {
   margin: 0;
   padding: 0;
 }
+
+/* Input and output nodes reset styles */
+.react-flow__node-input,
+.react-flow__node-output,
+.react-flow__node-input:hover,
+.react-flow__node-output:hover {
+  border: none;
+  padding: 0;
+  border-radius: 0;
+  background-color: transparent;
+  box-shadow: none !important;
+  text-align: left;
+  width: auto;
+  height: auto;
+  min-width: 100px;
+}

--- a/src/types/componentLibrary.ts
+++ b/src/types/componentLibrary.ts
@@ -1,5 +1,9 @@
 import type { LucideProps } from "lucide-react";
-import type { ChangeEvent, ForwardRefExoticComponent } from "react";
+import type {
+  ChangeEvent,
+  ForwardRefExoticComponent,
+  ReactElement,
+} from "react";
 
 import type { ComponentReference } from "@/utils/componentSpec";
 
@@ -22,8 +26,16 @@ export type ComponentFolder = {
   isUserFolder?: boolean;
 };
 
+// Special type for UI components that can include React elements
+export type UIComponentFolder = {
+  name: string;
+  components?: (ComponentReference | ReactElement)[];
+  folders?: UIComponentFolder[];
+  isUserFolder?: boolean;
+};
+
 export type FolderItemProps = {
-  folder: ComponentFolder;
+  folder: UIComponentFolder;
   icon?: ForwardRefExoticComponent<Omit<LucideProps, "ref">>;
 };
 

--- a/src/utils/componentSpec.ts
+++ b/src/utils/componentSpec.ts
@@ -28,6 +28,7 @@ export interface InputSpec extends InputOutputSpec {
   description?: string;
   default?: string;
   optional?: boolean;
+  value?: string;
   annotations?: {
     [k: string]: unknown;
   };

--- a/src/utils/inputConnectionUtils.ts
+++ b/src/utils/inputConnectionUtils.ts
@@ -1,0 +1,47 @@
+import type { ComponentSpec, GraphSpec } from "@/utils/componentSpec";
+
+/**
+ * Checks if an input is connected to any required fields in task nodes
+ * @param inputName - The name of the input to check
+ * @param componentSpec - The component specification containing the graph
+ * @returns An object with isConnectedToRequired (boolean) and connectedFields (array of field names)
+ */
+export const checkInputConnectionToRequiredFields = (
+  inputName: string,
+  componentSpec: ComponentSpec,
+): { isConnectedToRequired: boolean; connectedFields: string[] } => {
+  if (!("graph" in componentSpec.implementation)) {
+    return { isConnectedToRequired: false, connectedFields: [] };
+  }
+
+  const graphSpec: GraphSpec = componentSpec.implementation.graph;
+  const connectedFields: string[] = [];
+  let isConnectedToRequired = false;
+
+  // Iterate through all tasks in the graph
+  Object.entries(graphSpec.tasks).forEach(([taskId, taskSpec]) => {
+    const taskComponentSpec = taskSpec.componentRef.spec;
+
+    // Check each input of the task
+    taskComponentSpec?.inputs?.forEach((taskInput) => {
+      const argument = taskSpec.arguments?.[taskInput.name];
+
+      // Check if this argument is connected to our input
+      if (
+        argument &&
+        typeof argument === "object" &&
+        "graphInput" in argument &&
+        argument.graphInput.inputName === inputName
+      ) {
+        connectedFields.push(`${taskId}.${taskInput.name}`);
+
+        // Check if this field is required (not optional and no default)
+        if (!taskInput.optional && taskInput.default === undefined) {
+          isConnectedToRequired = true;
+        }
+      }
+    });
+  });
+
+  return { isConnectedToRequired, connectedFields };
+};

--- a/src/utils/nodes/createNodesFromComponentSpec.ts
+++ b/src/utils/nodes/createNodesFromComponentSpec.ts
@@ -34,7 +34,12 @@ const createInputNodes = (componentSpec: ComponentSpec) => {
 
     return {
       id: `input_${inputSpec.name}`,
-      data: { label: inputSpec.name },
+      data: {
+        label: inputSpec.name,
+        value: inputSpec.value,
+        default: inputSpec.default,
+        type: inputSpec.type,
+      },
       position: position,
       type: "input",
     } as Node;
@@ -47,7 +52,7 @@ const createOutputNodes = (componentSpec: ComponentSpec) => {
 
     return {
       id: `output_${outputSpec.name}`,
-      data: { label: outputSpec.name },
+      data: { label: outputSpec.name, type: outputSpec.type },
       position: position,
       type: "output",
     } as Node;


### PR DESCRIPTION
## Description

Closes: https://github.com/Cloud-Pipelines/pipeline-studio-app/issues/25

This PR lets users drag "special" nodes like input and output nodes to the graph where they can:
- Attach to the input or output of existing nodes
- Rename the nodes
- Change the type, which is mainly for the UI to help facilitate better UI such as date picker or boolean
- Change the value of an input node
- Export a pipeline and use it as a component

I have colour coded the nodes to blue and purple, which is a slight departure from cloud pipelines where they were blue and red. I didn't want the output to be red because that signifies an error.

None issues: Multi-select with IO nodes doesn't quite work. This will be fixed in a fast followup


**COPILOT:**
This pull request introduces significant enhancements to the `PipelineDetails` component, focusing on improving the user interface for editing pipeline inputs and outputs. It also includes new reusable form components, adds comprehensive tests for the input editor, and updates dependencies in `package.json`.

### Enhancements to `PipelineDetails`:

* Refactored the `PipelineDetails` component to include input and output editing functionality using the newly introduced `InputValueEditor` and `OutputNameEditor` components. This allows users to edit inputs and outputs directly from the UI. [[1]](diffhunk://#diff-3b726b146de91fa0b684dc3c8afa4415c7aa311812f0043a8e5218e148376f15R1-R46) [[2]](diffhunk://#diff-3b726b146de91fa0b684dc3c8afa4415c7aa311812f0043a8e5218e148376f15R55-R60) [[3]](diffhunk://#diff-3b726b146de91fa0b684dc3c8afa4415c7aa311812f0043a8e5218e148376f15R104-R112) [[4]](diffhunk://#diff-3b726b146de91fa0b684dc3c8afa4415c7aa311812f0043a8e5218e148376f15L190-R276)
* Replaced the previous list-based display of inputs and outputs with a more interactive layout, including "Edit" buttons for each input and output.

### New Components:

* [`FormFields.tsx`](diffhunk://#diff-68da2bdb9a52fb81f2ec0ccde101cb0d8c87196c18a9a6e3112e5422615d122bR1-R123): Introduced reusable form field components (`NameField`, `TextField`, `OptionalField`, and `TypeField`) for consistent input handling across the application.
* [`InputValueEditor.tsx`](diffhunk://#diff-40cfb4d75280789a5dec7ab1d60023940f67d308b4f503d8937d0cfd4f667ce5R1-R148): Added a new component for editing input values, including validation for duplicate names and support for optional fields.
* [`OutputNameEditor.tsx`](diffhunk://#diff-d687f1d466345ffcc970864702777502b4b642d7213a6b8ad5992266074fcdf2R1-R113): Added a new component for editing output names and types, with validation for duplicate names. [[1]](diffhunk://#diff-d687f1d466345ffcc970864702777502b4b642d7213a6b8ad5992266074fcdf2R1-R113) [[2]](diffhunk://#diff-15411aabbca8bd8101fc5aa79197b1b06ed5f67142aea9994b0e66bf07ea5b7dR1)

### Testing:

* Added comprehensive tests for the `InputValueEditor` component, covering scenarios such as validation errors, placeholder handling, and input value changes.

### Dependency Updates:

* Updated and reordered dependencies in `package.json` to maintain consistency. No version changes were made; the updates only fixed ordering issues. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L77-R78) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L87-R89)
## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Additional Comments


<img width="1512" alt="Screenshot 2025-07-04 at 9 08 10 PM" src="https://github.com/user-attachments/assets/f2843b72-b156-4772-be98-1f697580836f" />

Imported as a component
<img width="376" alt="Screenshot 2025-07-04 at 9 10 21 PM" src="https://github.com/user-attachments/assets/5575e33b-0cad-44c8-a715-179b92e9cb93" />

Imported with no value and is required
<img width="349" alt="Screenshot 2025-07-04 at 9 12 47 PM" src="https://github.com/user-attachments/assets/576a156f-4f4a-4769-9b7b-e98697bdb601" />

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
