### PR TITLE
Fix bug where empty arguments can not be set

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/utils.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/ArgumentsEditor/utils.ts
@@ -29,7 +29,7 @@ export const getArgumentInputs = (taskSpec: TaskSpec) => {
         value: initialValue ?? "",
         initialValue: initialValue ?? "",
         inputSpec: input,
-        isRemoved: !existingArgument,
+        isRemoved: existingArgument === undefined,
       } as ArgumentInput;
     }) ?? [];
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Fixes an unintended bug introduced or overlooked in #456 where unset arguments with no value could not be set.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
