### PR TITLE
CMD+A to select all nodes

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -132,8 +132,18 @@ const FlowCanvas = ({
           event.preventDefault();
         }
       }
+
+      if (event.key === "a" && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        setNodes((currentNodes) =>
+          currentNodes.map((node) => ({
+            ...node,
+            selected: event.shiftKey ? false : node.type === "task",
+          })),
+        );
+      }
     },
-    [handleTabCycle],
+    [handleTabCycle, setNodes],
   );
 
   const handleKeyUp = useCallback((event: KeyboardEvent) => {


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

`cmd + A` to select all nodes
`shift + cmd + A` to deselect all nodes


Note: due to the way ReactFlow works it's not possible to activate the selection toolbar programmatically. So the nodes will be selected but the toolbar will not show. Currently we do not have a workaround for this.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Closes https://github.com/Shopify/oasis-frontend/issues/183

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
