### PR TITLE
Improvements to StatusIcon

### DIFF
--- a/src/components/Editor/PipelineDetails.tsx
+++ b/src/components/Editor/PipelineDetails.tsx
@@ -104,7 +104,7 @@ const PipelineDetails = ({
   return (
     <div className="p-2 flex flex-col gap-6">
       {/* Header */}
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2 max-w-[90%]">
         <Network className="w-6 h-6 text-secondary-foreground rotate-270 min-w-6 min-h-6" />
         <h2 className="text-lg font-semibold">
           {componentSpec.name ?? "Unnamed Pipeline"}

--- a/src/components/PipelineRun/RunDetails.tsx
+++ b/src/components/PipelineRun/RunDetails.tsx
@@ -2,11 +2,6 @@ import { Frown, Videotape } from "lucide-react";
 
 import { Spinner } from "@/components/ui/spinner";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import {
   countTaskStatuses,
   fetchExecutionInfo,
   getRunStatus,
@@ -47,21 +42,12 @@ export const RunDetails = ({ runId = "" }: RunDetailsProps) => {
 
   return (
     <div className="p-2">
-      <div className="flex items-center gap-2 mb-8">
+      <div className="flex items-center gap-2 mb-8 max-w-[90%]">
         <Videotape className="w-6 h-6 text-gray-500" />
         <h2 className="text-lg font-semibold">
           {componentSpec.name ?? "Unnamed Pipeline"}
         </h2>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span>
-              <StatusIcon status={runStatus} />
-            </span>
-          </TooltipTrigger>
-          <TooltipContent>
-            <span>{`Run ${runStatus.toLowerCase()}`}</span>
-          </TooltipContent>
-        </Tooltip>
+        <StatusIcon status={runStatus} tooltip />
       </div>
       <div className="flex flex-col gap-4 px-2">
         {componentSpec.description && (

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/TaskConfiguration.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/TaskConfiguration.tsx
@@ -7,6 +7,7 @@ import {
 } from "lucide-react";
 
 import { ComponentFavoriteToggle } from "@/components/shared/FavoriteComponentToggle";
+import { StatusIcon } from "@/components/shared/Status";
 import {
   TaskDetails,
   TaskImplementation,
@@ -58,6 +59,7 @@ const TaskConfiguration = ({
     <div>
       <div className="flex items-center gap-2 px-2 pb-2 font-semibold text-lg">
         {name} <ComponentFavoriteToggle component={taskSpec.componentRef} />
+        {runStatus && <StatusIcon status={runStatus} tooltip label="task" />}
       </div>
 
       <div className="flex flex-col px-4 gap-4 overflow-y-auto pb-4">

--- a/src/components/shared/Status/StatusIcon.tsx
+++ b/src/components/shared/Status/StatusIcon.tsx
@@ -3,11 +3,47 @@ import {
   CircleCheck,
   CircleEllipsis,
   CircleHelp,
+  CircleMinus,
   CircleX,
   RefreshCcw,
 } from "lucide-react";
 
-const StatusIcon = ({ status }: { status?: string }) => {
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+const StatusIcon = ({
+  status,
+  tooltip = false,
+  label = "run",
+}: {
+  status?: string;
+  tooltip?: boolean;
+  label?: "run" | "task" | "pipeline";
+}) => {
+  if (tooltip) {
+    const capitalizedLabel = label.charAt(0).toUpperCase() + label.slice(1);
+    const tooltipText = `${capitalizedLabel} ${status?.toLowerCase() ?? "unknown"}`;
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span>
+            <Icon status={status} />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>
+          <span>{tooltipText}</span>
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return <Icon status={status} />;
+};
+
+const Icon = ({ status }: { status?: string }) => {
   switch (status) {
     case "SUCCEEDED":
       return <CircleCheck className="w-4 h-4 text-green-500" />;
@@ -26,6 +62,8 @@ const StatusIcon = ({ status }: { status?: string }) => {
       return <CircleX className="w-4 h-4 text-orange-500 animate-pulse" />;
     case "WAITING":
       return <CircleEllipsis className="w-4 h-4 text-gray-500" />;
+    case "SKIPPED":
+      return <CircleMinus className="w-4 h-4 text-gray-500" />;
     default:
       return <CircleHelp className="w-4 h-4 text-orange-500" />;
   }


### PR DESCRIPTION
## Description

A minor PR to add the option for tooltips on status icons. Also adds an icon for `SKIPPED`
Also fixes a bug where icons could overflow the sidebar toggle button on the right-side context panel.

## Related Issue and Pull requests

n/a

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

n/a

## Additional Comments

no significant changes to app functionality
