### PR TITLE
Click Digest to Highlight Similar Tasks

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsEditor.tsx
@@ -26,6 +26,8 @@ const COMMON_ANNOTATIONS: AnnotationConfig[] = [
   },
 ];
 
+const HIDDEN_ANNOTATIONS = ["editor.highlight"];
+
 export const AnnotationsEditor = ({
   annotations,
   onChange,
@@ -36,7 +38,8 @@ export const AnnotationsEditor = ({
   const remainingAnnotations = Object.entries(annotations).filter(
     ([key]) =>
       !COMPUTE_RESOURCES.some((resource) => resource.annotation === key) &&
-      !COMMON_ANNOTATIONS.some((common) => common.annotation === key),
+      !COMMON_ANNOTATIONS.some((common) => common.annotation === key) &&
+      !HIDDEN_ANNOTATIONS.includes(key),
   );
 
   const handleValueChange = (key: string, value: string) => {

--- a/src/utils/nodes/createTaskNode.ts
+++ b/src/utils/nodes/createTaskNode.ts
@@ -20,13 +20,15 @@ export const createTaskNode = (
   const nodeCallbacks = nodeData.nodeCallbacks;
   const dynamicCallbacks = generateDynamicNodeCallbacks(nodeId, nodeCallbacks);
 
+  const highlighted = taskSpec.annotations?.["editor.highlight"] ?? false;
+
   return {
     id: nodeId,
     data: {
       ...nodeData,
       taskSpec,
       taskId,
-      highlighted: false,
+      highlighted,
       callbacks: dynamicCallbacks, // Use these callbacks internally within the node
     },
     position: position,


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Click a task node's digest in the top-right of the node and nodes on the canvas with the same digest will be highlighted.

To make this work smoothly the previous highlight "logic" was rewritten. Previously we simply checked if a node was the potential target of a drag-and-drop replacement operation, and highlighted it accordingly. Now that there are multiple ways to highlight a node this is no longer fit for purpose. Instead, node highlighting is now controlled via a (hidden) taskSpec annotation `editor.highlight` that syncs with reactflow whenever nodes are redrawn.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Closes Shopify/oasis-frontend#198

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/k7Zn4eGgJXB4aaPJrw4u/05b13134-111b-4f81-a5ee-0fea72f2f17d.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
1. Add a bunch of the same task to a canvas.
2. Hover over the task digest in the top right. After a small delay all the other nodes with the same digest will be highlighted.
3. Remove the cursor to end the hover. Other nodes should un-highlight
4. Now add some modified versions of the same component, with a different digest, to the canvas.
5. Hover over the digests again to confirm that only the tasks with matching digests are highlighted.
6. Confirm that the existing highlight-on-hover from the drag-and-drop replace feature still works as expected without issue
7. Confirm that the existing task details actions duplicate, delete & upgrade continue to work as expected.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
