### PR TITLE
fix infinite loop loading artifacts

### DIFF
--- a/src/components/Home/RunSection/RunRow.tsx
+++ b/src/components/Home/RunSection/RunRow.tsx
@@ -20,8 +20,8 @@ import { useBackend } from "@/providers/BackendProvider";
 import { APP_ROUTES } from "@/routes/router";
 import {
   countTaskStatuses,
-  fetchExecutionInfo,
   getRunStatus,
+  useFetchExecutionInfo,
 } from "@/services/executionService";
 import { convertUTCToLocalTime, formatDate } from "@/utils/date";
 
@@ -33,7 +33,7 @@ const RunRow = ({ run }: { run: PipelineRunResponse }) => {
 
   const executionId = `${run.root_execution_id}`;
 
-  const { data, isLoading, error } = fetchExecutionInfo(
+  const { data, isLoading, error } = useFetchExecutionInfo(
     executionId,
     backendUrl,
   );

--- a/src/components/PipelineRun/RunDetails.test.tsx
+++ b/src/components/PipelineRun/RunDetails.test.tsx
@@ -28,7 +28,7 @@ vi.mock("@/hooks/useExecutionStatusQuery");
 vi.mock("@/services/executionService", async (importOriginal) => {
   return {
     ...(await importOriginal()),
-    fetchExecutionInfo: vi.fn(),
+    useFetchExecutionInfo: vi.fn(),
   };
 });
 vi.mock("@/services/pipelineRunService");
@@ -157,7 +157,7 @@ describe("<RunDetails/>", () => {
   describe("Inspect Pipeline Button", () => {
     test("should render inspect button", async () => {
       // arrange
-      vi.mocked(executionService.fetchExecutionInfo).mockReturnValue({
+      vi.mocked(executionService.useFetchExecutionInfo).mockReturnValue({
         data: {
           details: mockExecutionDetails,
           state: mockRunningExecutionState,
@@ -180,7 +180,7 @@ describe("<RunDetails/>", () => {
   describe("Clone Pipeline Button", () => {
     test("should render clone button", async () => {
       // arrange
-      vi.mocked(executionService.fetchExecutionInfo).mockReturnValue({
+      vi.mocked(executionService.useFetchExecutionInfo).mockReturnValue({
         data: {
           details: mockExecutionDetails,
           state: mockRunningExecutionState,
@@ -203,7 +203,7 @@ describe("<RunDetails/>", () => {
   describe("Cancel Pipeline Run Button", () => {
     test("should render cancel button when status is RUNNING", async () => {
       // arrange
-      vi.mocked(executionService.fetchExecutionInfo).mockReturnValue({
+      vi.mocked(executionService.useFetchExecutionInfo).mockReturnValue({
         data: {
           details: mockExecutionDetails,
           state: mockRunningExecutionState,
@@ -224,7 +224,7 @@ describe("<RunDetails/>", () => {
 
     test("should NOT render cancel button when status is not RUNNING", async () => {
       // arrange
-      vi.mocked(executionService.fetchExecutionInfo).mockReturnValue({
+      vi.mocked(executionService.useFetchExecutionInfo).mockReturnValue({
         data: {
           details: mockExecutionDetails,
           state: mockCancelledExecutionState,
@@ -247,7 +247,7 @@ describe("<RunDetails/>", () => {
   describe("Rerun Pipeline Run Button", () => {
     test("should render rerun button when status is CANCELLED", async () => {
       // arrange
-      vi.mocked(executionService.fetchExecutionInfo).mockReturnValue({
+      vi.mocked(executionService.useFetchExecutionInfo).mockReturnValue({
         data: {
           details: mockExecutionDetails,
           state: mockCancelledExecutionState,
@@ -268,7 +268,7 @@ describe("<RunDetails/>", () => {
 
     test("should NOT render rerun button when status is RUNNING", async () => {
       // arrange
-      vi.mocked(executionService.fetchExecutionInfo).mockReturnValue({
+      vi.mocked(executionService.useFetchExecutionInfo).mockReturnValue({
         data: {
           details: mockExecutionDetails,
           state: mockRunningExecutionState,

--- a/src/components/PipelineRun/RunDetails.tsx
+++ b/src/components/PipelineRun/RunDetails.tsx
@@ -6,10 +6,10 @@ import { useBackend } from "@/providers/BackendProvider";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import {
   countTaskStatuses,
-  fetchExecutionInfo,
   getRunStatus,
   isStatusComplete,
   isStatusInProgress,
+  useFetchExecutionInfo,
 } from "@/services/executionService";
 import { fetchPipelineRunById } from "@/services/pipelineRunService";
 import type { PipelineRun } from "@/types/pipelineRun";
@@ -33,7 +33,7 @@ export const RunDetails = ({ executionId = "" }: RunDetailsProps) => {
   const [isPolling, setIsPolling] = useState(true);
   const { componentSpec } = useComponentSpec();
 
-  const { data, isLoading, error, refetch } = fetchExecutionInfo(
+  const { data, isLoading, error, refetch } = useFetchExecutionInfo(
     executionId,
     backendUrl,
     isPolling,

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/io.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/io.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from "@tanstack/react-query";
-import { useEffect } from "react";
 
 import type { GetArtifactsApiExecutionsIdArtifactsGetResponse } from "@/api/types.gen";
 import { InfoBox } from "@/components/shared/InfoBox";
@@ -39,16 +38,11 @@ const Io = ({ taskSpec, executionId, readOnly }: IoProps) => {
     isLoading,
     isFetching,
     error,
-    refetch,
   } = useQuery({
     queryKey: ["artifacts", executionId],
     queryFn: () => getArtifacts(String(executionId), backendUrl),
     enabled: !!executionId,
   });
-
-  useEffect(() => {
-    refetch();
-  }, [backendUrl, refetch]);
 
   if (!configured) {
     return (

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
@@ -12,7 +12,7 @@ import { TaskNodeOutputs } from "./TaskNodeOutputs";
 
 const TaskNodeCard = () => {
   const taskNode = useTaskNode();
-  const { setContent, clearContent } = useContextPanel();
+  const { setContent } = useContextPanel();
 
   const nodeRef = useRef<HTMLDivElement | null>(null);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -61,8 +61,6 @@ const TaskNodeCard = () => {
   useEffect(() => {
     if (selected) {
       setContent(taskConfigMarkup);
-    } else {
-      clearContent();
     }
   }, [selected, taskConfigMarkup]);
 
@@ -85,12 +83,6 @@ const TaskNodeCard = () => {
       setCondensed(scrollHeight > dimensions.h);
     }
   }, [scrollHeight, dimensions.h]);
-
-  useEffect(() => {
-    if (selected) {
-      setContent(taskConfigMarkup);
-    }
-  }, [selected, setContent, taskConfigMarkup]);
 
   return (
     <Card

--- a/src/providers/ContextPanelProvider.tsx
+++ b/src/providers/ContextPanelProvider.tsx
@@ -2,8 +2,10 @@ import { useReactFlow } from "@xyflow/react";
 import {
   createContext,
   type ReactNode,
+  useCallback,
   useContext,
   useEffect,
+  useMemo,
   useState,
 } from "react";
 
@@ -35,13 +37,13 @@ export const ContextPanelProvider = ({
   const { setNodes } = useReactFlow();
   const [content, setContentState] = useState<ReactNode>(defaultContent);
 
-  const setContent = (content: ReactNode) => {
+  const setContent = useCallback((content: ReactNode) => {
     setContentState(content);
-  };
+  }, []);
 
-  const clearContent = () => {
+  const clearContent = useCallback(() => {
     setContentState(defaultContent);
-  };
+  }, [defaultContent]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -58,8 +60,13 @@ export const ContextPanelProvider = ({
     };
   }, [defaultContent]);
 
+  const value = useMemo(
+    () => ({ content, setContent, clearContent }),
+    [content, setContent, clearContent],
+  );
+
   return (
-    <ContextPanelContext.Provider value={{ content, setContent, clearContent }}>
+    <ContextPanelContext.Provider value={value}>
       {children}
     </ContextPanelContext.Provider>
   );

--- a/src/routes/PipelineRun/PipelineRun.tsx
+++ b/src/routes/PipelineRun/PipelineRun.tsx
@@ -16,7 +16,7 @@ import {
   useComponentSpec,
 } from "@/providers/ComponentSpecProvider";
 import { type RunDetailParams, runDetailRoute } from "@/routes/router";
-import { fetchExecutionInfo } from "@/services/executionService";
+import { useFetchExecutionInfo } from "@/services/executionService";
 import { getBackendStatusString } from "@/utils/backend";
 import type { ComponentSpec } from "@/utils/componentSpec";
 
@@ -24,7 +24,7 @@ const PipelineRun = () => {
   const { backendUrl, configured, available } = useBackend();
   const { id: rootExecutionId } = runDetailRoute.useParams() as RunDetailParams;
 
-  const { data, isLoading, error, refetch } = fetchExecutionInfo(
+  const { data, isLoading, error, refetch } = useFetchExecutionInfo(
     rootExecutionId,
     backendUrl,
     false,

--- a/src/services/executionService.ts
+++ b/src/services/executionService.ts
@@ -35,7 +35,7 @@ export const fetchExecutionDetails = async (
   return response.json();
 };
 
-export const fetchExecutionInfo = (
+export const useFetchExecutionInfo = (
   executionId: string,
   backendUrl: string,
   poll: boolean = false,


### PR DESCRIPTION
## Description

Closes https://github.com/Shopify/oasis-frontend/issues/176

Fixed several React hook-related issues:
- Removed an unnecessary duplicate effect in TaskNodeCard that was causing the same content to be set twice
- Eliminated a redundant refetch in the io.tsx component
- Optimized the ContextPanelProvider with useCallback and useMemo to prevent unnecessary re-renders
- Renamed `fetchExecutionInfo` to `useFetchExecutionInfo` to better reflect that it's a React hook.

One of the issues was a loop between `ContextPanelProvider` and `TaskNodeCard` where it tried to `setContent` multiple times.

<img width="1145" height="919" alt="image" src="https://github.com/user-attachments/assets/27c497ce-7242-4bc9-9fab-ffbe77f94a77" />


## Type of Change

- [x] Bugfix
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

Verify that pipeline runs and execution information still load correctly throughout the application, particularly in the RunRow, RunDetails, and PipelineRun components.