### PR TITLE
Disable Context Panel Updates when Dragging Nodes

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -506,38 +506,41 @@ const FlowCanvas = ({
     }
   }, [selectedElements, onElementsRemove, triggerConfirmation]);
 
-  const handleOnNodesChange = (changes: NodeChange[]) => {
-    const positionChanges = changes.filter(
-      (change) => change.type === "position" && change.dragging === false,
-    );
+  const handleOnNodesChange = useCallback(
+    (changes: NodeChange[]) => {
+      const positionChanges = changes.filter(
+        (change) => change.type === "position" && change.dragging === false,
+      );
 
-    if (positionChanges.length > 0) {
-      const updatedNodes = positionChanges
-        .map((change) => {
-          if ("id" in change && "position" in change) {
-            const node = nodes.find((n) => n.id === change.id);
-            return node
-              ? {
-                  ...node,
-                  position: { x: change?.position?.x, y: change?.position?.y },
-                }
-              : null;
-          }
-          return null;
-        })
-        .filter(Boolean) as Node[];
+      if (positionChanges.length > 0) {
+        const updatedNodes = positionChanges
+          .map((change) => {
+            if ("id" in change && "position" in change && change.position) {
+              const node = nodes.find((n) => n.id === change.id);
+              return node
+                ? {
+                    ...node,
+                    position: { x: change.position.x, y: change.position.y },
+                  }
+                : null;
+            }
+            return null;
+          })
+          .filter(Boolean) as Node[];
 
-      if (updatedNodes.length > 0) {
-        const updatedComponentSpec = updateNodePositions(
-          updatedNodes,
-          componentSpec,
-        );
-        setComponentSpec(updatedComponentSpec);
+        if (updatedNodes.length > 0) {
+          const updatedComponentSpec = updateNodePositions(
+            updatedNodes,
+            componentSpec,
+          );
+          setComponentSpec(updatedComponentSpec);
+        }
       }
-    }
 
-    onNodesChange(changes);
-  };
+      onNodesChange(changes);
+    },
+    [nodes, componentSpec, setComponentSpec, onNodesChange],
+  );
 
   const handleBeforeDelete = async (params: NodesAndEdges) => {
     if (readOnly) {

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
@@ -1,3 +1,4 @@
+import { useStore } from "@xyflow/react";
 import { CircleFadingArrowUp, CopyIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -13,6 +14,11 @@ import { TaskNodeOutputs } from "./TaskNodeOutputs";
 const TaskNodeCard = () => {
   const taskNode = useTaskNode();
   const { setContent, clearContent } = useContextPanel();
+
+  const isDragging = useStore((state) => {
+    const thisNode = state.nodes.find((node) => node.id === taskNode.nodeId);
+    return thisNode?.dragging || false;
+  });
 
   const nodeRef = useRef<HTMLDivElement | null>(null);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -79,7 +85,7 @@ const TaskNodeCard = () => {
   }, [scrollHeight, dimensions.h]);
 
   useEffect(() => {
-    if (selected) {
+    if (selected && !isDragging) {
       setContent(taskConfigMarkup);
     }
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Patches over a critical issue that was causing the app to crash when dragging nodes. The issue has multiple causes, all triggered by the drag operation and potential updates to annotations/arguments causing infinite rerenders of the context panel. This was made even worse when multiple nodes are selected as they begin competing for the context panel space. The issue was NOT observed on IO nodes, or on nodes with no upstream connections. However, it was observed in any scenario involving connected or unconnected nodes that have been multi-selected. The symptom of the issue is the context panel being infinitely updated while a drag operation takes place, but the cause of this is currently unknown.

This PR patches over it by disabling context panel updates while a node is being dragged. It is not a clean or nice solution, but prevents the app from failing while we investigate and come up with a longer term fix.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Patch for https://github.com/Shopify/oasis-frontend/issues/202 (stops the issue from occurring but does not address the underlying cause and introduces other regressions)

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

Issue being patched over:
https://github.com/user-attachments/assets/7e050ca4-7c1b-480a-a845-cbf7a5c92702


## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
Rapidly dragging nodes, or groups of nodes, around the canvas should no longer crash the app.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
This PR will need a follow-up to implement a longer-term fix for the underlying causes. This PR does introduce some regressions: e.g. the context panel does not update when dragged and instead will resort back to default state. This means that when moving nodes around the panel bounces between tasks and pipeline very often.
