### PR TITLE
Fix bug where context panel did not update when a node is deleted

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -224,15 +224,8 @@ const FlowCanvas = ({
       }
 
       setComponentSpec(updatedComponentSpec);
-
-      /**
-       * `onElementsRemove` maybe called asynchronously, so we need to clear the content after a short delay.
-       */
-      setTimeout(() => {
-        clearContent();
-      });
     },
-    [componentSpec, setComponentSpec, clearContent],
+    [componentSpec, setComponentSpec],
   );
 
   const onDelete = useCallback(

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
@@ -12,7 +12,7 @@ import { TaskNodeOutputs } from "./TaskNodeOutputs";
 
 const TaskNodeCard = () => {
   const taskNode = useTaskNode();
-  const { setContent } = useContextPanel();
+  const { setContent, clearContent } = useContextPanel();
 
   const nodeRef = useRef<HTMLDivElement | null>(null);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -62,7 +62,13 @@ const TaskNodeCard = () => {
     if (selected) {
       setContent(taskConfigMarkup);
     }
-  }, [selected, taskConfigMarkup]);
+
+    return () => {
+      if (selected) {
+        clearContent();
+      }
+    };
+  }, [selected, taskConfigMarkup, setContent, clearContent]);
 
   const handleInputSectionClick = useCallback(() => {
     setExpandedInputs((prev) => !prev);


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Fixes a recently introduced bug where the context panel would not reset to default when the selected node is deleted.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Bugfix for #606

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
