### PR TITLE
Add open raw logs to run details

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/TaskConfiguration.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/TaskConfiguration.tsx
@@ -24,7 +24,7 @@ import { type TaskNodeContextType } from "@/providers/TaskNodeProvider";
 import { AnnotationsSection } from "../AnnotationsEditor/AnnotationsSection";
 import ArgumentsSection from "../ArgumentsEditor/ArgumentsSection";
 import Io from "./io";
-import Logs from "./logs";
+import Logs, { OpenLogsInNewWindowLink } from "./logs";
 import OutputsList from "./OutputsList";
 
 interface ButtonPropsWithTooltip extends ButtonProps {
@@ -144,6 +144,12 @@ const TaskConfiguration = ({ taskNode, actions }: TaskConfigurationProps) => {
           </TabsContent>
           {readOnly && (
             <TabsContent value="logs" className="h-full">
+              <div className="flex w-full justify-end pr-4">
+                <OpenLogsInNewWindowLink
+                  executionId={taskSpec.annotations?.executionId as string}
+                  status={runStatus}
+                />
+              </div>
               <Logs
                 executionId={taskSpec.annotations?.executionId as string}
                 status={runStatus}

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/tests/logs.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/tests/logs.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { ContainerExecutionStatus } from "@/api/types.gen";
+import { useBackend } from "@/providers/BackendProvider";
+
+import { OpenLogsInNewWindowLink } from "../logs";
+
+// Mock the BackendProvider
+vi.mock("@/providers/BackendProvider");
+
+describe("OpenLogsInNewWindowLink", () => {
+  const defaultBackendUrl = "http://localhost:8000";
+
+  const defaultBackend = {
+    configured: true,
+    available: true,
+    backendUrl: defaultBackendUrl,
+    isConfiguredFromEnv: false,
+    isConfiguredFromRelativePath: false,
+    setEnvConfig: vi.fn(),
+    setRelativePathConfig: vi.fn(),
+    setBackendUrl: vi.fn(),
+    ping: vi.fn(),
+  };
+  const mockUseBackend = vi.mocked(useBackend);
+  const testExecutionId = "test-execution-123";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default backend configuration
+    mockUseBackend.mockReturnValue(defaultBackend);
+  });
+
+  test("returns null when executionId is not provided", () => {
+    render(<OpenLogsInNewWindowLink executionId="" status="SUCCEEDED" />);
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  test("renders link when executionId is provided and status should have logs", () => {
+    render(
+      <OpenLogsInNewWindowLink
+        executionId={testExecutionId}
+        status="SUCCEEDED"
+      />,
+    );
+
+    const link = screen.getByRole("link");
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveTextContent("Open in new tab");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    expect(link).toHaveAttribute("aria-label", "Open logs in a new tab");
+
+    expect(link).toHaveAttribute(
+      "href",
+      `${defaultBackendUrl}/api/executions/${testExecutionId}/stream_container_log`,
+    );
+  });
+
+  test("has correct accessible label when backend is not available", () => {
+    mockUseBackend.mockReturnValue({
+      ...defaultBackend,
+      available: false,
+    });
+
+    render(
+      <OpenLogsInNewWindowLink
+        executionId={testExecutionId}
+        status="SUCCEEDED"
+      />,
+    );
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveClass("cursor-not-allowed");
+    expect(link).toHaveClass("pointer-events-none");
+    expect(link).toHaveAttribute(
+      "aria-label",
+      "Cant open logs: Backend not available",
+    );
+  });
+
+  describe("different execution statuses", () => {
+    const statusesThatShouldHaveLogs: ContainerExecutionStatus[] = [
+      "RUNNING",
+      "PENDING",
+      "QUEUED",
+      "WAITING_FOR_UPSTREAM",
+      "CANCELLING",
+      "FAILED",
+      "SYSTEM_ERROR",
+      "SUCCEEDED",
+      "CANCELLED",
+    ];
+
+    const statusesThatShouldNotHaveLogs: ContainerExecutionStatus[] = [
+      "INVALID",
+      "UNINITIALIZED",
+      "SKIPPED",
+    ];
+
+    test.each(statusesThatShouldHaveLogs)(
+      "renders link for status: %s",
+      (status) => {
+        render(
+          <OpenLogsInNewWindowLink
+            executionId={testExecutionId}
+            status={status}
+          />,
+        );
+
+        const link = screen.getByRole("link");
+
+        expect(link).toBeInTheDocument();
+        expect(link).toHaveTextContent("Open in new tab");
+      },
+    );
+
+    test.each(statusesThatShouldNotHaveLogs)(
+      "returns null when should not have logs for status %s",
+      (status) => {
+        render(
+          <OpenLogsInNewWindowLink
+            executionId={testExecutionId}
+            status={status}
+          />,
+        );
+
+        expect(screen.queryByRole("link")).not.toBeInTheDocument();
+      },
+    );
+  });
+});

--- a/src/components/ui/link.tsx
+++ b/src/components/ui/link.tsx
@@ -1,12 +1,34 @@
+import { cva } from "class-variance-authority";
 import { DownloadIcon, ExternalLink } from "lucide-react";
 import { type AnchorHTMLAttributes } from "react";
 
 import { cn } from "@/lib/utils";
 
+const linkVariants = cva("items-center inline-flex cursor-pointer", {
+  variants: {
+    variant: {
+      default: "text-primary",
+      link: "text-primary hover:underline",
+      disabled: "text-muted-foreground cursor-not-allowed pointer-events-none",
+    },
+    size: {
+      default: "",
+      sm: "text-sm",
+      lg: "text-lg",
+    },
+  },
+  defaultVariants: {
+    variant: "default",
+    size: "default",
+  },
+});
+
 interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   external?: boolean;
   download?: boolean;
   iconClassName?: string;
+  variant?: "default" | "link" | "disabled";
+  size?: "default" | "sm" | "lg";
 }
 
 function Link({
@@ -15,6 +37,8 @@ function Link({
   className,
   download,
   iconClassName,
+  variant,
+  size,
   ...props
 }: LinkProps) {
   const target = external || download ? "_blank" : undefined;
@@ -25,7 +49,7 @@ function Link({
       target={target}
       rel={rel}
       {...props}
-      className={cn("items-center inline-flex", className)}
+      className={cn(linkVariants({ variant, size }), className)}
     >
       {children}
       {external && <ExternalLink className={cn("h-4", iconClassName)} />}


### PR DESCRIPTION
## Description

Added a "Open in new tab" link for task logs, allowing users to view logs in a separate browser tab. This feature enhances the user experience by providing a more flexible way to view execution logs, especially for longer log outputs.

## Related Issue and Pull requests

Closes https://github.com/Cloud-Pipelines/pipeline-studio-app/issues/144

## Type of Change

- [x] New feature
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

| Screenshot | Use-case |
|--------|--------|
| <img width="515" height="1272" alt="image" src="https://github.com/user-attachments/assets/b8c3cec2-8d71-405a-9c25-1727c489b844" /> | Base use-case - show link to open logs |
| <img width="515" height="1272" alt="image" src="https://github.com/user-attachments/assets/1f105465-e767-4716-803e-e0ec5ffa5105" /> | Logs are loading,  but link is always available |
| <img width="515" height="1272" alt="image" src="https://github.com/user-attachments/assets/738f816e-bb3e-4785-bee0-00895aff047f" /> | Logs are not available for not started tasks | 
| <img width="515" height="1272" alt="image" src="https://github.com/user-attachments/assets/2303a099-8a29-4b70-be7f-99a05a313fa4" /> | Backend is not available; link is disabled |

## Test Instructions

1. Create and run a pipeline with at least one task
2. Open the task configuration panel and navigate to the logs tab
3. Verify that the "Open in new tab" link appears in the top right corner
4. Click the link and confirm logs open in a new browser tab

## Additional Comments

The PR also improves log display logic by adding a clear message when logs are not available for certain execution states.