### PR TITLE
do not poll logs when status not appropriate

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/logs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/logs.tsx
@@ -55,9 +55,6 @@ const isStatusActivelyLogging = (
   }
   switch (status) {
     case "RUNNING":
-    case "PENDING":
-    case "QUEUED":
-    case "WAITING_FOR_UPSTREAM":
     case "CANCELLING":
       return true;
     default:

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/tests/logs.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/tests/logs.test.tsx
@@ -85,9 +85,6 @@ describe("OpenLogsInNewWindowLink", () => {
   describe("different execution statuses", () => {
     const statusesThatShouldHaveLogs: ContainerExecutionStatus[] = [
       "RUNNING",
-      "PENDING",
-      "QUEUED",
-      "WAITING_FOR_UPSTREAM",
       "CANCELLING",
       "FAILED",
       "SYSTEM_ERROR",
@@ -99,6 +96,9 @@ describe("OpenLogsInNewWindowLink", () => {
       "INVALID",
       "UNINITIALIZED",
       "SKIPPED",
+      "PENDING",
+      "QUEUED",
+      "WAITING_FOR_UPSTREAM",
     ];
 
     test.each(statusesThatShouldHaveLogs)(


### PR DESCRIPTION
## Description

Contributes to https://github.com/Shopify/oasis-frontend/issues/171

Removed task statuses `PENDING`, `QUEUED`, and `WAITING_FOR_UPSTREAM` from the list of statuses that are considered to be actively logging. Now only `RUNNING` and `CANCELLING` statuses will trigger active logging behavior.

## Related Issue and Pull requests

## Type of Change

- [x] Improvement
- [x] Bug fix

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

Verify that logs are only actively fetched for tasks with `RUNNING` or `CANCELLING` status, and not for tasks with `PENDING`, `QUEUED`, or `WAITING_FOR_UPSTREAM` status.