### PR TITLE
fix run status polling behavior

### DIFF
--- a/src/components/PipelineRun/PipelineRunPage.tsx
+++ b/src/components/PipelineRun/PipelineRunPage.tsx
@@ -13,6 +13,7 @@ import { ContextPanelProvider } from "@/providers/ContextPanelProvider";
 import { PipelineRunsProvider } from "@/providers/PipelineRunsProvider";
 
 import { CollapsibleContextPanel } from "../shared/ContextPanel/CollapsibleContextPanel";
+import { RootExecutionStatusProvider } from "./RootExecutionStatusProvider";
 import { RunDetails } from "./RunDetails";
 
 const GRID_SIZE = 10;
@@ -40,30 +41,30 @@ const PipelineRunPage = ({ rootExecutionId }: { rootExecutionId: string }) => {
 
   return (
     <PipelineRunsProvider pipelineName={componentSpec.name || ""}>
-      <ContextPanelProvider
-        defaultContent={<RunDetails executionId={rootExecutionId} />}
-      >
-        <ComponentLibraryProvider>
-          <ResizablePanelGroup direction="horizontal">
-            <ResizablePanel>
-              <div className="reactflow-wrapper h-full w-full">
-                <FlowCanvas {...flowConfig} readOnly>
-                  <MiniMap position="bottom-left" pannable />
-                  <FlowControls
-                    className="ml-[224px]! mb-[24px]!"
-                    config={flowConfig}
-                    updateConfig={updateFlowConfig}
-                    showInteractive={false}
-                  />
-                  <Background gap={GRID_SIZE} className="bg-slate-50!" />
-                </FlowCanvas>
-              </div>
-            </ResizablePanel>
-            <ResizableHandle />
-            <CollapsibleContextPanel />
-          </ResizablePanelGroup>
-        </ComponentLibraryProvider>
-      </ContextPanelProvider>
+      <RootExecutionStatusProvider rootExecutionId={rootExecutionId}>
+        <ContextPanelProvider defaultContent={<RunDetails />}>
+          <ComponentLibraryProvider>
+            <ResizablePanelGroup direction="horizontal">
+              <ResizablePanel>
+                <div className="reactflow-wrapper h-full w-full">
+                  <FlowCanvas {...flowConfig} readOnly>
+                    <MiniMap position="bottom-left" pannable />
+                    <FlowControls
+                      className="ml-[224px]! mb-[24px]!"
+                      config={flowConfig}
+                      updateConfig={updateFlowConfig}
+                      showInteractive={false}
+                    />
+                    <Background gap={GRID_SIZE} className="bg-slate-50!" />
+                  </FlowCanvas>
+                </div>
+              </ResizablePanel>
+              <ResizableHandle />
+              <CollapsibleContextPanel />
+            </ResizablePanelGroup>
+          </ComponentLibraryProvider>
+        </ContextPanelProvider>
+      </RootExecutionStatusProvider>
     </PipelineRunsProvider>
   );
 };

