### PR TITLE
Explicit prettier config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": false
+}


### PR DESCRIPTION
## Description

Added a `.prettierrc` configuration file to standardize code formatting across the project. 

I noticed, that VSCode formats slightly differently compared to CLI, even though the version of prettier is the same. Having configuration explicit helps to avoid divergence.

The configuration specifies:
- Trailing commas for all multi-line structures
- Tab width of 2 spaces
- Semicolons required
- Double quotes preferred over single quotes

## Related Issue and Pull requests

## Type of Change

- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Run `prettier --write .` to verify the new configuration is applied correctly
2. Check that your IDE's Prettier integration picks up the new configuration

## Additional Comments

This standardization will help maintain consistent code style across the codebase and reduce formatting-related merge conflicts.