### PR TITLE
Collapsible Context Panel

### DIFF
--- a/src/components/Editor/PipelineDetails.tsx
+++ b/src/components/Editor/PipelineDetails.tsx
@@ -105,7 +105,7 @@ const PipelineDetails = ({
     <div className="p-2 flex flex-col gap-6">
       {/* Header */}
       <div className="flex items-center gap-2">
-        <Network className="w-6 h-6 text-secondary-foreground rotate-270" />
+        <Network className="w-6 h-6 text-secondary-foreground rotate-270 min-w-6 min-h-6" />
         <h2 className="text-lg font-semibold">
           {componentSpec.name ?? "Unnamed Pipeline"}
         </h2>

--- a/src/components/Editor/PipelineEditor.tsx
+++ b/src/components/Editor/PipelineEditor.tsx
@@ -23,7 +23,7 @@ import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { ContextPanelProvider } from "@/providers/ContextPanelProvider";
 import { savePipelineSpecToSessionStorage } from "@/utils/storage";
 
-import { ContextPanel } from "../shared/ContextPanel/ContextPanel";
+import { CollapsibleContextPanel } from "../shared/ContextPanel/CollapsibleContextPanel";
 import PipelineDetails from "./PipelineDetails";
 
 const GRID_SIZE = 10;
@@ -83,9 +83,7 @@ const PipelineEditor = () => {
             </div>
           </ResizablePanel>
           <ResizableHandle />
-          <ResizablePanel defaultSize={30} minSize={10} maxSize={50}>
-            <ContextPanel />
-          </ResizablePanel>
+          <CollapsibleContextPanel />
         </ResizablePanelGroup>
       </ComponentLibraryProvider>
     </ContextPanelProvider>

--- a/src/components/PipelineRun/PipelineRunPage.tsx
+++ b/src/components/PipelineRun/PipelineRunPage.tsx
@@ -11,7 +11,7 @@ import { ComponentLibraryProvider } from "@/providers/ComponentLibraryProvider";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { ContextPanelProvider } from "@/providers/ContextPanelProvider";
 
-import { ContextPanel } from "../shared/ContextPanel/ContextPanel";
+import { CollapsibleContextPanel } from "../shared/ContextPanel/CollapsibleContextPanel";
 import RunDetails from "./RunDetails";
 
 const GRID_SIZE = 10;
@@ -56,9 +56,7 @@ const PipelineRunPage = () => {
             </div>
           </ResizablePanel>
           <ResizableHandle />
-          <ResizablePanel defaultSize={30} minSize={10} maxSize={50}>
-            <ContextPanel />
-          </ResizablePanel>
+          <CollapsibleContextPanel />
         </ResizablePanelGroup>
       </ComponentLibraryProvider>
     </ContextPanelProvider>

--- a/src/components/shared/ContextPanel/CollapsibleContextPanel.tsx
+++ b/src/components/shared/ContextPanel/CollapsibleContextPanel.tsx
@@ -1,0 +1,64 @@
+import { PanelRightClose, PanelRightOpen } from "lucide-react";
+import { useRef, useState } from "react";
+import type { ImperativePanelHandle } from "react-resizable-panels";
+
+import { Button } from "@/components/ui/button";
+import { ResizablePanel } from "@/components/ui/resizable";
+import { cn } from "@/lib/utils";
+
+import { ContextPanel } from "./ContextPanel";
+
+export function CollapsibleContextPanel({
+  defaultSize = 30,
+  minSize = 15,
+  maxSize = 50,
+  collapsedSize = 3,
+}: {
+  defaultSize?: number;
+  minSize?: number;
+  maxSize?: number;
+  collapsedSize?: number;
+}) {
+  const resizablePanelRef = useRef<ImperativePanelHandle>(null);
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <ResizablePanel
+      ref={resizablePanelRef}
+      collapsible
+      defaultSize={defaultSize}
+      minSize={minSize}
+      maxSize={maxSize}
+      collapsedSize={collapsedSize}
+      onCollapse={() => setCollapsed(true)}
+      onExpand={() => setCollapsed(false)}
+    >
+      {collapsed && (
+        <div className="relative">
+          <Button
+            className="absolute top-2 right-2"
+            variant="ghost"
+            onClick={() => {
+              resizablePanelRef.current?.expand();
+              resizablePanelRef.current?.resize(30);
+            }}
+          >
+            <PanelRightOpen className="h-6 w-6" />
+          </Button>
+        </div>
+      )}
+      <div className={cn("h-full relative", collapsed && "hidden")}>
+        <Button
+          className="absolute top-2 right-2"
+          variant="ghost"
+          onClick={() => {
+            resizablePanelRef.current?.collapse();
+          }}
+        >
+          <PanelRightClose className="h-6 w-6" />
+        </Button>
+        <ContextPanel />
+      </div>
+    </ResizablePanel>
+  );
+}


### PR DESCRIPTION
## Description

The right-side context panel is now collapsible.

## Related Issue and Pull requests

https://github.com/Shopify/oasis-frontend/issues/114

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/db303596-eb84-49f2-94d9-4a0484b14b63)

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->

Note a floating icon to the left of the panel, similar to the one to the left of the sidebar, was not possible due to the way ResizablePanel works.