--- a/src/components/PipelineRun/RootExecutionStatusProvider.test.tsx
+++ b/src/components/PipelineRun/RootExecutionStatusProvider.test.tsx
@@ -1,0 +1,537 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type {
+  GetExecutionInfoResponse,
+  GetGraphExecutionStateResponse,
+} from "@/api/types.gen";
+import { useBackend } from "@/providers/BackendProvider";
+import * as executionService from "@/services/executionService";
+
+import {
+  RootExecutionStatusProvider,
+  useRootExecutionContext,
+} from "./RootExecutionStatusProvider";
+
+// Mock dependencies
+vi.mock("@/providers/BackendProvider");
+vi.mock("@/services/executionService", async (importOriginal) => {
+  return {
+    ...(await importOriginal()),
+    useFetchExecutionInfo: vi.fn(),
+  };
+});
+
+// Test component to access context
+function TestConsumer() {
+  const context = useRootExecutionContext();
+  return (
+    <div>
+      <div data-testid="loading">{context.isLoading.toString()}</div>
+      <div data-testid="run-id">{context.runId || "null"}</div>
+      <div data-testid="error">{context.error?.message || "null"}</div>
+      <div data-testid="details-id">{context.details?.id || "null"}</div>
+      <div data-testid="state-available">
+        {context.state ? "available" : "null"}
+      </div>
+    </div>
+  );
+}
+
+// Invalid consumer (outside provider)
+function InvalidConsumer() {
+  const context = useRootExecutionContext();
+  return <div>{context.runId}</div>;
+}
+
+describe("<RootExecutionStatusProvider />", () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  const mockExecutionDetails: GetExecutionInfoResponse = {
+    id: "test-execution-id",
+    pipeline_run_id: "test-run-id-123",
+    task_spec: {
+      componentRef: {
+        spec: {
+          name: "Test Pipeline",
+          description: "Test pipeline description",
+          metadata: {
+            annotations: {
+              "test-annotation": "test-value",
+            },
+          },
+          inputs: [],
+          outputs: [],
+        },
+      },
+    },
+    child_task_execution_ids: {
+      task1: "execution1",
+      task2: "execution2",
+    },
+  };
+
+  const mockRunningExecutionState: GetGraphExecutionStateResponse = {
+    child_execution_status_stats: {
+      execution1: { SUCCEEDED: 1 },
+      execution2: { RUNNING: 1 },
+    },
+  };
+
+  const mockCompletedExecutionState: GetGraphExecutionStateResponse = {
+    child_execution_status_stats: {
+      execution1: { SUCCEEDED: 1 },
+      execution2: { SUCCEEDED: 1 },
+    },
+  };
+
+  const mockFailedExecutionState: GetGraphExecutionStateResponse = {
+    child_execution_status_stats: {
+      execution1: { SUCCEEDED: 1 },
+      execution2: { FAILED: 1 },
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(useBackend).mockReturnValue({
+      configured: true,
+      available: true,
+      backendUrl: "http://localhost:8000",
+      isConfiguredFromEnv: false,
+      isConfiguredFromRelativePath: false,
+      setEnvConfig: vi.fn(),
+      setRelativePathConfig: vi.fn(),
+      setBackendUrl: vi.fn(),
+      ping: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  const renderWithProvider = (rootExecutionId: string) => {
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <RootExecutionStatusProvider rootExecutionId={rootExecutionId}>
+          <TestConsumer />
+        </RootExecutionStatusProvider>
+      </QueryClientProvider>,
+    );
+  };
+
+  describe("Provider functionality", () => {
+    test("renders children correctly", () => {
+      vi.mocked(executionService.useFetchExecutionInfo).mockReturnValue({
+        data: {
+          details: undefined,
+          state: undefined,
+        },
+        isLoading: true,
+        error: null,
+        isFetching: false,
+        refetch: vi.fn(),
+      });
+
+      renderWithProvider("test-execution-id");
+
+      expect(screen.getByTestId("loading")).toHaveTextContent("true");
+      expect(screen.getByTestId("run-id")).toHaveTextContent("null");
+      expect(screen.getByTestId("error")).toHaveTextContent("null");
+    });
+
+    test("provides correct context values when data is loaded", () => {
+      vi.mocked(executionService.useFetchExecutionInfo).mockReturnValue({
+        data: {
+          details: mockExecutionDetails,
+          state: mockRunningExecutionState,
+        },
+        isLoading: false,
+        error: null,
+        isFetching: false,
+        refetch: vi.fn(),
+      });
+
+      renderWithProvider("test-execution-id");
+
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+      expect(screen.getByTestId("run-id")).toHaveTextContent("test-run-id-123");
+      expect(screen.getByTestId("error")).toHaveTextContent("null");
+      expect(screen.getByTestId("details-id")).toHaveTextContent(
+        "test-execution-id",
+      );
+      expect(screen.getByTestId("state-available")).toHaveTextContent(
+        "available",
+      );
+    });
+
+    test("handles loading state correctly", () => {
+      vi.mocked(executionService.useFetchExecutionInfo).mockReturnValue({
+        data: {
+          details: undefined,
+          state: undefined,
+        },
+        isLoading: true,
+        error: null,
+        isFetching: true,
+        refetch: vi.fn(),
+      });
+
+      renderWithProvider("test-execution-id");
+
+      expect(screen.getByTestId("loading")).toHaveTextContent("true");
+    });
+
+    test("handles error state correctly", () => {
+      const mockError = new Error("Failed to fetch execution info");
+      vi.mocked(executionService.useFetchExecutionInfo).mockReturnValue({
+        data: {
+          details: undefined,
+          state: undefined,
+        },
+        isLoading: false,
+        error: mockError,
+        isFetching: false,
+        refetch: vi.fn(),
+      });
+
+      renderWithProvider("test-execution-id");
+
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+      expect(screen.getByTestId("error")).toHaveTextContent(
+        "Failed to fetch execution info",
+      );
+    });
+  });
+
+  describe("Polling behavior", () => {
+    test("starts with polling enabled", () => {
+      const mockUseFetchExecutionInfo = vi.mocked(
+        executionService.useFetchExecutionInfo,
+      );
+      mockUseFetchExecutionInfo.mockReturnValue({
+        data: {
+          details: undefined,
+          state: undefined,
+        },
+        isLoading: true,
+        error: null,
+        isFetching: false,
+        refetch: vi.fn(),
+      });
+
+      renderWithProvider("test-execution-id");
+
+      // Verify polling is initially enabled
+      expect(mockUseFetchExecutionInfo).toHaveBeenCalledWith(
+        "test-execution-id",
+        "http://localhost:8000",
+        true,
+      );
+    });
+
+    test("stops polling when status becomes complete (SUCCEEDED)", async () => {
+      // Create a mock that can track state changes
+      const mockUseFetchExecutionInfo = vi.mocked(
+        executionService.useFetchExecutionInfo,
+      );
+
+      // Mock the service functions used in the effect
+      vi.spyOn(executionService, "countTaskStatuses").mockReturnValue({
+        total: 2,
+        succeeded: 2,
+        failed: 0,
+        running: 0,
+        waiting: 0,
+        skipped: 0,
+        cancelled: 0,
+      });
+      vi.spyOn(executionService, "getRunStatus").mockReturnValue("SUCCEEDED");
+      vi.spyOn(executionService, "isStatusComplete").mockReturnValue(true);
+
+      // First call - still loading
+      mockUseFetchExecutionInfo.mockReturnValueOnce({
+        data: {
+          details: undefined,
+          state: undefined,
+        },
+        isLoading: true,
+        error: null,
+        isFetching: false,
+        refetch: vi.fn(),
+      });
+
+      const { rerender } = renderWithProvider("test-execution-id");
+
+      // Simulate data loading with completed status
+      mockUseFetchExecutionInfo.mockReturnValue({
+        data: {
+          details: mockExecutionDetails,
+          state: mockCompletedExecutionState,
+        },
+        isLoading: false,
+        error: null,
+        isFetching: false,
+        refetch: vi.fn(),
+      });
+
+      // Trigger re-render to simulate data update
+      rerender(
+        <QueryClientProvider client={queryClient}>
+          <RootExecutionStatusProvider rootExecutionId="test-execution-id">
+            <TestConsumer />
+          </RootExecutionStatusProvider>
+        </QueryClientProvider>,
+      );
+
+      // Wait for effect to process
+      await waitFor(() => {
+        // Verify that polling was disabled (false) in subsequent calls
+        const calls = mockUseFetchExecutionInfo.mock.calls;
+        expect(calls.some((call) => call[2] === false)).toBe(true);
+      });
+    });
+
+    test("stops polling when status becomes complete (FAILED)", async () => {
+      const mockUseFetchExecutionInfo = vi.mocked(
+        executionService.useFetchExecutionInfo,
+      );
+
+      // Mock the service functions
+      vi.spyOn(executionService, "countTaskStatuses").mockReturnValue({
+        total: 2,
+        succeeded: 1,
+        failed: 1,
+        running: 0,
+        waiting: 0,
+        skipped: 0,
+        cancelled: 0,
+      });
+      vi.spyOn(executionService, "getRunStatus").mockReturnValue("FAILED");
+      vi.spyOn(executionService, "isStatusComplete").mockReturnValue(true);
+
+      // First call - still loading
+      mockUseFetchExecutionInfo.mockReturnValueOnce({
+        data: {
+          details: undefined,
+          state: undefined,
+        },
+        isLoading: true,
+        error: null,
+        isFetching: false,
+        refetch: vi.fn(),
+      });
+
+      const { rerender } = renderWithProvider("test-execution-id");
+
+      // Simulate data loading with failed status
+      mockUseFetchExecutionInfo.mockReturnValue({
+        data: {
+          details: mockExecutionDetails,
+          state: mockFailedExecutionState,
+        },
+        isLoading: false,
+        error: null,
+        isFetching: false,
+        refetch: vi.fn(),
+      });
+
+      rerender(
+        <QueryClientProvider client={queryClient}>
+          <RootExecutionStatusProvider rootExecutionId="test-execution-id">
+            <TestConsumer />
+          </RootExecutionStatusProvider>
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        const calls = mockUseFetchExecutionInfo.mock.calls;
+        expect(calls.some((call) => call[2] === false)).toBe(true);
+      });
+    });
+
+    test("continues polling when status is still running", () => {
+      const mockUseFetchExecutionInfo = vi.mocked(
+        executionService.useFetchExecutionInfo,
+      );
+
+      // Mock the service functions for running status
+      vi.spyOn(executionService, "countTaskStatuses").mockReturnValue({
+        total: 2,
+        succeeded: 1,
+        failed: 0,
+        running: 1,
+        waiting: 0,
+        skipped: 0,
+        cancelled: 0,
+      });
+      vi.spyOn(executionService, "getRunStatus").mockReturnValue("RUNNING");
+      vi.spyOn(executionService, "isStatusComplete").mockReturnValue(false);
+
+      mockUseFetchExecutionInfo.mockReturnValue({
+        data: {
+          details: mockExecutionDetails,
+          state: mockRunningExecutionState,
+        },
+        isLoading: false,
+        error: null,
+        isFetching: false,
+        refetch: vi.fn(),
+      });
+
+      renderWithProvider("test-execution-id");
+
+      // All calls should still have polling enabled (true)
+      const calls = mockUseFetchExecutionInfo.mock.calls;
+      calls.forEach((call) => {
+        expect(call[2]).toBe(true);
+      });
+    });
+  });
+
+  describe("Context values", () => {
+    test("provides undefined values when no data is loaded", () => {
+      vi.mocked(executionService.useFetchExecutionInfo).mockReturnValue({
+        data: {
+          details: undefined,
+          state: undefined,
+        },
+        isLoading: false,
+        error: null,
+        isFetching: false,
+        refetch: vi.fn(),
+      });
+
+      renderWithProvider("test-execution-id");
+
+      expect(screen.getByTestId("details-id")).toHaveTextContent("null");
+      expect(screen.getByTestId("state-available")).toHaveTextContent("null");
+      expect(screen.getByTestId("run-id")).toHaveTextContent("null");
+    });
+
+    test("extracts pipeline_run_id correctly from details", () => {
+      vi.mocked(executionService.useFetchExecutionInfo).mockReturnValue({
+        data: {
+          details: mockExecutionDetails,
+          state: mockRunningExecutionState,
+        },
+        isLoading: false,
+        error: null,
+        isFetching: false,
+        refetch: vi.fn(),
+      });
+
+      renderWithProvider("test-execution-id");
+
+      expect(screen.getByTestId("run-id")).toHaveTextContent(
+        mockExecutionDetails.pipeline_run_id!,
+      );
+    });
+  });
+
+  describe("useRootExecutionContext hook", () => {
+    test("throws error when used outside provider", () => {
+      // Mock console.error to avoid noise in test output
+      const consoleSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      expect(() => {
+        render(<InvalidConsumer />);
+      }).toThrow(
+        "useRootExecutionContext must be used within RootExecutionContext",
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    test("returns context when used within provider", () => {
+      vi.mocked(executionService.useFetchExecutionInfo).mockReturnValue({
+        data: {
+          details: mockExecutionDetails,
+          state: mockRunningExecutionState,
+        },
+        isLoading: false,
+        error: null,
+        isFetching: false,
+        refetch: vi.fn(),
+      });
+
+      renderWithProvider("test-execution-id");
+
+      // If we reach here without throwing, the hook works correctly
+      expect(screen.getByTestId("run-id")).toBeInTheDocument();
+    });
+  });
+
+  describe("Backend integration", () => {
+    test("uses backendUrl from BackendProvider", () => {
+      const mockUseFetchExecutionInfo = vi.mocked(
+        executionService.useFetchExecutionInfo,
+      );
+      mockUseFetchExecutionInfo.mockReturnValue({
+        data: {
+          details: undefined,
+          state: undefined,
+        },
+        isLoading: true,
+        error: null,
+        isFetching: false,
+        refetch: vi.fn(),
+      });
+
+      renderWithProvider("test-execution-id");
+
+      expect(mockUseFetchExecutionInfo).toHaveBeenCalledWith(
+        "test-execution-id",
+        "http://localhost:8000",
+        true,
+      );
+    });
+
+    test("handles different backend URLs", () => {
+      const customBackendUrl = "https://custom-backend.com";
+      vi.mocked(useBackend).mockReturnValue({
+        configured: true,
+        available: true,
+        backendUrl: customBackendUrl,
+        isConfiguredFromEnv: false,
+        isConfiguredFromRelativePath: false,
+        setEnvConfig: vi.fn(),
+        setRelativePathConfig: vi.fn(),
+        setBackendUrl: vi.fn(),
+        ping: vi.fn(),
+      });
+
+      const mockUseFetchExecutionInfo = vi.mocked(
+        executionService.useFetchExecutionInfo,
+      );
+      mockUseFetchExecutionInfo.mockReturnValue({
+        data: {
+          details: undefined,
+          state: undefined,
+        },
+        isLoading: true,
+        error: null,
+        isFetching: false,
+        refetch: vi.fn(),
+      });
+
+      renderWithProvider("test-execution-id");
+
+      expect(mockUseFetchExecutionInfo).toHaveBeenCalledWith(
+        "test-execution-id",
+        customBackendUrl,
+        true,
+      );
+    });
+  });
+});

--- a/src/components/PipelineRun/RootExecutionStatusProvider.tsx
+++ b/src/components/PipelineRun/RootExecutionStatusProvider.tsx
@@ -1,0 +1,83 @@
+import {
+  createContext,
+  type PropsWithChildren,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+import type {
+  GetExecutionInfoResponse,
+  GetGraphExecutionStateResponse,
+} from "@/api/types.gen";
+import { useBackend } from "@/providers/BackendProvider";
+import {
+  countTaskStatuses,
+  getRunStatus,
+  isStatusComplete,
+  useFetchExecutionInfo,
+} from "@/services/executionService";
+
+interface RootExecutionStatus {
+  details: GetExecutionInfoResponse | undefined;
+  state: GetGraphExecutionStateResponse | undefined;
+  runId: string | undefined | null;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+const RootExecutionContext = createContext<RootExecutionStatus | null>(null);
+
+export function RootExecutionStatusProvider({
+  rootExecutionId,
+  children,
+}: PropsWithChildren<{ rootExecutionId: string }>) {
+  const { backendUrl } = useBackend();
+
+  const [isPolling, setIsPolling] = useState(true);
+
+  const { data, isLoading, error } = useFetchExecutionInfo(
+    rootExecutionId,
+    backendUrl,
+    isPolling,
+  );
+  const { details, state } = data;
+  const runId = details?.pipeline_run_id;
+
+  useEffect(() => {
+    if (details && state) {
+      const statusCounts = countTaskStatuses(details, state);
+      const runStatus = getRunStatus(statusCounts);
+      if (isStatusComplete(runStatus)) {
+        setIsPolling(false);
+      }
+    }
+  }, [details, state]);
+
+  const value = useMemo(
+    () => ({
+      details,
+      state,
+      runId,
+      isLoading,
+      error,
+    }),
+    [details, state, runId, isLoading, error],
+  );
+
+  return (
+    <RootExecutionContext.Provider value={value}>
+      {children}
+    </RootExecutionContext.Provider>
+  );
+}
+
+export function useRootExecutionContext() {
+  const ctx = useContext(RootExecutionContext);
+  if (!ctx)
+    throw new Error(
+      "useRootExecutionContext must be used within RootExecutionContext",
+    );
+  return ctx;
+}

--- a/src/components/PipelineRun/RunDetails.test.tsx
+++ b/src/components/PipelineRun/RunDetails.test.tsx
@@ -15,6 +15,7 @@ import * as executionService from "@/services/executionService";
 import * as pipelineRunService from "@/services/pipelineRunService";
 import type { ComponentSpec } from "@/utils/componentSpec";
 
+import { RootExecutionStatusProvider } from "./RootExecutionStatusProvider";
 import { RunDetails } from "./RunDetails";
 
 // Mock the hooks and services
@@ -147,7 +148,11 @@ describe("<RunDetails/>", () => {
       <ComponentSpecProvider spec={mockComponentSpec}>
         <QueryClientProvider client={queryClient}>
           <PipelineRunsProvider pipelineName={mockPipelineRun.pipeline_name}>
-            {component}
+            <RootExecutionStatusProvider
+              rootExecutionId={mockPipelineRun.root_execution_id.toString()}
+            >
+              {component}
+            </RootExecutionStatusProvider>
           </PipelineRunsProvider>
         </QueryClientProvider>
       </ComponentSpecProvider>,
@@ -169,7 +174,7 @@ describe("<RunDetails/>", () => {
       });
 
       // act
-      renderWithQueryClient(<RunDetails executionId="test-execution-id" />);
+      renderWithQueryClient(<RunDetails />);
 
       // assert
       const inspect = screen.getByTestId("inspect-pipeline-button");
@@ -192,7 +197,7 @@ describe("<RunDetails/>", () => {
       });
 
       // act
-      renderWithQueryClient(<RunDetails executionId="test-execution-id" />);
+      renderWithQueryClient(<RunDetails />);
 
       // assert
       const cloneButton = screen.getByTestId("clone-pipeline-run-button");
@@ -215,7 +220,7 @@ describe("<RunDetails/>", () => {
       });
 
       // act
-      renderWithQueryClient(<RunDetails executionId="test-execution-id" />);
+      renderWithQueryClient(<RunDetails />);
 
       // assert
       const cancelButton = screen.getByTestId("cancel-pipeline-run-button");
@@ -236,7 +241,7 @@ describe("<RunDetails/>", () => {
       });
 
       // act
-      renderWithQueryClient(<RunDetails executionId="test-execution-id" />);
+      renderWithQueryClient(<RunDetails />);
 
       // assert
       const cancelButton = screen.queryByTestId("cancel-pipeline-run-button");
@@ -259,7 +264,7 @@ describe("<RunDetails/>", () => {
       });
 
       // act
-      renderWithQueryClient(<RunDetails executionId="test-execution-id" />);
+      renderWithQueryClient(<RunDetails />);
 
       // assert
       const rerunButton = screen.getByTestId("rerun-pipeline-button");
@@ -280,7 +285,7 @@ describe("<RunDetails/>", () => {
       });
 
       // act
-      renderWithQueryClient(<RunDetails executionId="test-execution-id" />);
+      renderWithQueryClient(<RunDetails />);
 
       // assert
       const rerunButton = screen.queryByTestId("rerun-pipeline-button");

--- a/src/components/PipelineRun/RunDetails.tsx
+++ b/src/components/PipelineRun/RunDetails.tsx
@@ -9,7 +9,6 @@ import {
   getRunStatus,
   isStatusComplete,
   isStatusInProgress,
-  useFetchExecutionInfo,
 } from "@/services/executionService";
 import { fetchPipelineRunById } from "@/services/pipelineRunService";
 import type { PipelineRun } from "@/types/pipelineRun";
@@ -21,39 +20,15 @@ import { CancelPipelineRunButton } from "./components/CancelPipelineRunButton";
 import { ClonePipelineButton } from "./components/ClonePipelineButton";
 import { InspectPipelineButton } from "./components/InspectPipelineButton";
 import { RerunPipelineButton } from "./components/RerunPipelineButton";
+import { useRootExecutionContext } from "./RootExecutionStatusProvider";
 
-type RunDetailsProps = {
-  executionId?: string;
-};
+export const RunDetails = () => {
+  const { details, state, runId, isLoading, error } = useRootExecutionContext();
 
-export const RunDetails = ({ executionId = "" }: RunDetailsProps) => {
-  const { backendUrl, configured } = useBackend();
+  const { configured } = useBackend();
 
   const [metadata, setMetadata] = useState<PipelineRun | null>(null);
-  const [isPolling, setIsPolling] = useState(true);
   const { componentSpec } = useComponentSpec();
-
-  const { data, isLoading, error, refetch } = useFetchExecutionInfo(
-    executionId,
-    backendUrl,
-    isPolling,
-  );
-  const { details, state } = data;
-  const runId = details?.pipeline_run_id;
-
-  useEffect(() => {
-    refetch();
-  }, [backendUrl, executionId, refetch]);
-
-  useEffect(() => {
-    if (details && state) {
-      const statusCounts = countTaskStatuses(details, state);
-      const runStatus = getRunStatus(statusCounts);
-      if (isStatusComplete(runStatus)) {
-        setIsPolling(false);
-      }
-    }
-  }, [details, state]);
 
   useEffect(() => {
     const fetchData = async () => {


### PR DESCRIPTION
## Description

Closes https://github.com/Shopify/oasis-frontend/issues/179

Added a new `RootExecutionStatusProvider` to centralize pipeline run execution status management. This provider fetches and maintains execution information, handles polling logic, and exposes execution details through a context API.

The implementation includes:
- A context provider that manages execution status data
- Automatic polling that stops when execution completes
- Comprehensive test coverage for the new provider
- Refactored `RunDetails` component to consume the context instead of managing its own state

## Type of Change

- [x] Bugfix
- [x] Cleanup/Refactor

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Navigate to any pipeline run page
2. Verify that run details are displayed correctly
3. For in-progress runs, verify that status updates automatically
4. For completed runs, verify that polling stops appropriately

https://github.com/user-attachments/assets/93026a6b-4d7f-4951-97e4-d3b57a4e1367


## Additional Comments

This change does not remove excessive network requests, it just restores polling behavior.