### PR TITLE
Backend Configuration Dialog

### DIFF
--- a/src/components/shared/BackendStatus.tsx
+++ b/src/components/shared/BackendStatus.tsx
@@ -1,4 +1,5 @@
 import { Database } from "lucide-react";
+import { useCallback, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -9,8 +10,16 @@ import {
 import { cn } from "@/lib/utils";
 import { useBackend } from "@/providers/BackendProvider";
 
+import BackendConfigurationDialog from "./Dialogs/BackendConfigurationDialog";
+
 const BackendStatus = () => {
-  const { available, backendUrl, ping } = useBackend();
+  const { available, backendUrl } = useBackend();
+
+  const [open, setOpen] = useState(false);
+
+  const handleOpen = useCallback(() => {
+    setOpen(true);
+  }, []);
 
   const hideBackendUrl = backendUrl === import.meta.env.VITE_BACKEND_API_URL;
   const backendAvailableString = hideBackendUrl
@@ -18,11 +27,11 @@ const BackendStatus = () => {
     : `Connected to ${backendUrl}`;
 
   return (
-    <div className="flex items-center">
+    <>
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
-            onClick={ping}
+            onClick={handleOpen}
             className="bg-none hover:opacity-80"
             size="icon"
           >
@@ -41,7 +50,9 @@ const BackendStatus = () => {
           {available ? backendAvailableString : "Backend unavailable"}
         </TooltipContent>
       </Tooltip>
-    </div>
+
+      <BackendConfigurationDialog open={open} setOpen={setOpen} />
+    </>
   );
 };
 

--- a/src/components/shared/Dialogs/BackendConfigurationDialog.tsx
+++ b/src/components/shared/Dialogs/BackendConfigurationDialog.tsx
@@ -1,0 +1,232 @@
+import { AlertCircle, DatabaseZap, RefreshCcw } from "lucide-react";
+import { type ChangeEvent, useCallback, useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { useBackend } from "@/providers/BackendProvider";
+
+import { InfoBox } from "../InfoBox";
+
+interface BackendConfigurationDialogProps {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+const BackendConfigurationDialog = ({
+  open,
+  setOpen,
+}: BackendConfigurationDialogProps) => {
+  const {
+    backendUrl,
+    available,
+    isConfiguredFromEnv,
+    ping,
+    setEnvConfig,
+    setBackendUrl,
+  } = useBackend();
+
+  const [inputBackendUrl, setInputBackendUrl] = useState(
+    isConfiguredFromEnv ? "" : backendUrl,
+  );
+  const [inputBackendTestResult, setInputBackendTestResult] = useState<
+    boolean | null
+  >(null);
+  const [isEnvConfig, setIsEnvConfig] = useState(isConfiguredFromEnv);
+
+  const hasEnvConfig = !!import.meta.env.VITE_BACKEND_API_URL;
+
+  const handleInputChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    setInputBackendUrl(e.target.value);
+    setInputBackendTestResult(null);
+  }, []);
+
+  const handleRefresh = useCallback(() => {
+    ping({});
+  }, [ping]);
+
+  const handleTest = useCallback(async () => {
+    const result = await ping({
+      url: inputBackendUrl,
+      notifyResult: true,
+      saveAvailability: false,
+    });
+    setInputBackendTestResult(result);
+  }, [inputBackendUrl, ping]);
+
+  const handleConfirm = useCallback(() => {
+    setEnvConfig(isEnvConfig);
+    setBackendUrl(inputBackendUrl);
+    setInputBackendTestResult(null);
+    setOpen(false);
+  }, [isEnvConfig, inputBackendUrl, setEnvConfig, setBackendUrl, setOpen]);
+
+  const handleClose = useCallback(() => {
+    setIsEnvConfig(isConfiguredFromEnv);
+    setInputBackendUrl("");
+    setInputBackendTestResult(null);
+    setOpen(false);
+  }, [isConfiguredFromEnv, setOpen]);
+
+  useEffect(() => {
+    setIsEnvConfig(isConfiguredFromEnv);
+  }, [isConfiguredFromEnv, setIsEnvConfig]);
+
+  useEffect(() => {
+    setInputBackendUrl(isConfiguredFromEnv ? "" : backendUrl);
+  }, [isConfiguredFromEnv, backendUrl, setInputBackendUrl]);
+
+  const hasBackendConfigured =
+    !!inputBackendUrl || (isEnvConfig && hasEnvConfig);
+  const confirmButtonText = hasBackendConfigured
+    ? "Confirm"
+    : "Continue without backend";
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent
+        className="w-2xl overflow-hidden"
+        aria-label="Configure backend"
+      >
+        <DialogHeader>
+          <DialogTitle>
+            <span>Configure Backend</span>
+          </DialogTitle>
+        </DialogHeader>
+
+        <DialogDescription aria-label="Configure backend">
+          <span>Attach the Oasis frontend to a valid backend.</span>
+        </DialogDescription>
+
+        <div className="flex flex-col gap-4">
+          <div className="flex items-center gap-2">
+            <span>Backend status: </span>
+            <Tooltip>
+              <TooltipTrigger className="flex items-center gap-2" tabIndex={-1}>
+                <span
+                  className={cn(
+                    "w-2 h-2 rounded-full",
+                    available ? "bg-green-500" : "bg-red-500",
+                  )}
+                />
+                <span className="font-light text-xs italic">
+                  {available ? "available" : "unavailable"}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                {isConfiguredFromEnv && hasEnvConfig
+                  ? "Configured from .env"
+                  : backendUrl.length > 0
+                    ? `Configured to ${backendUrl}`
+                    : "No backend configured"}
+              </TooltipContent>
+            </Tooltip>
+            <Button onClick={handleRefresh} size="icon" variant="ghost">
+              <RefreshCcw />
+            </Button>
+          </div>
+
+          {hasEnvConfig && (
+            <>
+              <hr />
+              <div className="flex flex-col gap-2">
+                <p className="font-semibold">Configure using .env</p>
+                <div className="flex items-center gap-2">
+                  <Switch
+                    checked={isEnvConfig}
+                    onCheckedChange={setIsEnvConfig}
+                  />
+                  Use backend url configuration from environment file.
+                </div>
+              </div>
+            </>
+          )}
+
+          {!(isEnvConfig && hasEnvConfig) && (
+            <>
+              <hr />
+              <InfoBox title="Manual Configuration">
+                <span>
+                  You can set the backend URL in the environment file or use the
+                  input below.
+                </span>
+              </InfoBox>
+              <div>
+                <label className="block text-sm font-medium text-gray-700">
+                  Backend URL
+                </label>
+                <div className="relative flex items-center">
+                  <Input
+                    type="text"
+                    value={inputBackendUrl}
+                    placeholder="http://localhost:8000"
+                    onChange={handleInputChange}
+                    className={inputBackendTestResult !== null ? "pr-10" : ""}
+                  />
+                  {inputBackendTestResult !== null && (
+                    <Tooltip>
+                      <TooltipTrigger
+                        className={cn(
+                          "absolute right-24 flex items-center h-full text-lg",
+                          inputBackendTestResult
+                            ? "text-green-500"
+                            : "text-red-500",
+                        )}
+                      >
+                        {inputBackendTestResult ? "✓" : "✗"}
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {inputBackendTestResult
+                          ? "Backend responded"
+                          : "No response"}
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                  <Button
+                    variant="secondary"
+                    className="ml-2"
+                    onClick={handleTest}
+                  >
+                    <DatabaseZap className="h-4 w-4" />
+                    Test
+                  </Button>
+                </div>
+              </div>
+              {!inputBackendUrl && (
+                <div className="flex items-center gap-2">
+                  <AlertCircle className="inline-block text-red-500 h-4 w-4" />
+                  <p className="text-red-500 text-sm">
+                    No backend is configured. Certain features may not be
+                    operable.
+                  </p>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="secondary" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleConfirm}>{confirmButtonText}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default BackendConfigurationDialog;

--- a/src/utils/URL.test.ts
+++ b/src/utils/URL.test.ts
@@ -1,0 +1,195 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import {
+  convertGcsUrlToBrowserUrl,
+  convertGithubUrlToDirectoryUrl,
+  downloadYamlFromComponentText,
+  getIdOrTitleFromPath,
+  normalizeUrl,
+} from "./URL";
+
+// normalizeUrl tests
+describe("normalizeUrl", () => {
+  it("returns empty string for empty input", () => {
+    expect(normalizeUrl("")).toBe("");
+  });
+
+  it("returns empty string for input with only spaces", () => {
+    expect(normalizeUrl("   ")).toBe("");
+  });
+
+  it("returns unchanged for http:// URLs", () => {
+    expect(normalizeUrl("http://example.com")).toBe("http://example.com");
+  });
+
+  it("returns unchanged for https:// URLs", () => {
+    expect(normalizeUrl("https://example.com")).toBe("https://example.com");
+  });
+
+  it("prepends http:// for URLs without protocol", () => {
+    expect(normalizeUrl("example.com")).toBe("http://example.com");
+  });
+
+  it("trims spaces and prepends http:// if missing", () => {
+    expect(normalizeUrl("  example.com  ")).toBe("http://example.com");
+  });
+
+  it("does not prepend protocol for uppercase HTTP/HTTPS", () => {
+    expect(normalizeUrl("HTTP://example.com")).toBe("HTTP://example.com");
+    expect(normalizeUrl("HTTPS://example.com")).toBe("HTTPS://example.com");
+  });
+
+  it("prepends http:// for other protocols", () => {
+    expect(normalizeUrl("ftp://example.com")).toBe("http://ftp://example.com");
+  });
+});
+
+// convertGcsUrlToBrowserUrl tests
+describe("convertGcsUrlToBrowserUrl", () => {
+  it("returns unchanged if not a gs:// url", () => {
+    expect(convertGcsUrlToBrowserUrl("http://example.com", false)).toBe(
+      "http://example.com",
+    );
+  });
+
+  it("converts gs:// bucket to browser directory url", () => {
+    expect(convertGcsUrlToBrowserUrl("gs://my-bucket/my-dir", true)).toBe(
+      "https://console.cloud.google.com/storage/browser/my-bucket/my-dir",
+    );
+  });
+
+  it("converts gs:// file to cloud storage url", () => {
+    expect(convertGcsUrlToBrowserUrl("gs://my-bucket/my-file.txt", false)).toBe(
+      "https://storage.cloud.google.com/my-bucket/my-file.txt",
+    );
+  });
+});
+
+// convertGithubUrlToDirectoryUrl tests
+describe("convertGithubUrlToDirectoryUrl", () => {
+  it("converts raw github url to directory url", () => {
+    const rawUrl =
+      "https://raw.githubusercontent.com/user/repo/commit/path/to/file.txt";
+    expect(convertGithubUrlToDirectoryUrl(rawUrl)).toBe(
+      "https://github.com/user/repo/tree/commit/path/to",
+    );
+  });
+
+  it("converts web github url to directory url", () => {
+    const webUrl = "https://github.com/user/repo/blob/commit/path/to/file.txt";
+    expect(convertGithubUrlToDirectoryUrl(webUrl)).toBe(
+      "https://github.com/user/repo/tree/commit/path/to",
+    );
+  });
+
+  it("throws error for unsupported github url format", () => {
+    expect(() =>
+      convertGithubUrlToDirectoryUrl("https://github.com/user/repo"),
+    ).toThrow();
+  });
+
+  it("throws error for invalid raw github url", () => {
+    expect(() =>
+      convertGithubUrlToDirectoryUrl(
+        "https://raw.githubusercontent.com/user/repo",
+      ),
+    ).toThrow();
+  });
+
+  it("throws error for invalid web github url", () => {
+    expect(() =>
+      convertGithubUrlToDirectoryUrl(
+        "https://github.com/user/repo/blob/commit/",
+      ),
+    ).toThrow();
+  });
+});
+
+// getIdOrTitleFromPath tests
+describe("getIdOrTitleFromPath", () => {
+  it("returns last path segment and enableApi true if RUNS_BASE_PATH is present", () => {
+    const path = "/foo/bar/runs/123";
+    // mock RUNS_BASE_PATH to "/runs"
+    vi.mock("@/routes/router", () => ({
+      RUNS_BASE_PATH: "/runs",
+    }));
+    const { idOrTitle, enableApi } = getIdOrTitleFromPath(path);
+    expect(idOrTitle).toBe("123");
+    expect(enableApi).toBe(true);
+  });
+
+  it("returns last path segment and enableApi false if RUNS_BASE_PATH is not present", () => {
+    const path = "/foo/bar/other/456";
+    const { idOrTitle, enableApi } = getIdOrTitleFromPath(path);
+    expect(idOrTitle).toBe("456");
+    expect(enableApi).toBe(false);
+  });
+
+  it("decodes URI components", () => {
+    const path = "/foo/bar/runs/some%20id";
+    const { idOrTitle } = getIdOrTitleFromPath(path);
+    expect(idOrTitle).toBe("some id");
+  });
+
+  it("returns empty string if path ends with slash", () => {
+    const path = "/foo/bar/runs/";
+    const { idOrTitle } = getIdOrTitleFromPath(path);
+    expect(idOrTitle).toBe("");
+  });
+});
+
+// downloadYamlFromComponentText tests
+describe("downloadYamlFromComponentText", () => {
+  beforeAll(() => {
+    // @ts-expect-error: global.URL may not exist in the test environment, so we mock it for testing purposes
+    global.URL = {
+      createObjectURL: vi.fn(),
+      revokeObjectURL: vi.fn(),
+    };
+  });
+
+  afterAll(() => {
+    // @ts-expect-error: global.URL may not exist in the test environment, so we mock it for testing purposes
+    delete global.URL;
+  });
+
+  it("creates a downloadable yaml file with correct name", () => {
+    const mockComponentSpec = { name: "testComponent", foo: "bar" };
+    const displayName = "displayName";
+    const createObjectURLSpy = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:url");
+    const revokeObjectURLSpy = vi
+      .spyOn(URL, "revokeObjectURL")
+      .mockImplementation(() => {});
+    const appendChildSpy = vi
+      .spyOn(document.body, "appendChild")
+      .mockImplementation((node) => node);
+    const removeChildSpy = vi
+      .spyOn(document.body, "removeChild")
+      .mockImplementation((node) => node);
+    const clickSpy = vi.fn();
+
+    vi.spyOn(document, "createElement").mockImplementation(
+      () =>
+        ({
+          href: "",
+          download: "",
+          click: clickSpy,
+        }) as any,
+    );
+
+    downloadYamlFromComponentText(mockComponentSpec as any, displayName);
+
+    expect(createObjectURLSpy).toHaveBeenCalled();
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith("blob:url");
+    expect(appendChildSpy).toHaveBeenCalled();
+    expect(removeChildSpy).toHaveBeenCalled();
+    expect(clickSpy).toHaveBeenCalled();
+
+    createObjectURLSpy.mockRestore();
+    revokeObjectURLSpy.mockRestore();
+    appendChildSpy.mockRestore();
+    removeChildSpy.mockRestore();
+  });
+});

--- a/src/utils/URL.ts
+++ b/src/utils/URL.ts
@@ -108,10 +108,23 @@ const getBackendUrlFromEnv = () => {
   return url || "";
 };
 
+const normalizeUrl = (url: string) => {
+  if (url.trim() === "") {
+    return "";
+  }
+
+  let normalizedUrl = url.trim();
+  if (!/^https?:\/\//i.test(normalizedUrl)) {
+    normalizedUrl = "http://" + normalizedUrl;
+  }
+  return normalizedUrl;
+};
+
 export {
   convertGcsUrlToBrowserUrl,
   convertGithubUrlToDirectoryUrl,
   downloadYamlFromComponentText,
   getBackendUrlFromEnv,
   getIdOrTitleFromPath,
+  normalizeUrl,
 };

--- a/src/utils/localforage.ts
+++ b/src/utils/localforage.ts
@@ -41,6 +41,12 @@ const userComponentStore = localforage.createInstance({
   description: "Store for user component data",
 });
 
+const settingsStore = localforage.createInstance({
+  name: "oasis-app",
+  storeName: "settings",
+  description: "Store for application settings",
+});
+
 // Function to save a component
 export async function saveComponent(component: Component): Promise<Component> {
   const now = Date.now();
@@ -87,3 +93,16 @@ export async function getAllUserComponents(): Promise<UserComponent[]> {
 
   return userComponents;
 }
+
+// App Settings
+export const getUserBackendUrl = async () => {
+  return (await settingsStore.getItem<string>("userBackendUrl")) ?? "";
+};
+export const setUserBackendUrl = (url: string) =>
+  settingsStore.setItem("userBackendUrl", url);
+
+export const getUseEnv = async () => {
+  return (await settingsStore.getItem<boolean>("useEnv")) ?? true;
+};
+export const setUseEnv = (flag: boolean) =>
+  settingsStore.setItem("useEnv", flag);


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Implements a dialog where the user can configure a backend url and test it.

NOTE: this does not propagate the entered backend url through to fetch methods and such. That functionality will come in the next PR.

Also includes a toggle to use the config from the env file, or override it with a user-entered value.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Progresses https://github.com/Shopify/oasis-frontend/issues/133

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] New feature

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<img width="714" height="339" alt="image" src="https://github.com/user-attachments/assets/70a12837-e903-47b0-a1db-721c1288ea2e" />

<img width="702" height="534" alt="image" src="https://github.com/user-attachments/assets/8316064d-856f-47c9-b5c8-681a483245b1" />

<img width="693" height="494" alt="image" src="https://github.com/user-attachments/assets/af28f1fb-1c2c-4e9a-a4e2-87acd8f1ae04" />



## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
