### PR TITLE
Move Node Callbacks into a Hook

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
@@ -58,18 +58,6 @@ const TaskNodeCard = () => {
     [nodeId, callbacks.onDuplicate, callbacks.onUpgrade, isCustomComponent],
   );
 
-  useEffect(() => {
-    if (selected) {
-      setContent(taskConfigMarkup);
-    }
-
-    return () => {
-      if (selected) {
-        clearContent();
-      }
-    };
-  }, [selected, taskConfigMarkup, setContent, clearContent]);
-
   const handleInputSectionClick = useCallback(() => {
     setExpandedInputs((prev) => !prev);
   }, []);
@@ -89,6 +77,18 @@ const TaskNodeCard = () => {
       setCondensed(scrollHeight > dimensions.h);
     }
   }, [scrollHeight, dimensions.h]);
+
+  useEffect(() => {
+    if (selected) {
+      setContent(taskConfigMarkup);
+    }
+
+    return () => {
+      if (selected) {
+        clearContent();
+      }
+    };
+  }, [selected, taskConfigMarkup, setContent, clearContent]);
 
   return (
     <Card

--- a/src/hooks/useConfirmationDialog.ts
+++ b/src/hooks/useConfirmationDialog.ts
@@ -5,7 +5,7 @@ type ConfirmationDialogHandlers = {
   onCancel: () => void;
 };
 
-type TriggerDialogProps = {
+export type TriggerDialogProps = {
   title?: string;
   description?: string;
   content?: ReactNode;

--- a/src/hooks/useNodeCallbacks.ts
+++ b/src/hooks/useNodeCallbacks.ts
@@ -1,0 +1,199 @@
+import type { Node, ReactFlowInstance } from "@xyflow/react";
+import { useCallback } from "react";
+
+import { getDeleteConfirmationDetails } from "@/components/shared/ReactFlow/FlowCanvas/ConfirmationDialogs/DeleteConfirmation";
+import { getUpgradeConfirmationDetails } from "@/components/shared/ReactFlow/FlowCanvas/ConfirmationDialogs/UpgradeComponent";
+import type { NodesAndEdges } from "@/components/shared/ReactFlow/FlowCanvas/types";
+import { duplicateNodes } from "@/components/shared/ReactFlow/FlowCanvas/utils/duplicateNodes";
+import replaceTaskAnnotationsInGraphSpec from "@/components/shared/ReactFlow/FlowCanvas/utils/replaceTaskAnnotationsInGraphSpec";
+import replaceTaskArgumentsInGraphSpec from "@/components/shared/ReactFlow/FlowCanvas/utils/replaceTaskArgumentsInGraphSpec";
+import { replaceTaskNode } from "@/components/shared/ReactFlow/FlowCanvas/utils/replaceTaskNode";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+import type { Annotations } from "@/types/annotations";
+import type { NodeAndTaskId } from "@/types/taskNode";
+import type { ComponentReference } from "@/utils/componentSpec";
+import type { ArgumentType } from "@/utils/componentSpec";
+
+import type { TriggerDialogProps } from "./useConfirmationDialog";
+import useToastNotification from "./useToastNotification";
+
+interface UseNodeCallbacksProps {
+  reactFlowInstance: ReactFlowInstance | undefined;
+  triggerConfirmation: (data: TriggerDialogProps) => Promise<boolean>;
+  onElementsRemove: (params: NodesAndEdges) => void;
+  updateOrAddNodes: (params: {
+    updatedNodes?: Node[];
+    newNodes?: Node[];
+  }) => void;
+}
+
+export const useNodeCallbacks = ({
+  reactFlowInstance,
+  triggerConfirmation,
+  onElementsRemove,
+  updateOrAddNodes,
+}: UseNodeCallbacksProps) => {
+  const notify = useToastNotification();
+
+  const { graphSpec, updateGraphSpec } = useComponentSpec();
+
+  // Workaround for nodes state being stale in task node callbacks
+  const getNodeById = useCallback(
+    (id: string) => {
+      if (!reactFlowInstance) {
+        console.warn("React Flow instance is not available.");
+        return undefined;
+      }
+
+      const { getNodes } = reactFlowInstance;
+      const nodes = getNodes();
+      if (!nodes) {
+        console.warn("No nodes found in the current React Flow instance.");
+        return undefined;
+      }
+
+      const node = nodes.find((n) => n.id === id);
+      if (!node) {
+        console.warn(`Node with id ${id} not found.`);
+        return undefined;
+      }
+      return node;
+    },
+    [reactFlowInstance],
+  );
+
+  const onDelete = useCallback(
+    async (ids: NodeAndTaskId) => {
+      const nodeId = ids.nodeId;
+
+      const nodeToDelete = getNodeById(nodeId);
+
+      if (!nodeToDelete) {
+        console.warn(`Node with id ${nodeId} not found.`);
+        return;
+      }
+
+      if (!reactFlowInstance) {
+        console.warn("React Flow instance is not available.");
+        return;
+      }
+
+      const currentEdges = reactFlowInstance.getEdges();
+
+      const edgesToRemove = currentEdges.filter(
+        (edge) => edge.source === nodeId || edge.target === nodeId,
+      );
+
+      const params = {
+        nodes: [nodeToDelete],
+        edges: edgesToRemove,
+      } as NodesAndEdges;
+
+      const confirmed = await triggerConfirmation(
+        getDeleteConfirmationDetails(params),
+      );
+
+      if (confirmed) {
+        onElementsRemove(params);
+      }
+    },
+    [triggerConfirmation, onElementsRemove, getNodeById],
+  );
+
+  const setArguments = useCallback(
+    (ids: NodeAndTaskId, args: Record<string, ArgumentType>) => {
+      const taskId = ids.taskId;
+      const newGraphSpec = replaceTaskArgumentsInGraphSpec(
+        taskId,
+        graphSpec,
+        args,
+      );
+      updateGraphSpec(newGraphSpec);
+    },
+    [graphSpec, updateGraphSpec],
+  );
+
+  const setAnnotations = useCallback(
+    (ids: NodeAndTaskId, annotations: Annotations) => {
+      const taskId = ids.taskId;
+      const newGraphSpec = replaceTaskAnnotationsInGraphSpec(
+        taskId,
+        graphSpec,
+        annotations,
+      );
+      updateGraphSpec(newGraphSpec);
+    },
+    [graphSpec, updateGraphSpec],
+  );
+
+  const onDuplicate = useCallback(
+    (ids: NodeAndTaskId, selected = true) => {
+      const nodeId = ids.nodeId;
+      const node = getNodeById(nodeId);
+
+      if (!node) {
+        console.warn(`Node with id ${nodeId} not found.`);
+        return;
+      }
+
+      const { updatedGraphSpec, newNodes, updatedNodes } = duplicateNodes(
+        graphSpec,
+        [node],
+        { selected },
+      );
+
+      updateGraphSpec(updatedGraphSpec);
+
+      updateOrAddNodes({
+        updatedNodes,
+        newNodes,
+      });
+    },
+    [graphSpec, getNodeById, updateGraphSpec, updateOrAddNodes],
+  );
+
+  const onUpgrade = useCallback(
+    async (ids: NodeAndTaskId, newComponentRef: ComponentReference) => {
+      const nodeId = ids.nodeId;
+      const node = getNodeById(nodeId);
+
+      if (!node) {
+        console.warn(`Node with id ${nodeId} not found.`);
+        return;
+      }
+
+      const { updatedGraphSpec, lostInputs } = replaceTaskNode(
+        node,
+        newComponentRef,
+        graphSpec,
+      );
+
+      if (!newComponentRef.digest) {
+        console.error("Component reference does not have a digest.");
+        return;
+      }
+
+      const dialogData = getUpgradeConfirmationDetails(
+        node,
+        newComponentRef.digest,
+        lostInputs,
+      );
+
+      const confirmed = await triggerConfirmation(dialogData);
+
+      if (confirmed) {
+        updateGraphSpec(updatedGraphSpec);
+        notify("Component updated", "success");
+      }
+    },
+    [graphSpec, getNodeById, updateGraphSpec, triggerConfirmation, notify],
+  );
+
+  return {
+    onDelete,
+    setArguments,
+    setAnnotations,
+    onDuplicate,
+    onUpgrade,
+  };
+};


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Just moving some code to improve readability and reduce the size of FlowCanvas.tsx. To facilitate this the `getNodesById` method is shifted to rely on `reactFlowInstance`, rather than `setNodes`.

No (intended) change to app functionality

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Cleanup/Refactor

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
