### PR TITLE
CreateInputNode and CreateOutputNode Methods

### DIFF
--- a/src/utils/nodes/createInputNode.ts
+++ b/src/utils/nodes/createInputNode.ts
@@ -1,0 +1,22 @@
+import { type Node } from "@xyflow/react";
+
+import type { InputSpec } from "../componentSpec";
+import { extractPositionFromAnnotations } from "./extractPositionFromAnnotations";
+import { inputNameToNodeId } from "./nodeIdUtils";
+
+export const createInputNode = (input: InputSpec) => {
+  const { name, annotations, ...rest } = input;
+
+  const position = extractPositionFromAnnotations(annotations);
+  const nodeId = inputNameToNodeId(name);
+
+  return {
+    id: nodeId,
+    data: {
+      ...rest,
+      label: name,
+    },
+    position: position,
+    type: "input",
+  } as Node;
+};

--- a/src/utils/nodes/createNodesFromComponentSpec.ts
+++ b/src/utils/nodes/createNodesFromComponentSpec.ts
@@ -2,8 +2,9 @@ import { type Node } from "@xyflow/react";
 
 import type { TaskNodeData } from "@/types/taskNode";
 import type { ComponentSpec, GraphSpec } from "@/utils/componentSpec";
-import { extractPositionFromAnnotations } from "@/utils/nodes/extractPositionFromAnnotations";
 
+import { createInputNode } from "./createInputNode";
+import { createOutputNode } from "./createOutputNode";
 import { createTaskNode } from "./createTaskNode";
 
 const createNodesFromComponentSpec = (
@@ -23,40 +24,21 @@ const createNodesFromComponentSpec = (
 };
 
 const createTaskNodes = (graphSpec: GraphSpec, nodeData: TaskNodeData) => {
-  return Object.entries(graphSpec.tasks).map((task) => {
-    return createTaskNode(task, nodeData);
-  });
+  return Object.entries(graphSpec.tasks).map((task) =>
+    createTaskNode(task, nodeData),
+  );
 };
 
 const createInputNodes = (componentSpec: ComponentSpec) => {
-  return (componentSpec.inputs ?? []).map((inputSpec) => {
-    const position = extractPositionFromAnnotations(inputSpec.annotations);
-
-    return {
-      id: `input_${inputSpec.name}`,
-      data: {
-        label: inputSpec.name,
-        value: inputSpec.value,
-        default: inputSpec.default,
-        type: inputSpec.type,
-      },
-      position: position,
-      type: "input",
-    } as Node;
-  });
+  return (componentSpec.inputs ?? []).map((inputSpec) =>
+    createInputNode(inputSpec),
+  );
 };
 
 const createOutputNodes = (componentSpec: ComponentSpec) => {
-  return (componentSpec.outputs ?? []).map((outputSpec) => {
-    const position = extractPositionFromAnnotations(outputSpec.annotations);
-
-    return {
-      id: `output_${outputSpec.name}`,
-      data: { label: outputSpec.name, type: outputSpec.type },
-      position: position,
-      type: "output",
-    } as Node;
-  });
+  return (componentSpec.outputs ?? []).map((outputSpec) =>
+    createOutputNode(outputSpec),
+  );
 };
 
 export default createNodesFromComponentSpec;

--- a/src/utils/nodes/createOutputNode.ts
+++ b/src/utils/nodes/createOutputNode.ts
@@ -1,0 +1,22 @@
+import { type Node } from "@xyflow/react";
+
+import type { OutputSpec } from "../componentSpec";
+import { extractPositionFromAnnotations } from "./extractPositionFromAnnotations";
+import { outputNameToNodeId } from "./nodeIdUtils";
+
+export const createOutputNode = (output: OutputSpec) => {
+  const { name, annotations, ...rest } = output;
+
+  const position = extractPositionFromAnnotations(annotations);
+  const nodeId = outputNameToNodeId(name);
+
+  return {
+    id: nodeId,
+    data: {
+      ...rest,
+      label: name,
+    },
+    position: position,
+    type: "output",
+  } as Node;
+};


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Moves IO node creation into separate methods so they can be reused by IO duplication actions (similar to task nodes).

No change to app functionality; just setting up for IO node duplication functionality.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Progresses https://github.com/Shopify/oasis-frontend/issues/148

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Cleanup/Refactor

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
1. confirm that IO nodes work exactly the same as before

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
