### PR TITLE
Dynamically set the height of the code viwer in artifacts

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/ioCell.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/ioCell.tsx
@@ -1,7 +1,7 @@
 import { ChevronsUpDown } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
-import CodeSyntaxHighlighter from "@/components/shared/CodeViewer/CodeSyntaxHighlighter";
+import { CodeViewer } from "@/components/shared/CodeViewer";
 import {
   Collapsible,
   CollapsibleContent,
@@ -21,6 +21,10 @@ import type {
 } from "@/utils/componentSpec";
 import { copyToClipboard, formatBytes } from "@/utils/string";
 import { convertGcsUrlToBrowserUrl } from "@/utils/URL";
+
+const MAX_LINES = 10;
+const JSON_CODE_LINE_HEIGHT = 31;
+const HEADER_HEIGHT = 55;
 
 interface IoCellProps {
   io: InputSpec | OutputSpec;
@@ -176,7 +180,7 @@ const IoCell = ({ io, artifacts }: IoCellProps) => {
             {artifacts.artifact_data.value !== undefined && (
               <div className="flex px-3 py-0 w-full">
                 <span
-                  className="flex-1 w-full cursor-copy"
+                  className="flex-1 w-full cursor-copy overflow-hidden"
                   onClick={handleCopyValue}
                 >
                   {(() => {
@@ -197,11 +201,21 @@ const IoCell = ({ io, artifacts }: IoCellProps) => {
                       parsed = value;
                     }
 
+                    const codeString = JSON.stringify(parsed, null, 2);
+
+
+                    const lines = codeString.split("\n");
+                    const maxLines = Math.min(MAX_LINES, lines.length);
+                    const lineHeight = `${maxLines * JSON_CODE_LINE_HEIGHT + HEADER_HEIGHT}px`;
+
                     return (
-                      <CodeSyntaxHighlighter
-                        code={JSON.stringify(parsed, null, 2)}
-                        language="json"
-                      />
+                      <div style={{ height: lineHeight }}>
+                        <CodeViewer
+                          code={codeString}
+                          language="json"
+                          filename={io.name}
+                        />
+                      </div>
                     );
                   })()}
                 </span>


### PR DESCRIPTION
## Description

This pull request updates the way JSON artifact data is displayed in the `IoCell` component, improving both the code structure and the user interface. The main changes include switching to a new `CodeViewer` component, limiting the display height for large JSON values, and ensuring better UI handling for overflowing content.

**UI and Display Improvements:**

* Replaced the older `CodeSyntaxHighlighter` with the new `CodeViewer` component for displaying JSON artifact data, and wrapped it in a container with a calculated maximum height to prevent large outputs from overflowing the UI. [[1]](diffhunk://#diff-c8b80cdb5e8b1ccd48eac5c5a43dfed571341015e6a61f9f7660ed2d389e6a28L4-R4) [[2]](diffhunk://#diff-c8b80cdb5e8b1ccd48eac5c5a43dfed571341015e6a61f9f7660ed2d389e6a28R200-R218)
* Added logic to limit the visible lines of JSON output to a maximum of 10, dynamically adjusting the container height based on the number of lines, and ensuring the header is always visible.
* Added the `overflow-hidden` class to the value container to improve UI handling when content exceeds the available space.
<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

Previous: 
<img width="425" height="143" alt="Screenshot 2025-08-15 at 11 35 28 AM" src="https://github.com/user-attachments/assets/7150ea1d-1e09-4eaf-8aff-e4d811a8f5fa" />

<!-- Include any screenshots that might help explain the changes or provide visual context -->
New: 

Long code
<img width="463" height="542" alt="Screenshot 2025-08-15 at 11 35 11 AM" src="https://github.com/user-attachments/assets/12e5b551-3dff-4de5-a7c4-8dd346f25aff" />

Short code:

<img width="447" height="358" alt="Screenshot 2025-08-15 at 11 36 10 AM" src="https://github.com/user-attachments/assets/24c84105-4e69-4bf5-aa10-84f5a3d3fd66" />



## Test Instructions

- create a run (I suggest using just `Train XGBoost model on CSV`)
- View artifacts for that task node
- Open up min_split_loss
- You should see one line of code
<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
