### PR TITLE
Grow Argument Input Fields

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsInput.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsInput.tsx
@@ -80,7 +80,7 @@ export const AnnotationsInput = ({
           config?.enableQuantity ? handleQuantitySelectChange : onChange
         }
       >
-        <SelectTrigger className={cn("w-24 max-24", className)}>
+        <SelectTrigger className={cn("min-w-24 grow", className)}>
           <SelectValue placeholder={"Select " + placeholder} />
         </SelectTrigger>
         <SelectContent>
@@ -125,7 +125,7 @@ export const AnnotationsInput = ({
               : validateChange
           }
           autoFocus={autoFocus}
-          className={className}
+          className={cn("min-w-16", className)}
         />
         {isInvalid && (
           <div className="flex items-center gap-1 my-1 text-xs text-warning">
@@ -137,7 +137,7 @@ export const AnnotationsInput = ({
   }
 
   return (
-    <div className="flex items-center gap-2 w-1/2">
+    <div className="flex items-center gap-2 grow flex-wrap">
       {inputElement}
       {config?.enableQuantity && (
         <QuantityInput
@@ -175,13 +175,13 @@ const QuantityInput = ({
   };
 
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-2 max-w-1/3">
       <span>x</span>
       <Input
         type="number"
         value={getAnnotationValue(annotation, annotations)}
         onChange={handleValueInputChange}
-        className="w-12 [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+        className="min-w-8 [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
         disabled={disabled}
       />
     </div>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/ComputeResourcesEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/ComputeResourcesEditor.tsx
@@ -62,7 +62,7 @@ export const ComputeResourcesEditor = ({
       <h3>Compute Resources</h3>
       {COMPUTE_RESOURCES.map((resource) => (
         <div key={resource.annotation} className="flex items-center gap-2">
-          <span className="text-xs text-muted-foreground w-40 truncate">
+          <span className="text-xs text-muted-foreground min-w-24 truncate">
             {resource.label} {resource.unit && `(${resource.unit})`}
           </span>
 

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/ArgumentInputField.tsx
@@ -130,7 +130,7 @@ export const ArgumentInputField = ({
         className="flex w-full items-center justify-between gap-2 py-1 rounded-md hover:bg-secondary/40 cursor-pointer"
         onClick={handleBackgroundClick}
       >
-        <div className="flex items-center gap-2 justify-between w-2/5 pr-2">
+        <div className="flex items-center gap-2 justify-between w-40 pr-2">
           <div className="flex items-center gap-2">
             <Tooltip>
               <TooltipTrigger asChild>
@@ -177,7 +177,8 @@ export const ArgumentInputField = ({
             </Tooltip>
           )}
         </div>
-        <div className="relative w-48">
+
+        <div className="relative min-w-24 grow">
           <Tooltip>
             <TooltipTrigger asChild>
               <Input
@@ -206,7 +207,7 @@ export const ArgumentInputField = ({
           </Tooltip>
         </div>
 
-        <div className="flex gap-1 items-center w-1/5 justify-end">
+        <div className="flex gap-1 items-center w-24 justify-end">
           <Tooltip>
             <TooltipTrigger asChild>
               <Button

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/OutputsList.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/OutputsList.tsx
@@ -14,7 +14,7 @@ const OutputsList = ({ taskSpec }: OutputsListProps) => {
       <span className="text-sm">
         <span className="font-medium">{output.name}</span>
         {output.type && (
-          <span className="text-xs text-muted-foreground italic">
+          <span className="text-xs text-muted-foreground italic ml-1">
             ({output.type as string})
           </span>
         )}


### PR DESCRIPTION
## Description

Now that the task config is int he context panel, and the context panel can be resized, the arguments editor needs updating to make use of the extra space. The input fields will now grow to fill the available space.

The annotations editor has similarly been updated as well.

## Related Issue and Pull requests

Closes https://github.com/Shopify/oasis-frontend/issues/116

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/694fb07c-a286-479d-9fd8-a06e4c27b0d3)


## Additional Comments

n/a
