### PR TITLE
fix side panel sync on node remove

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -224,8 +224,15 @@ const FlowCanvas = ({
       }
 
       setComponentSpec(updatedComponentSpec);
+
+      /**
+       * `onElementsRemove` maybe called asynchronously, so we need to clear the content after a short delay.
+       */
+      setTimeout(() => {
+        clearContent();
+      });
     },
-    [componentSpec, setComponentSpec],
+    [componentSpec, setComponentSpec, clearContent],
   );
 
   const onDelete = useCallback(


### PR DESCRIPTION
## Description

Added a clear content of the side panel when node is removed in the FlowCanvas component. 

## Related Issue and Pull requests

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Open a flow with elements
2. Delete an element
3. Verify that the content is properly cleared after deletion

https://github.com/user-attachments/assets/8d1a2c5a-30c3-461b-9d9a-da859c98ce51

