### PR TITLE
Adds polling to status on side bar

### DIFF
--- a/src/components/PipelineRun/RunDetails.test.tsx
+++ b/src/components/PipelineRun/RunDetails.test.tsx
@@ -8,9 +8,11 @@ import type {
   GetGraphExecutionStateResponse,
 } from "@/api/types.gen";
 import { useExecutionStatusQuery } from "@/hooks/useExecutionStatusQuery";
+import { ComponentSpecProvider } from "@/providers/ComponentSpecProvider";
 import { PipelineRunsProvider } from "@/providers/PipelineRunsProvider";
 import * as executionService from "@/services/executionService";
 import * as pipelineRunService from "@/services/pipelineRunService";
+import type { ComponentSpec } from "@/utils/componentSpec";
 
 import { RunDetails } from "./RunDetails";
 
@@ -76,6 +78,25 @@ describe("<RunDetails/>", () => {
     },
   };
 
+  const mockComponentSpec: ComponentSpec = {
+    name: "Test Pipeline",
+    description: "Test pipeline description",
+    metadata: {
+      annotations: {
+        "test-annotation": "test-value",
+      },
+    },
+    inputs: [],
+    outputs: [],
+    implementation: {
+      container: {
+        image: "test-image",
+        command: ["test-command"],
+        args: ["test-arg"],
+      },
+    },
+  };
+
   const mockPipelineRun = {
     id: 123,
     root_execution_id: 456,
@@ -103,11 +124,13 @@ describe("<RunDetails/>", () => {
 
   const renderWithQueryClient = (component: React.ReactElement) => {
     return render(
-      <QueryClientProvider client={queryClient}>
-        <PipelineRunsProvider pipelineName={mockPipelineRun.pipeline_name}>
-          {component}
-        </PipelineRunsProvider>
-      </QueryClientProvider>,
+      <ComponentSpecProvider spec={mockComponentSpec}>
+        <QueryClientProvider client={queryClient}>
+          <PipelineRunsProvider pipelineName={mockPipelineRun.pipeline_name}>
+            {component}
+          </PipelineRunsProvider>
+        </QueryClientProvider>
+      </ComponentSpecProvider>,
     );
   };
 

--- a/src/services/executionService.ts
+++ b/src/services/executionService.ts
@@ -31,7 +31,10 @@ export const fetchExecutionDetails = async (
   return response.json();
 };
 
-export const fetchExecutionInfo = (executionId: string) => {
+export const fetchExecutionInfo = (
+  executionId: string,
+  poll: boolean = false,
+) => {
   const {
     data: details,
     isLoading: isDetailsLoading,
@@ -40,6 +43,7 @@ export const fetchExecutionInfo = (executionId: string) => {
     queryKey: ["pipeline-run-details", executionId],
     refetchOnWindowFocus: false,
     queryFn: () => fetchExecutionDetails(executionId),
+    refetchInterval: poll ? 5000 : false,
   });
 
   const {
@@ -50,6 +54,7 @@ export const fetchExecutionInfo = (executionId: string) => {
     queryKey: ["pipeline-run-state", executionId],
     refetchOnWindowFocus: false,
     queryFn: () => fetchExecutionState(executionId),
+    refetchInterval: poll ? 5000 : false,
   });
 
   const isLoading = isDetailsLoading || isStateLoading;
@@ -125,11 +130,11 @@ export const getRunStatus = (statusData: TaskStatusCounts) => {
   return STATUS.UNKNOWN;
 };
 
-export const isStatusInProgress = (status: string) => {
+export const isStatusInProgress = (status: string = "") => {
   return status === STATUS.RUNNING || status === STATUS.WAITING;
 };
 
-export const isStatusComplete = (status: string) => {
+export const isStatusComplete = (status: string = "") => {
   return (
     status === STATUS.SUCCEEDED ||
     status === STATUS.FAILED ||


### PR DESCRIPTION
## Description
resolves: https://github.com/Shopify/oasis-frontend/issues/143

This PR fixes an issue where the run status wasn't updating. You can use



Copilot:
This pull request introduces enhancements to the `RunDetails` component and related services, focusing on improving polling functionality, integrating the `ComponentSpecProvider`, and refining error handling. The changes primarily affect the `RunDetails` component, its corresponding test file, and the `executionService`.

### Enhancements to polling functionality:
* [`src/components/PipelineRun/RunDetails.tsx`](diffhunk://#diff-e0f565b9451ffdc2507ef5c334dbe20d0e726b8211b79830703b77a8913e2da7R29-R44): Added polling control via the `isPolling` state and updated the `fetchExecutionInfo` function to use the `poll` parameter for dynamic refetch intervals. Polling stops automatically when the pipeline run status is complete. [[1]](diffhunk://#diff-e0f565b9451ffdc2507ef5c334dbe20d0e726b8211b79830703b77a8913e2da7R29-R44) [[2]](diffhunk://#diff-e0f565b9451ffdc2507ef5c334dbe20d0e726b8211b79830703b77a8913e2da7L57-R66)
* [`src/services/executionService.ts`](diffhunk://#diff-3a18ac868f996567a095520107b9960fee8198412100f5021bf86aff0083b812L34-R37): Modified `fetchExecutionInfo` to accept a `poll` parameter, enabling dynamic refetch intervals for execution details and state. [[1]](diffhunk://#diff-3a18ac868f996567a095520107b9960fee8198412100f5021bf86aff0083b812L34-R37) [[2]](diffhunk://#diff-3a18ac868f996567a095520107b9960fee8198412100f5021bf86aff0083b812R46) [[3]](diffhunk://#diff-3a18ac868f996567a095520107b9960fee8198412100f5021bf86aff0083b812R57)

### Integration of `ComponentSpecProvider`:
* [`src/components/PipelineRun/RunDetails.tsx`](diffhunk://#diff-e0f565b9451ffdc2507ef5c334dbe20d0e726b8211b79830703b77a8913e2da7R5): Replaced the `untypedComponentSpec` with `componentSpec` from the `ComponentSpecProvider`, ensuring consistent handling of component specifications. [[1]](diffhunk://#diff-e0f565b9451ffdc2507ef5c334dbe20d0e726b8211b79830703b77a8913e2da7R5) [[2]](diffhunk://#diff-e0f565b9451ffdc2507ef5c334dbe20d0e726b8211b79830703b77a8913e2da7L57-R66) [[3]](diffhunk://#diff-e0f565b9451ffdc2507ef5c334dbe20d0e726b8211b79830703b77a8913e2da7L75-L79)
* [`src/components/PipelineRun/RunDetails.test.tsx`](diffhunk://#diff-f6613a344b22f9f527d55a4aa5cc7b32d08c8ab728193769a0f35c153e6cdc82R11-R15): Updated tests to include `ComponentSpecProvider` in the rendering logic and added a mock `ComponentSpec` for testing purposes. [[1]](diffhunk://#diff-f6613a344b22f9f527d55a4aa5cc7b32d08c8ab728193769a0f35c153e6cdc82R11-R15) [[2]](diffhunk://#diff-f6613a344b22f9f527d55a4aa5cc7b32d08c8ab728193769a0f35c153e6cdc82R81-R99) [[3]](diffhunk://#diff-f6613a344b22f9f527d55a4aa5cc7b32d08c8ab728193769a0f35c153e6cdc82R127-R133)

### Refinements to error handling:
* [`src/services/executionService.ts`](diffhunk://#diff-3a18ac868f996567a095520107b9960fee8198412100f5021bf86aff0083b812L128-R137): Enhanced `isStatusInProgress` and `isStatusComplete` functions to handle undefined or empty status strings gracefully.
<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

You can test it easily by using this component: 

```yaml
name: Sleep then pass value
inputs:
  - name: Seconds
    type: Integer
    default: '60'
  - name: Value
    description: The value to pass.
outputs:
  - name: Value
    description: Passed value.
implementation:
  container:
    image: alpine
    command:
      - sh
      - '-c'
      - |
        seconds=$0
        value=$1
        output_path=$2
        sleep $seconds
        mkdir -p "$(dirname "$output_path")"
        printf "$value" >"$output_path"
      - inputValue: Seconds
      - inputValue: Value
      - outputPath: Value

```

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
