### PR TITLE
Potential Fix for Empty Pipeline Exports on Staging/Production

### DIFF
--- a/src/components/shared/ReactFlow/FlowSidebar/sections/SettingsAndActions.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/SettingsAndActions.tsx
@@ -1,5 +1,4 @@
 import { useNavigate } from "@tanstack/react-router";
-import { useStoreApi } from "@xyflow/react";
 import { FileDownIcon, FileUpIcon, Save, SaveAll } from "lucide-react";
 import { useEffect, useMemo, useRef } from "react";
 
@@ -25,8 +24,6 @@ const SettingsAndActions = ({ isOpen }: { isOpen: boolean }) => {
   const { savePipeline } = useSavePipeline(componentSpec);
   const notify = useToastNotification();
   const navigate = useNavigate();
-  const store = useStoreApi();
-  const nodes = store.getState().nodes.filter((node) => node.type === "task");
 
   const notifyPipelineSaved = (name: string) => {
     notify(`Pipeline saved as "${name}"`, "success");
@@ -60,16 +57,6 @@ const SettingsAndActions = ({ isOpen }: { isOpen: boolean }) => {
 
   const componentText = useMemo(() => {
     try {
-      if (
-        !componentSpecRef.current ||
-        !nodes.length ||
-        !("graph" in componentSpecRef.current.implementation) ||
-        !componentSpecRef.current?.implementation?.graph?.tasks ||
-        Object.keys(componentSpecRef.current?.implementation?.graph?.tasks)
-          .length !== nodes.length
-      ) {
-        return "";
-      }
       return componentSpecToYaml(componentSpecRef.current);
     } catch (err) {
       console.error("Error preparing pipeline for export:", err);
@@ -77,7 +64,7 @@ const SettingsAndActions = ({ isOpen }: { isOpen: boolean }) => {
         ? componentSpecToYaml(componentSpecRef.current)
         : "";
     }
-  }, [nodes]);
+  }, [componentSpecRef]);
 
   const componentTextBlob = new Blob([componentText], { type: "text/yaml" });
   const filename = componentSpec?.name


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
https://github.com/Cloud-Pipelines/pipeline-studio-app/pull/485 removed outdated autosave logic which had proven to be buggy. This PR removes some additional code that had been added to circumvent errors that were caused by the old autosave feature. Now that the feature has been removed we no longer need the workaround code.

Additionally, we now have a new autosave feature and the workaround is now potentially a detriment that is causing the export pipeline feature to print empty yaml files after a pipeline has been reloaded.

The exact cause is not known (on of the boolean conditions in the if statement must be failing), but it is possible that with additional node types recently added the task/node length check is the culprit.

This PR will be immediately pushed through to staging for testing.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Hopefully closes https://github.com/Cloud-Pipelines/pipeline-studio-app/issues/548

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
