### PR TITLE
Fix ability to add nodes to a ReadOnly Pipeline via TAB

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -91,13 +91,14 @@ const FlowCanvas = ({
   });
 
   const allNodes = useMemo(() => {
+    if (readOnly) return nodes;
     if (ghostNode) {
       return [...nodes, ghostNode];
     } else if (tabHintNode) {
       return [...nodes, tabHintNode];
     }
     return nodes;
-  }, [nodes, ghostNode, tabHintNode]);
+  }, [readOnly, nodes, ghostNode, tabHintNode]);
 
   const {
     handlers: confirmationHandlers,

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/Handles.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/Handles.tsx
@@ -27,7 +27,7 @@ export const InputHandle = ({
   onLabelClick,
   onHandleSelectionChange,
 }: InputHandleProps) => {
-  const { nodeId } = useTaskNode();
+  const { nodeId, state } = useTaskNode();
 
   const fromHandle = useConnection((connection) => connection.fromHandle?.id);
   const toHandle = useConnection((connection) => connection.toHandle?.id);
@@ -118,6 +118,7 @@ export const InputHandle = ({
             missing,
             (selected || active) && "bg-blue-500!",
             highlight && "bg-green-500!",
+            state.readOnly && "cursor-pointer!",
           )}
           onClick={handleHandleClick}
         />
@@ -180,7 +181,7 @@ export const OutputHandle = ({
   onLabelClick,
   onHandleSelectionChange,
 }: OutputHandleProps) => {
-  const { nodeId } = useTaskNode();
+  const { nodeId, state } = useTaskNode();
 
   const fromHandle = useConnection((connection) => connection.fromHandle?.id);
   const toHandle = useConnection((connection) => connection.toHandle?.id);
@@ -294,6 +295,7 @@ export const OutputHandle = ({
           "relative! border-0! !w-[12px] !h-[12px] transform-none! translate-x-6 cursor-pointer bg-gray-500!",
           (selected || active) && "bg-blue-500!",
           highlight && "bg-green-500!",
+          state.readOnly && "cursor-pointer!",
         )}
       />
     </div>


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Issue noticed during tests on staging. Also changed the cursor in readOnly mode for handles to show they they can draw edges.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
