### PR TITLE
Add BackendProvider and show Status in Menu

### DIFF
--- a/src/components/layout/AppMenu.tsx
+++ b/src/components/layout/AppMenu.tsx
@@ -5,6 +5,7 @@ import ImportPipeline from "@/components/shared/ImportPipeline";
 import { useLoadComponentSpecAndDetailsFromId } from "@/hooks/useLoadComponentSpecDetailsFromId";
 import { TOP_NAV_HEIGHT } from "@/utils/constants";
 
+import BackendStatus from "../shared/BackendStatus";
 import NewPipelineButton from "../shared/NewPipelineButton";
 
 const AppMenu = () => {
@@ -16,7 +17,7 @@ const AppMenu = () => {
       className="w-full bg-stone-900 p-2"
       style={{ height: `${TOP_NAV_HEIGHT}px` }}
     >
-      <div className="flex justify-between items-center w-3/4 mx-auto">
+      <div className="flex justify-between items-center w-full mx-auto px-8">
         <div className="flex flex-row gap-2 items-center">
           <Link to="/">
             <img
@@ -27,10 +28,13 @@ const AppMenu = () => {
           </Link>
           <span className="text-white text-sm font-bold">{title}</span>
         </div>
-        <div className="flex flex-row gap-2 items-center">
-          <CloneRunButton />
-          <ImportPipeline />
-          <NewPipelineButton />
+        <div className="flex flex-row gap-32 items-center">
+          <div className="flex flex-row gap-2 items-center">
+            <CloneRunButton />
+            <ImportPipeline />
+            <NewPipelineButton />
+          </div>
+          <BackendStatus />
         </div>
       </div>
     </div>

--- a/src/components/layout/RootLayout.tsx
+++ b/src/components/layout/RootLayout.tsx
@@ -5,6 +5,7 @@ import { ToastContainer } from "react-toastify";
 import { FullscreenProvider } from "@/components/shared/CodeViewer";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { BackendProvider } from "@/providers/BackendProvider";
 
 import AppFooter from "./AppFooter";
 import AppMenu from "./AppMenu";
@@ -13,25 +14,27 @@ const RootLayout = () => {
   useDocumentTitle();
 
   return (
-    <SidebarProvider>
-      <FullscreenProvider>
-        <ToastContainer />
+    <BackendProvider>
+      <SidebarProvider>
+        <FullscreenProvider>
+          <ToastContainer />
 
-        <div className="App flex flex-col min-h-screen w-full">
-          <AppMenu />
+          <div className="App flex flex-col min-h-screen w-full">
+            <AppMenu />
 
-          <main className="flex-1 grid">
-            <Outlet />
-          </main>
+            <main className="flex-1 grid">
+              <Outlet />
+            </main>
 
-          <AppFooter />
+            <AppFooter />
 
-          {import.meta.env.VITE_ENABLE_ROUTER_DEVTOOLS === "true" && (
-            <TanStackRouterDevtools />
-          )}
-        </div>
-      </FullscreenProvider>
-    </SidebarProvider>
+            {import.meta.env.VITE_ENABLE_ROUTER_DEVTOOLS === "true" && (
+              <TanStackRouterDevtools />
+            )}
+          </div>
+        </FullscreenProvider>
+      </SidebarProvider>
+    </BackendProvider>
   );
 };
 

--- a/src/components/shared/BackendStatus.tsx
+++ b/src/components/shared/BackendStatus.tsx
@@ -1,0 +1,48 @@
+import { Database } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { useBackend } from "@/providers/BackendProvider";
+
+const BackendStatus = () => {
+  const { available, backendUrl, ping } = useBackend();
+
+  const hideBackendUrl = backendUrl === import.meta.env.VITE_BACKEND_API_URL;
+  const backendAvailableString = hideBackendUrl
+    ? "Backend available"
+    : `Connected to ${backendUrl}`;
+
+  return (
+    <div className="flex items-center">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            onClick={ping}
+            className="bg-none hover:opacity-80"
+            size="icon"
+          >
+            <div className="relative">
+              <Database className="h-4 w-4 text-white flex-shrink-0" />
+              <span
+                className={cn(
+                  "absolute -bottom-0.25 -right-0.25 w-2 h-2 rounded-full border-1 border-slate-900",
+                  available ? "bg-green-500" : "bg-red-500",
+                )}
+              />
+            </div>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          {available ? backendAvailableString : "Backend unavailable"}
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  );
+};
+
+export default BackendStatus;

--- a/src/providers/BackendProvider.tsx
+++ b/src/providers/BackendProvider.tsx
@@ -1,0 +1,106 @@
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+import useToastNotification from "@/hooks/useToastNotification";
+
+type BackendContextType = {
+  available: boolean;
+  backendUrl: string;
+  ping: () => Promise<boolean>;
+  setBackendUrl: (url: string) => void;
+  resetBackendUrl: () => void;
+};
+
+const BackendContext = createContext<BackendContextType | undefined>(undefined);
+
+export const BackendProvider = ({ children }: { children: ReactNode }) => {
+  const notify = useToastNotification();
+
+  const [backendUrl, setBackendUrl] = useState(() => {
+    return (
+      localStorage.getItem("backendUrl") ||
+      import.meta.env.VITE_BACKEND_API_URL ||
+      ""
+    );
+  });
+  const [available, setAvailable] = useState(false);
+
+  const handleSetBackendUrl = useCallback((url: string) => {
+    setBackendUrl(url);
+    localStorage.setItem("backendUrl", url);
+  }, []);
+
+  const resetBackendUrl = useCallback(() => {
+    setBackendUrl(import.meta.env.VITE_BACKEND_API_URL || "");
+    localStorage.removeItem("backendUrl");
+  }, []);
+
+  const ping = useCallback(
+    (notification = true) => {
+      if (!backendUrl) {
+        if (notification) {
+          notify("Backend is not configured", "error");
+        }
+        setAvailable(false);
+        return Promise.resolve(false);
+      }
+      return fetch(`${backendUrl}/services/ping`)
+        .then((res) => {
+          if (notification) {
+            if (res.ok) {
+              notify("Backend available", "success");
+            } else {
+              notify(`Backend unavailable: ${res.statusText}`, "error");
+            }
+          }
+          setAvailable(res.ok);
+          return res.ok;
+        })
+        .catch(() => {
+          if (notification) {
+            notify("Backend unavailable", "error");
+          }
+          setAvailable(false);
+          return false;
+        });
+    },
+    [backendUrl],
+  );
+
+  useEffect(() => {
+    ping(false);
+  }, [backendUrl]);
+
+  const contextValue = useMemo(
+    () => ({
+      available,
+      backendUrl,
+      ping,
+      setBackendUrl: handleSetBackendUrl,
+      resetBackendUrl,
+    }),
+    [available, backendUrl, ping, handleSetBackendUrl, resetBackendUrl],
+  );
+
+  return (
+    <BackendContext.Provider value={contextValue}>
+      {children}
+    </BackendContext.Provider>
+  );
+};
+
+export const useBackend = () => {
+  const ctx = useContext(BackendContext);
+  if (!ctx)
+    throw new Error(
+      "useBackend must be used within a ComponentLibraryProvider",
+    );
+  return ctx;
+};


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Wraps the app in a BackendProvider that provides the app with the ability to ping the backend to see how it's doing. This is then used to display the backend status on the menu bar. Click the status to ping the backend for an update (will be changed in a later PR to open a dialog where backend url can be edited)

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Progresses https://github.com/Shopify/oasis-frontend/issues/133

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->
<img width="547" height="128" alt="image" src="https://github.com/user-attachments/assets/783bc16e-a103-45e8-9af9-f286f7e23ed9" />


## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->

This will be developed in further PR's into a system where users without a backend will be prompted to configure their own one. At the moment this PR is intended to provide a foundation or skeleton to work from.
