### PR TITLE
Inline fullscreen element

### DIFF
--- a/src/betaFlags.ts
+++ b/src/betaFlags.ts
@@ -4,4 +4,10 @@ export const ExistingBetaFlags = {
     description: "Enable the code viewer virtualization.",
     default: false,
   },
+  ["fullscreen-code-viewer"]: {
+    name: "Fullscreen Code Viewer",
+    description: "Enable the fast fullscreen code viewer via inline element.",
+    enabled: false,
+    default: false,
+  },
 };

--- a/src/components/shared/CodeViewer/CodeSyntaxHighlighter.tsx
+++ b/src/components/shared/CodeViewer/CodeSyntaxHighlighter.tsx
@@ -120,6 +120,19 @@ const VirtualizedViewportContent = memo(function VirtualizedViewportContent({
   );
 });
 
+function bypassScrollLocks(element: HTMLElement | null) {
+  if (element) {
+    /**
+     * To ensure scrolling the code viewer in any context (e.g. fullscreen)
+     * we need to bypass the scroll locks introduced by https://github.com/theKashey/react-remove-scroll in Dialogs
+     */
+    element.onwheel = (e) => e.stopPropagation();
+    element.ontouchmove = (e) => e.stopPropagation();
+  }
+
+  return element;
+}
+
 function VirtualizedViewport({
   rows,
   stylesheet,
@@ -146,7 +159,9 @@ function VirtualizedViewport({
     <div
       ref={(el) => {
         if (!listRef.current) {
-          listRef.current = el?.closest("pre")?.parentElement ?? null;
+          listRef.current = bypassScrollLocks(
+            el?.closest("pre")?.parentElement ?? null,
+          );
         }
       }}
     >

--- a/src/components/shared/CodeViewer/CodeViewer.tsx
+++ b/src/components/shared/CodeViewer/CodeViewer.tsx
@@ -1,8 +1,9 @@
-import { Maximize2 } from "lucide-react";
-import { useCallback } from "react";
+import { Maximize2, X as XIcon } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 
+import { FullscreenElement } from "../FullscreenElement";
 import { useBetaFlagValue } from "../Settings/useBetaFlags";
 import CodeSyntaxHighlighter from "./CodeSyntaxHighlighter";
 import { useFullscreen } from "./FullscreenCodeViewer";
@@ -25,16 +26,50 @@ const CodeViewer = ({
   onFullscreenChange = () => {},
 }: CodeViewerProps) => {
   const isVirtualized = useBetaFlagValue("codeViewer");
+  const isFullscreenElement = useBetaFlagValue("fullscreen-code-viewer");
+
+  const [isFullscreen, setIsFullscreen] = useState(false);
 
   const { openFullscreen } = useFullscreen();
 
   const handleEnterFullscreen = useCallback(() => {
-    openFullscreen({ code, language, title });
-    onFullscreenChange(true);
-  }, [code, language, title, openFullscreen, onFullscreenChange]);
-  return (
+    if (isFullscreenElement) {
+      setIsFullscreen((prev) => !prev);
+      onFullscreenChange(!isFullscreen);
+    } else {
+      openFullscreen({ code, language, title });
+      onFullscreenChange(true);
+    }
+  }, [
+    code,
+    language,
+    title,
+    openFullscreen,
+    onFullscreenChange,
+    isFullscreenElement,
+    isFullscreen,
+  ]);
+
+  // Handle Escape key
+  useEffect(() => {
+    const handleEscapeKey = (e: KeyboardEvent) => {
+      if (isFullscreen && e.key === "Escape") {
+        setIsFullscreen(false);
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    };
+
+    document.addEventListener("keydown", handleEscapeKey);
+
+    return () => {
+      document.removeEventListener("keydown", handleEscapeKey);
+    };
+  }, [isFullscreen]);
+
+  const codeViewer = (
     <>
-      <div className="border rounded-md h-full bg-slate-900 flex flex-col">
+      <div className="h-full bg-slate-900 flex flex-col">
         <div className="flex justify-between items-center p-2 sticky top-0 z-10 bg-slate-800">
           <h3 className="text-secondary font-medium ml-2">
             {filename} <span className="text-sm">(Read Only)</span>
@@ -44,9 +79,13 @@ const CodeViewer = ({
             size="icon"
             onClick={handleEnterFullscreen}
             className="text-gray-300 hover:text-slate-800"
-            title="View fullscreen"
+            title={isFullscreen ? "Exit fullscreen" : "View fullscreen"}
           >
-            <Maximize2 className="size-4" />
+            {isFullscreen ? (
+              <XIcon className="size-4" />
+            ) : (
+              <Maximize2 className="size-4" />
+            )}
           </Button>
         </div>
         <div className="flex-1 relative">
@@ -65,6 +104,14 @@ const CodeViewer = ({
         </div>
       </div>
     </>
+  );
+
+  return isFullscreenElement ? (
+    <FullscreenElement fullscreen={isFullscreen}>
+      {codeViewer}
+    </FullscreenElement>
+  ) : (
+    codeViewer
   );
 };
 

--- a/src/components/shared/FullscreenElement/FullscreenElement.test.tsx
+++ b/src/components/shared/FullscreenElement/FullscreenElement.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { FullscreenElement } from "./FullscreenElement";
+
+describe("FullscreenElement", () => {
+  test("renders children in normal mode (not fullscreen)", () => {
+    render(
+      <FullscreenElement fullscreen={false}>
+        <div data-testid="test-content">Test Content</div>
+      </FullscreenElement>,
+    );
+
+    expect(screen.getByTestId("test-content")).toBeInTheDocument();
+  });
+
+  test("renders children in fullscreen mode", () => {
+    render(
+      <FullscreenElement fullscreen={true}>
+        <div data-testid="test-content">Fullscreen Content</div>
+      </FullscreenElement>,
+    );
+
+    expect(screen.getByTestId("test-content")).toBeInTheDocument();
+  });
+
+  test("appends container to document.body in fullscreen mode", () => {
+    render(
+      <FullscreenElement fullscreen={true}>
+        <div data-testid="fullscreen-content">Fullscreen</div>
+      </FullscreenElement>,
+    );
+
+    const fullscreenContainer = screen.getByTestId("fullscreen-container");
+
+    expect(fullscreenContainer.parentElement).toBe(document.body);
+
+    expect(screen.getByTestId("fullscreen-content")).toBeInTheDocument();
+  });
+
+  test("switches from normal to fullscreen mode", () => {
+    const { rerender } = render(
+      <FullscreenElement fullscreen={false}>
+        <div data-testid="switching-content">Content</div>
+      </FullscreenElement>,
+    );
+
+    const switchingContentA = screen.getByTestId("switching-content");
+
+    const elementMountingPoint = screen.getByTestId(
+      "fullscreen-element-mounting-point",
+    );
+    const fullscreenContainer = screen.getByTestId("fullscreen-container");
+
+    expect(fullscreenContainer).toBeInTheDocument();
+    expect(fullscreenContainer.parentElement).toBe(elementMountingPoint);
+    expect(fullscreenContainer).toHaveClass("contents");
+    expect(fullscreenContainer).toHaveClass("pointer-events-auto");
+
+    rerender(
+      <FullscreenElement fullscreen={true}>
+        <div data-testid="switching-content">Content</div>
+      </FullscreenElement>,
+    );
+
+    const switchingContentB = screen.getByTestId("switching-content");
+
+    expect(switchingContentA).toStrictEqual(switchingContentB);
+
+    expect(fullscreenContainer).toBeInTheDocument();
+    expect(fullscreenContainer.parentElement).toBe(document.body);
+    expect(fullscreenContainer).toHaveClass("fixed");
+    expect(fullscreenContainer).toHaveClass("z-[2147483647]");
+  });
+
+  test("switches from fullscreen to normal mode", () => {
+    const { rerender } = render(
+      <FullscreenElement fullscreen={true}>
+        <div data-testid="switching-content">Content</div>
+      </FullscreenElement>,
+    );
+
+    const switchingContentA = screen.getByTestId("switching-content");
+
+    const elementMountingPoint = screen.getByTestId(
+      "fullscreen-element-mounting-point",
+    );
+    const fullscreenContainer = screen.getByTestId("fullscreen-container");
+
+    expect(fullscreenContainer).toBeInTheDocument();
+    expect(fullscreenContainer.parentElement).toBe(document.body);
+    expect(fullscreenContainer).toHaveClass("fixed");
+    expect(fullscreenContainer).toHaveClass("z-[2147483647]");
+
+    rerender(
+      <FullscreenElement fullscreen={false}>
+        <div data-testid="switching-content">Content</div>
+      </FullscreenElement>,
+    );
+
+    const switchingContentB = screen.getByTestId("switching-content");
+
+    expect(switchingContentA).toStrictEqual(switchingContentB);
+
+    expect(fullscreenContainer).toBeInTheDocument();
+    expect(fullscreenContainer.parentElement).toBe(elementMountingPoint);
+    expect(fullscreenContainer).toHaveClass("contents");
+    expect(fullscreenContainer).toHaveClass("pointer-events-auto");
+  });
+
+  test("cleans up container when unmounting from fullscreen mode", () => {
+    const { unmount } = render(
+      <FullscreenElement fullscreen={true}>
+        <div data-testid="cleanup-content">Content</div>
+      </FullscreenElement>,
+    );
+
+    const fullscreenContainer = screen.getByTestId("fullscreen-container");
+
+    unmount();
+
+    expect(fullscreenContainer).not.toBeInTheDocument();
+  });
+});

--- a/src/components/shared/FullscreenElement/FullscreenElement.tsx
+++ b/src/components/shared/FullscreenElement/FullscreenElement.tsx
@@ -1,0 +1,82 @@
+import {
+  type PropsWithChildren,
+  type RefObject,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
+import { createPortal } from "react-dom";
+
+import { cn } from "@/lib/utils";
+
+interface FullscreenElementProps extends PropsWithChildren {
+  fullscreen: boolean;
+  defaultMountElement: RefObject<HTMLElement | null>;
+}
+
+function FullscreenElementPortal({
+  children,
+  fullscreen,
+  defaultMountElement,
+}: FullscreenElementProps) {
+  const id = useRef(Math.random().toString(15).substring(2, 15));
+  const containerElementRef = useRef<HTMLElement>(
+    document.createElement("div"),
+  );
+
+  useEffect(() => {
+    containerElementRef.current.dataset.testid = "fullscreen-container";
+    if (fullscreen) {
+      containerElementRef.current.className = cn(
+        "fixed",
+        "top-0",
+        "left-0",
+        "z-[2147483647]",
+        "w-full",
+        "h-full",
+        "overflow-hidden",
+      );
+      document.body.appendChild(containerElementRef.current);
+    } else {
+      containerElementRef.current.className = cn(
+        "contents",
+        "pointer-events-auto",
+      );
+
+      if (defaultMountElement.current) {
+        defaultMountElement.current.appendChild(containerElementRef.current);
+      }
+    }
+
+    return () => {
+      containerElementRef.current.remove();
+    };
+  }, [fullscreen, defaultMountElement]);
+
+  const fragment = useMemo(() => <>{children}</>, [children]);
+
+  return createPortal(fragment, containerElementRef.current, id.current);
+}
+
+export function FullscreenElement({
+  children,
+  fullscreen,
+}: PropsWithChildren<{ fullscreen: boolean }>) {
+  const mountRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <>
+      <div
+        ref={mountRef}
+        data-testid="fullscreen-element-mounting-point"
+        style={{ display: "contents" }}
+      />
+      <FullscreenElementPortal
+        fullscreen={fullscreen}
+        defaultMountElement={mountRef}
+      >
+        {children}
+      </FullscreenElementPortal>
+    </>
+  );
+}

--- a/src/components/shared/FullscreenElement/index.ts
+++ b/src/components/shared/FullscreenElement/index.ts
@@ -1,0 +1,1 @@
+export { FullscreenElement } from "./FullscreenElement";


### PR DESCRIPTION
## Description

The `FullscreenElement` component provides seamless fullscreen functionality for any React content while preserving component state and optimizing performance through intelligent DOM manipulation. The change is behind the beta flag.

- Acts instantly - no delays for heavy-computational components.
- Component state, form inputs, scroll positions, and all internal state are preserved during fullscreen transitions
- Content is only re-rendered when children actually change, not on every fullscreen toggle
- Existing DOM elements are reused - nothing is recreated during transitions

This approach allows to replace convoluted Provider based existing solution, where we creating duplicates of the components.

## Related Issue and Pull requests

Closes https://github.com/Shopify/oasis-frontend/issues/124

## Type of Change

- [x] Bug fix
- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

https://github.com/user-attachments/assets/250833e5-f418-4401-8859-0487d4e3c93d

## Additional Comments

Follow up PR will clean up beta flag and remove obsolete approach.