### PR TITLE
fix broken add to favorite

### DIFF
--- a/src/services/componentService.test.ts
+++ b/src/services/componentService.test.ts
@@ -18,6 +18,7 @@ import {
 vi.mock("@/utils/localforage", () => ({
   componentExistsByUrl: vi.fn(),
   getComponentByUrl: vi.fn(),
+  getComponentById: vi.fn(),
   saveComponent: vi.fn(),
   getAllUserComponents: vi.fn(),
 }));
@@ -281,6 +282,28 @@ describe("componentService", () => {
 
       expect(result).toBeNull();
       expect(localforage.saveComponent).not.toHaveBeenCalled();
+    });
+
+    it("should not override existing component if component already exists", async () => {
+      const yamlText = yaml.dump(mockComponentSpec);
+      const id = `component-${await generateDigest(yamlText)}`;
+
+      vi.mocked(localforage.getComponentById).mockResolvedValue({
+        id,
+        data: yamlText,
+        url: "",
+        createdAt: 1,
+        updatedAt: 1,
+      });
+
+      const component: ComponentReference = {
+        text: yamlText,
+      };
+
+      const result = await fetchAndStoreComponent(component);
+
+      expect(localforage.saveComponent).not.toHaveBeenCalled();
+      expect(result).toEqual(mockComponentSpec);
     });
   });
 

--- a/src/services/componentService.ts
+++ b/src/services/componentService.ts
@@ -16,6 +16,7 @@ import type {
 import {
   componentExistsByUrl,
   getAllUserComponents,
+  getComponentById,
   getComponentByUrl,
   saveComponent,
   type UserComponent,
@@ -210,13 +211,19 @@ export const fetchAndStoreComponent = async (
       const createdAt = Date.now();
       const updatedAt = Date.now();
 
-      await saveComponent({
-        id,
-        url: component.url ?? "",
-        data: text,
-        createdAt,
-        updatedAt,
-      });
+      const existingComponent = await getComponentById(id);
+
+      if (!existingComponent || text !== existingComponent.data) {
+        await saveComponent({
+          // preserve existing state
+          ...(existingComponent ?? {}),
+          id,
+          url: component.url ?? "",
+          data: text,
+          createdAt: existingComponent?.createdAt ?? createdAt,
+          updatedAt,
+        });
+      }
     }
 
     return spec;

--- a/src/utils/localforage.ts
+++ b/src/utils/localforage.ts
@@ -72,7 +72,7 @@ export async function componentExistsByUrl(url: string): Promise<boolean> {
 }
 
 // Function to get a component by ID
-async function getComponentById(id: string): Promise<Component | null> {
+export async function getComponentById(id: string): Promise<Component | null> {
   return componentStore.getItem<Component>(id);
 }
 


### PR DESCRIPTION
## Description

Closes https://github.com/Shopify/oasis-frontend/issues/203

Improved component storage logic to prevent overwriting existing components unnecessarily. The changes ensure that when fetching and storing components, we check if a component with the same ID already exists and only update it if the content has changed. This preserves existing component state while avoiding redundant storage operations.

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Test loading components from a library multiple times to verify they aren't unnecessarily overwritten
2. Verify that component state is preserved when re-fetching existing components
3. Run the updated tests to confirm the new behavior works as expected



https://github.com/user-attachments/assets/4833783f-e843-4f5d-99f0-0c5bd284383b




