### PR TITLE
Populate Component Refs from Spec and Text before Url

### DIFF
--- a/src/providers/ComponentLibraryProvider.tsx
+++ b/src/providers/ComponentLibraryProvider.tsx
@@ -21,7 +21,7 @@ import {
   fetchUserComponents,
   filterToUniqueByDigest,
   flattenFolders,
-  populateComponentRefsFromUrls,
+  populateComponentRefs,
 } from "@/utils/componentLibrary";
 import type { ComponentReference } from "@/utils/componentSpec";
 import {
@@ -132,7 +132,7 @@ export const ComponentLibraryProvider = ({
     const { data: updatedLibrary } = await refetchLibrary();
 
     if (updatedLibrary) {
-      populateComponentRefsFromUrls(updatedLibrary).then((result) => {
+      populateComponentRefs(updatedLibrary).then((result) => {
         setComponentLibrary(result);
       });
     }
@@ -142,7 +142,7 @@ export const ComponentLibraryProvider = ({
     const { data: updatedUserComponents } = await refetchUserComponents();
 
     if (updatedUserComponents) {
-      populateComponentRefsFromUrls(updatedUserComponents).then((result) => {
+      populateComponentRefs(updatedUserComponents).then((result) => {
         setUserComponentsFolder(result);
       });
     }
@@ -395,7 +395,7 @@ export const ComponentLibraryProvider = ({
       setComponentLibrary(undefined);
       return;
     }
-    populateComponentRefsFromUrls(rawComponentLibrary).then((result) => {
+    populateComponentRefs(rawComponentLibrary).then((result) => {
       setComponentLibrary(result);
     });
   }, [rawComponentLibrary]);
@@ -405,7 +405,7 @@ export const ComponentLibraryProvider = ({
       setUserComponentsFolder(undefined);
       return;
     }
-    populateComponentRefsFromUrls(rawUserComponentsFolder).then((result) => {
+    populateComponentRefs(rawUserComponentsFolder).then((result) => {
       setUserComponentsFolder(result);
     });
   }, [rawUserComponentsFolder]);


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Component library will now load component refs first by spec, then by text, and only then by url.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Related: https://github.com/Shopify/oasis-frontend/issues/146

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
