### PR TITLE
Fix Spec not unloading when pipeline is closed

### DIFF
--- a/src/hooks/useLoadComponentSpecFromId.ts
+++ b/src/hooks/useLoadComponentSpecFromId.ts
@@ -19,7 +19,10 @@ export const useLoadComponentSpecFromId = () => {
 
   useEffect(() => {
     const loadPipelineFromStorage = async () => {
-      if (!idOrTitle) return;
+      if (!idOrTitle) {
+        setComponentSpec(undefined);
+        return;
+      }
 
       setIsLoadingPipeline(true);
       try {


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Fixes a bug where pipeline spec was not unloaded when the pipeline was closed, resulting in the clone button returning the wrong pipeline and potentially other downstream issues.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Closes https://github.com/Shopify/oasis-frontend/issues/168

tbc https://github.com/Shopify/oasis-frontend/issues/169

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
