### PR TITLE
Removes header API calls

### DIFF
--- a/src/components/PipelineRun/RunDetails.tsx
+++ b/src/components/PipelineRun/RunDetails.tsx
@@ -129,8 +129,8 @@ export const RunDetails = () => {
 
       <div>
         <div className="flex gap-2">
-          <InspectPipelineButton pipelineName={componentSpec.name} />
           <ClonePipelineButton componentSpec={componentSpec} />
+          <InspectPipelineButton pipelineName={componentSpec.name} />
           {isInProgress && <CancelPipelineRunButton runId={runId} />}
           {isComplete && <RerunPipelineButton componentSpec={componentSpec} />}
         </div>

--- a/src/components/layout/AppMenu.tsx
+++ b/src/components/layout/AppMenu.tsx
@@ -1,9 +1,6 @@
 import { Link } from "@tanstack/react-router";
 
-import CloneRunButton from "@/components/shared/CloneRunButton";
 import ImportPipeline from "@/components/shared/ImportPipeline";
-import { useLoadComponentSpecFromPath } from "@/hooks/useLoadComponentSpecFromPath";
-import { useBackend } from "@/providers/BackendProvider";
 import { TOP_NAV_HEIGHT } from "@/utils/constants";
 
 import BackendStatus from "../shared/BackendStatus";
@@ -11,10 +8,6 @@ import NewPipelineButton from "../shared/NewPipelineButton";
 import { PersonalPreferences } from "../shared/Settings/PersonalPreferences";
 
 const AppMenu = () => {
-  const { backendUrl } = useBackend();
-  const { componentSpec } = useLoadComponentSpecFromPath(backendUrl);
-  const title = componentSpec?.name;
-
   return (
     <div
       className="w-full bg-stone-900 p-2"
@@ -29,11 +22,9 @@ const AppMenu = () => {
               className="w-10 h-10 filter invert cursor-pointer"
             />
           </Link>
-          <span className="text-white text-sm font-bold">{title}</span>
         </div>
         <div className="flex flex-row gap-32 items-center">
           <div className="flex flex-row gap-2 items-center">
-            <CloneRunButton spec={componentSpec} />
             <ImportPipeline />
             <NewPipelineButton />
           </div>


### PR DESCRIPTION
## Description

partly resolves: https://github.com/Shopify/oasis-frontend/issues/171

Reorganized UI buttons in the pipeline run interface for better user experience. Swapped the order of "Clone Pipeline" and "Inspect Pipeline" buttons in the RunDetails component, and removed the CloneRunButton and title display from the AppMenu.

This PR removes 1 of 4 "details" API calls from the run page.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Screenshots (if applicable)

## Test Instructions

1. Navigate to a pipeline run page and verify the "Clone Pipeline" button now appears before the "Inspect Pipeline" button
2. Check that the AppMenu no longer displays the pipeline title or Clone Run button
3. Verify all remaining functionality works as expected

## Additional Comments

This change improves UI consistency and simplifies the top navigation bar.