### PR TITLE
Fix Task Node buttons not working due to stale nodes reference

### DIFF
--- a/src/components/shared/TaskDetails/Details.tsx
+++ b/src/components/shared/TaskDetails/Details.tsx
@@ -61,6 +61,7 @@ const TaskDetails = ({
   additionalSection = [],
 }: TaskDetailsProps) => {
   const notify = useToastNotification();
+
   const [confirmDelete, setConfirmDelete] = useState(false);
   const { isCopied, isTooltipOpen, handleCopy, handleTooltipOpen } =
     useCopyToClipboard(componentDigest);
@@ -124,7 +125,7 @@ const TaskDetails = ({
     );
   };
 
-  const handleDelete = useCallback(async () => {
+  const handleDelete = useCallback(() => {
     if (confirmDelete || !hasDeletionConfirmation) {
       try {
         onDelete?.();
@@ -291,6 +292,7 @@ const TaskDetails = ({
             </TooltipTrigger>
             <TooltipContent>Copy YAML</TooltipContent>
           </Tooltip>
+
           {!readOnly && actions}
 
           {onDelete && !readOnly && (


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Fixes an issue where the callbacks passed into a task node were memoized with stale `nodes` array references on first render, meaning that an operation would not succeed.

The callbacks will now fetch the nodes array when called rather than relying on a memoized value.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Closes https://github.com/Shopify/oasis-frontend/issues/169

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
