### PR TITLE
Populate PipelineDetails Executions on Initial Load

### DIFF
--- a/src/components/Editor/PipelineDetails.tsx
+++ b/src/components/Editor/PipelineDetails.tsx
@@ -1,17 +1,15 @@
 import { Frown, Network } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
 import useToastNotification from "@/hooks/useToastNotification";
-import { usePipelineRuns } from "@/providers/PipelineRunsProvider";
 import type { ComponentSpec } from "@/utils/componentSpec";
 import { getComponentFileFromList } from "@/utils/componentStore";
 import { USER_PIPELINES_LIST_NAME } from "@/utils/constants";
 
-import RunOverview from "../shared/RunOverview";
 import { TaskImplementation } from "../shared/TaskDetails";
+import RecentExecutions from "./components/RecentExecutions";
 import RenamePipeline from "./RenamePipeline";
 
 type PipelineDetailsProps = {
@@ -23,7 +21,6 @@ const PipelineDetails = ({
   componentSpec,
   isLoading,
 }: PipelineDetailsProps) => {
-  const { runs } = usePipelineRuns();
   const notify = useToastNotification();
 
   // State for file metadata
@@ -55,28 +52,6 @@ const PipelineDetails = ({
     };
     fetchMeta();
   }, [componentSpec?.name]);
-
-  const runOverviews = useMemo(
-    () =>
-      runs.map((run) => (
-        <a key={run.id} href={`/runs/${run.root_execution_id}`} tabIndex={0}>
-          <RunOverview
-            run={run}
-            config={{
-              showStatus: true,
-              showName: false,
-              showExecutionId: true,
-              showCreatedAt: true,
-              showTaskStatusBar: false,
-              showStatusCounts: "full",
-              showAuthor: true,
-            }}
-            className="rounded-sm"
-          />
-        </a>
-      )),
-    [runs],
-  );
 
   if (!componentSpec) {
     return (
@@ -246,18 +221,7 @@ const PipelineDetails = ({
       </div>
 
       {/* Recent Executions */}
-      <div>
-        <h3 className="text-md font-medium mb-1">
-          Recent Executions ({runOverviews.length} total)
-        </h3>
-        {runs.length === 0 ? (
-          <div className="text-xs text-muted-foreground">No runs yet.</div>
-        ) : (
-          <ScrollArea className="h-48 bg-gray-100 border border-gray-300 rounded p-2">
-            {runOverviews}
-          </ScrollArea>
-        )}
-      </div>
+      <RecentExecutions />
 
       {/* Pipeline YAML */}
       <div className="flex flex-col h-full">

--- a/src/components/Editor/components/RecentExecutions.tsx
+++ b/src/components/Editor/components/RecentExecutions.tsx
@@ -1,0 +1,79 @@
+import { useMemo } from "react";
+
+import RunOverview from "@/components/shared/RunOverview";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Spinner } from "@/components/ui/spinner";
+import { usePipelineRuns } from "@/providers/PipelineRunsProvider";
+
+const RecentExecutions = () => {
+  const { runs, recentRuns, isLoading, error } = usePipelineRuns();
+
+  const runOverviews = useMemo(
+    () =>
+      recentRuns.map((run) => (
+        <a key={run.id} href={`/runs/${run.root_execution_id}`} tabIndex={0}>
+          <RunOverview
+            run={run}
+            config={{
+              showStatus: true,
+              showName: false,
+              showExecutionId: true,
+              showCreatedAt: true,
+              showTaskStatusBar: false,
+              showStatusCounts: "full",
+              showAuthor: true,
+            }}
+            className="rounded-sm"
+          />
+        </a>
+      )),
+    [recentRuns],
+  );
+
+  const remainingRuns = runs.length - recentRuns.length;
+
+  if (isLoading) {
+    return (
+      <div>
+        <h3 className="text-md font-medium mb-1">Recent Executions</h3>
+        <div className="h-48 bg-gray-100 border border-gray-300 rounded p-2 flex items-center justify-center">
+          <Spinner className="mr-2" />
+          <p className="text-secondary-foreground">
+            Loading recent executions...
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div>
+        <h3 className="text-md font-medium mb-1">Recent Executions</h3>
+        <div className="h-48 bg-gray-100 border border-gray-300 rounded p-2 flex items-center justify-center">
+          <p className="text-destructive">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h3 className="text-md font-medium mb-1">Recent Executions</h3>
+      {recentRuns.length === 0 ? (
+        <div className="text-xs text-muted-foreground">No runs yet.</div>
+      ) : (
+        <ScrollArea className="h-fit bg-gray-100 border border-gray-300 rounded p-2">
+          {runOverviews}
+          {remainingRuns > 0 && (
+            <div className="mt-2 text-xs text-muted-foreground w.full text-center">
+              +{remainingRuns} more executions
+            </div>
+          )}
+        </ScrollArea>
+      )}
+    </div>
+  );
+};
+
+export default RecentExecutions;

--- a/src/components/shared/RunOverview.tsx
+++ b/src/components/shared/RunOverview.tsx
@@ -1,17 +1,8 @@
 import { useNavigate } from "@tanstack/react-router";
-import { Loader2 } from "lucide-react";
-import { useEffect, useState } from "react";
 
 import { StatusBar, StatusIcon, StatusText } from "@/components/shared/Status/";
-import { useExecutionStatusQuery } from "@/hooks/useExecutionStatusQuery";
 import { cn } from "@/lib/utils";
 import { APP_ROUTES } from "@/routes/router";
-import {
-  countTaskStatuses,
-  fetchExecutionInfo,
-  getRunStatus,
-} from "@/services/executionService";
-import { fetchPipelineRunById } from "@/services/pipelineRunService";
 import type { PipelineRun } from "@/types/pipelineRun";
 import { formatDate } from "@/utils/date";
 
@@ -46,57 +37,11 @@ const RunOverview = ({
 }: RunOverviewProps) => {
   const navigate = useNavigate();
 
-  const [metadata, setMetadata] = useState<PipelineRun | null>(null);
-  const [loadingMetadata, setLoadingMetadata] = useState(true);
-
-  const executionId = `${run.root_execution_id}`;
-  const { data: status } = useExecutionStatusQuery(executionId);
-
-  const { data, isLoading, error } = fetchExecutionInfo(executionId);
-  const { details, state } = data;
-
-  useEffect(() => {
-    const fetchData = async () => {
-      const res = await fetchPipelineRunById(`${run.id}`);
-      if (!res) return;
-
-      const runData = res as PipelineRun;
-
-      runData.status = status;
-
-      setMetadata(runData);
-      setLoadingMetadata(false);
-    };
-
-    fetchData();
-  }, [run.id, status]);
-
-  if (isLoading || loadingMetadata) {
-    return (
-      <div className="flex flex-col p-2 text-sm">
-        <div className="flex items-center gap-2">
-          <Loader2 className="w-4 h-4 animate-spin" />
-        </div>
-      </div>
-    );
-  }
-
-  if (error || !details || !state) {
-    return (
-      <div className="flex flex-col p-2 text-sm text-red-500">
-        <span>Error loading run details</span>
-        <span className="text-xs">{error?.message}</span>
-      </div>
-    );
-  }
-
-  const statusCounts = countTaskStatuses(details, state);
-
   return (
     <div
       onClick={(e) => {
         e.stopPropagation();
-        navigate({ to: `${APP_ROUTES.RUNS}/${executionId}` });
+        navigate({ to: `${APP_ROUTES.RUNS}/${run.root_execution_id}` });
       }}
       className={cn(
         "flex flex-col p-2 text-sm hover:bg-gray-50 cursor-pointer",
@@ -107,41 +52,43 @@ const RunOverview = ({
         <div className="flex items-center gap-2">
           {config?.showName && <span>{run.pipeline_name}</span>}
           <div className="flex items-center gap-3">
-            {config?.showStatus && (
-              <StatusIcon status={getRunStatus(statusCounts)} />
-            )}
+            {config?.showStatus && <StatusIcon status={run.status} />}
             {config?.showExecutionId && (
-              <div className="text-xs">{`#${executionId}`}</div>
+              <div className="text-xs">{`#${run.root_execution_id}`}</div>
             )}
           </div>
-          {config?.showCreatedAt && metadata?.created_at && (
+          {config?.showCreatedAt && run.created_at && (
             <div className="flex items-center gap-2">
               <span>•</span>
-              <span className="text-gray-500 text-xs">{`${formatDate(metadata.created_at || "")}`}</span>
+              <span className="text-gray-500 text-xs">{`${formatDate(run.created_at || "")}`}</span>
             </div>
           )}
-          {config?.showAuthor && metadata?.created_by && (
+          {config?.showAuthor && run.created_by && (
             <div className="flex items-center gap-1">
               <span className="mr-1">•</span>
               <span className="text-xs">Initiated by</span>
               <span className="text-gray-500 text-xs max-w-32 truncate">
-                {metadata.created_by}
+                {run.created_by}
               </span>
             </div>
           )}
         </div>
-        {config?.showStatusCounts && config.showStatusCounts !== "none" && (
-          <StatusText
-            statusCounts={statusCounts}
-            shorthand={
-              config.showStatusCounts === "shorthand" ||
-              (config.showAuthor && !!metadata?.created_by)
-            }
-          />
-        )}
+        {config?.showStatusCounts &&
+          config.showStatusCounts !== "none" &&
+          run.statusCounts && (
+            <StatusText
+              statusCounts={run.statusCounts}
+              shorthand={
+                config.showStatusCounts === "shorthand" ||
+                (config.showAuthor && !!run.created_by)
+              }
+            />
+          )}
       </div>
 
-      {config?.showTaskStatusBar && <StatusBar statusCounts={statusCounts} />}
+      {config?.showTaskStatusBar && (
+        <StatusBar statusCounts={run.statusCounts} />
+      )}
     </div>
   );
 };

--- a/src/components/shared/Status/StatusText.tsx
+++ b/src/components/shared/Status/StatusText.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/lib/utils";
-import type { TaskStatusCounts } from "@/services/executionService";
+import type { TaskStatusCounts } from "@/types/pipelineRun";
 
 const StatusText = ({
   statusCounts,

--- a/src/components/shared/Status/TaskStatusBar.tsx
+++ b/src/components/shared/Status/TaskStatusBar.tsx
@@ -1,4 +1,4 @@
-import type { TaskStatusCounts } from "@/services/executionService";
+import type { TaskStatusCounts } from "@/types/pipelineRun";
 
 const getSegmentStyle = (width: string, hatched: boolean = false) =>
   hatched

--- a/src/services/executionService.test.ts
+++ b/src/services/executionService.test.ts
@@ -1,10 +1,8 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  getRunStatus,
-  STATUS,
-  type TaskStatusCounts,
-} from "./executionService";
+import type { TaskStatusCounts } from "@/types/pipelineRun";
+
+import { getRunStatus, STATUS } from "./executionService";
 
 describe("getRunStatus()", () => {
   it("should return CANCELLED when there are cancelled tasks", () => {

--- a/src/services/executionService.ts
+++ b/src/services/executionService.ts
@@ -4,6 +4,7 @@ import type {
   GetExecutionInfoResponse,
   GetGraphExecutionStateResponse,
 } from "@/api/types.gen";
+import type { TaskStatusCounts } from "@/types/pipelineRun";
 import { API_URL } from "@/utils/constants";
 
 export const fetchExecutionState = async (executionId: string) => {
@@ -16,19 +17,21 @@ export const fetchExecutionState = async (executionId: string) => {
   return response.json();
 };
 
-export const fetchExecutionInfo = (executionId: string) => {
-  const fetchDetails = async (): Promise<GetExecutionInfoResponse> => {
-    const response = await fetch(
-      `${API_URL}/api/executions/${executionId}/details`,
+export const fetchExecutionDetails = async (
+  executionId: string,
+): Promise<GetExecutionInfoResponse> => {
+  const response = await fetch(
+    `${API_URL}/api/executions/${executionId}/details`,
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch execution details: ${response.statusText}`,
     );
-    if (!response.ok) {
-      throw new Error(
-        `Failed to fetch execution details: ${response.statusText}`,
-      );
-    }
-    return response.json();
-  };
+  }
+  return response.json();
+};
 
+export const fetchExecutionInfo = (executionId: string) => {
   const {
     data: details,
     isLoading: isDetailsLoading,
@@ -36,7 +39,7 @@ export const fetchExecutionInfo = (executionId: string) => {
   } = useQuery<GetExecutionInfoResponse>({
     queryKey: ["pipeline-run-details", executionId],
     refetchOnWindowFocus: false,
-    queryFn: fetchDetails,
+    queryFn: () => fetchExecutionDetails(executionId),
   });
 
   const {
@@ -90,16 +93,6 @@ export const fetchExecutionStatus = async (executionId: string) => {
     );
   }
 };
-
-export interface TaskStatusCounts {
-  total: number;
-  succeeded: number;
-  failed: number;
-  running: number;
-  waiting: number;
-  skipped: number;
-  cancelled: number;
-}
 
 /**
  * Determine the overall run status based on the task statuses.

--- a/src/types/pipelineRun.ts
+++ b/src/types/pipelineRun.ts
@@ -6,4 +6,15 @@ export interface PipelineRun {
   pipeline_name: string;
   pipeline_digest?: string;
   status?: string;
+  statusCounts?: TaskStatusCounts;
+}
+
+export interface TaskStatusCounts {
+  total: number;
+  succeeded: number;
+  failed: number;
+  running: number;
+  waiting: number;
+  skipped: number;
+  cancelled: number;
 }


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Fixes an issue where the PipelineDetails context panel was refetching execution status info every time the panel rendered (i.e. after deselecting a node).

The relevant execution data is now fetched in PipelineRunsProvider when the page is loaded and provided to the panel so it does not need to fetch the data itself.

To keep initial load times reasonable it is now possible to specify how many recent executions the additional data will be fetched for. The execution info in the context panel will display this number of executions, with the remainder being relegated to "+X more executions" and not (currently) accessible.

This also mitigates somewhat the previous error spam in the console when an execution could not be found: now the run (without status) will be returned so at least we can display what run data we do have in the UI.

Most importantly, switching back to the pipeline details in the panel is now seamless and faster  🚀

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Closes https://github.com/Shopify/oasis-frontend/issues/111

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->
![image](https://github.com/user-attachments/assets/7537b7a8-6e8d-42ce-b3b6-29d10c63648b)


## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
Note: I moved relevant logic into a new RecentExecutions component to keep things tidy.

To test: in the pipeline editor load a pipeline for which you have some executions/runs. Select a node. Deselect the node. The panel should switch to the node details and back to pipeline details seamlessly. (previously when switching back to pipeline details it would refetch all the run info again).
