### PR TITLE
Extend log polling to 5s

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/logs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/logs.tsx
@@ -87,11 +87,11 @@ const Logs = ({
     log_text?: string;
     system_error_exception_full?: string;
   }>();
-  const { data, isLoading, isFetching, error, refetch } = useQuery({
+  const { data, isLoading, error, refetch } = useQuery({
     queryKey: ["logs", executionId],
     queryFn: () => getLogs(String(executionId), backendUrl),
     enabled: isLogging,
-    refetchInterval: 1000,
+    refetchInterval: 5000,
     refetchIntervalInBackground: false,
   });
 
@@ -126,7 +126,7 @@ const Logs = ({
     );
   }
 
-  if (isLoading || isFetching) {
+  if (isLoading) {
     return (
       <div className="flex gap-2 items-center">
         <Spinner /> Loading Logs...


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Polling every 1s could be an issue for large logs. Changing to 5s.

Also removes `isFetching` which was causing it to flicker between logs and loading state. Another solution will be needed when reloading logs due to a change in backend url.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
