### PR TITLE
remote components search beta flag

### DIFF
--- a/src/betaFlags.ts
+++ b/src/betaFlags.ts
@@ -7,6 +7,11 @@ export const ExistingBetaFlags = {
       "Highlight the tasks on the Pipeline canvas when the component is hovered over in the component library.",
     default: false,
   } as BetaFlag,
+  ["remote-component-library-search"]: {
+    name: "Remote component library search",
+    description: "Enable the remote component library search.",
+    default: false,
+  } as BetaFlag,
 
   ["redirect-on-new-pipeline-run"]: {
     name: "Redirect on new pipeline run",


### PR DESCRIPTION
## Description

Added a new beta flag for remote component library search functionality. This flag will enable users to search for components in remote libraries.

## Related Issue and Pull requests

## Type of Change

- [x] New feature

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Enable the "remote-component-library-search" beta flag
2. Verify that the remote component library search functionality becomes available
3. Test searching for components in remote libraries

## Additional Comments

The beta flag is disabled by default and can be enabled for testing purposes.