### PR TITLE
Configure Backend By Relative URL

### DIFF
--- a/src/utils/localforage.ts
+++ b/src/utils/localforage.ts
@@ -112,3 +112,10 @@ export const getUseEnv = async () => {
 };
 export const setUseEnv = (flag: boolean) =>
   settingsStore.setItem("useEnv", flag);
+
+export const getUseRelativePath = async () => {
+  return (await settingsStore.getItem<boolean>("useRelativePath")) ?? true;
+};
+
+export const setUseRelativePath = (flag: boolean) =>
+  settingsStore.setItem("useRelativePath", flag);


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Follows #551 to allow the backend to be configured relative to the frontend url if there is no env variable. this is needed to keep the app functioning on staging & production, as env variables are not available there and they are configured relative to the domain.

When there is no env defined the system will instead attempt to use a relative backend url.

Also cleans-up some of the experimentation I was doing on staging.

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->
<img width="572" height="390" alt="image" src="https://github.com/user-attachments/assets/2f8f0b18-8a61-459b-a679-24814206a57b" />


## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
