### PR TITLE
hydrate component reference

### DIFF
--- a/src/hooks/useHydrateComponentReference.test.tsx
+++ b/src/hooks/useHydrateComponentReference.test.tsx
@@ -1,0 +1,133 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ComponentReference } from "@/utils/componentSpec";
+
+import { useHydrateComponentReference } from "./useHydrateComponentReference";
+
+// Mock only the hydrateComponentReference function from componentService
+vi.mock("@/services/componentService", () => ({
+  hydrateComponentReference: vi.fn(),
+}));
+
+import { hydrateComponentReference } from "@/services/componentService";
+import type { HydratedComponentReference } from "@/utils/componentSpec";
+
+describe("useHydrateComponentReference", () => {
+  let queryClient: QueryClient;
+
+  const createWrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it("should hydrate a component reference with URL", async () => {
+    const mockComponent: ComponentReference = {
+      name: "test-component",
+      url: "https://example.com/component.yaml",
+    };
+
+    const mockHydratedComponent: HydratedComponentReference = {
+      name: mockComponent.name || "test-component",
+      spec: {
+        name: "test-component",
+        description: "Test component spec",
+        inputs: [],
+        outputs: [],
+        implementation: {
+          container: {
+            image: "test:latest",
+            command: ["echo"],
+            args: ["hello"],
+          },
+        },
+      },
+      text: "component yaml content",
+      digest: "abc123",
+      url: mockComponent.url,
+    };
+
+    vi.mocked(hydrateComponentReference).mockResolvedValue(
+      mockHydratedComponent,
+    );
+
+    const { result } = renderHook(
+      () => useHydrateComponentReference(mockComponent),
+      { wrapper: createWrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current).toEqual(mockHydratedComponent);
+    });
+
+    expect(hydrateComponentReference).toHaveBeenCalledWith(mockComponent);
+    expect(hydrateComponentReference).toHaveBeenCalledTimes(1);
+  });
+
+  it("should cache the result for 1 hour", async () => {
+    const mockComponent: ComponentReference = {
+      name: "cached-component",
+      digest: "cache-test",
+    };
+
+    const mockHydratedComponent: HydratedComponentReference = {
+      name: mockComponent.name || "cached-component",
+      digest: mockComponent.digest || "cache-test",
+      spec: {
+        name: "cached",
+        inputs: [],
+        outputs: [],
+        implementation: {
+          container: {
+            image: "test:latest",
+            command: ["cached"],
+          },
+        },
+      },
+      text: "cached content",
+    };
+
+    vi.mocked(hydrateComponentReference).mockResolvedValue(
+      mockHydratedComponent,
+    );
+
+    // First render
+    const { result: result1 } = renderHook(
+      () => useHydrateComponentReference(mockComponent),
+      { wrapper: createWrapper },
+    );
+
+    await waitFor(() => {
+      expect(result1.current).toEqual(mockHydratedComponent);
+    });
+
+    // Second render with same component
+    const { result: result2 } = renderHook(
+      () => useHydrateComponentReference(mockComponent),
+      { wrapper: createWrapper },
+    );
+
+    await waitFor(() => {
+      expect(result2.current).toEqual(mockHydratedComponent);
+    });
+
+    // Should only be called once due to caching
+    expect(hydrateComponentReference).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useHydrateComponentReference.ts
+++ b/src/hooks/useHydrateComponentReference.ts
@@ -1,0 +1,34 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+import { hydrateComponentReference } from "@/services/componentService";
+import type { ComponentReference } from "@/utils/componentSpec";
+
+const wildcardReference = Symbol("wildcardReference");
+
+/**
+ * Hydrate a component reference by fetching the text and spec from the URL or local storage
+ * This is experimental function, that potentially can replace all other methods of getting ComponentRef.
+ *
+ * @param component - The component reference to hydrate
+ * @returns The hydrated component reference or null if the component reference is invalid
+ */
+export function useHydrateComponentReference(component: ComponentReference) {
+  /**
+   * If the component has a digest or url, we can assume that the component is not going to change frequently
+   * Otherwise we dont cache result.
+   */
+  const staleTime = component.digest || component.url ? 1000 * 60 * 60 * 1 : 0;
+
+  const { data: componentRef } = useSuspenseQuery({
+    queryKey: [
+      "component",
+      "hydrate",
+      component.digest ?? component.url ?? wildcardReference,
+    ],
+    staleTime,
+    retryOnMount: true,
+    queryFn: () => hydrateComponentReference(component),
+  });
+
+  return componentRef;
+}

--- a/src/services/componentService.ts
+++ b/src/services/componentService.ts
@@ -7,11 +7,25 @@ import {
   isValidComponentLibrary,
 } from "@/types/componentLibrary";
 import { loadObjectFromYamlData } from "@/utils/cache";
-import type {
-  ComponentReference,
-  ComponentSpec,
-  InputSpec,
-  TaskSpec,
+import {
+  type ComponentReference,
+  type ComponentSpec,
+  type ContentfulComponentReference,
+  type DiscoverableComponentReference,
+  type HydratedComponentReference,
+  type InputSpec,
+  isContentfulComponentReference,
+  isDiscoverableComponentReference,
+  isHydratedComponentReference,
+  isInvalidComponentReference,
+  isLoadableComponentReference,
+  isNotMaterializedComponentReference,
+  isPartialContentfulComponentReference,
+  isSpecOnlyComponentReference,
+  isTextOnlyComponentReference,
+  type LoadableComponentReference,
+  type TaskSpec,
+  type UnknownComponentReference,
 } from "@/utils/componentSpec";
 import {
   componentExistsByUrl,
@@ -355,4 +369,249 @@ export const inputsWithInvalidArguments = (
       return !isOptional && !hasDefault && !isDefinedInArguments;
     })
     .map((input) => input.name);
+};
+
+function componentId(component: UnknownComponentReference): string {
+  if (
+    isHydratedComponentReference(component) ||
+    isDiscoverableComponentReference(component)
+  ) {
+    return `component-${component.digest}`;
+  }
+
+  // not sure how we can get here, but just in case
+  return "";
+}
+
+/**
+ * Hydrate a component reference from a contentful component reference.
+ * This function assumes, that text and spec are in sync.
+ *
+ * @param component - The component reference to hydrate
+ * @returns The hydrated component reference or null if the component reference is invalid
+ */
+async function hydrateFromContentfulComponentReference(
+  component: ContentfulComponentReference,
+): Promise<HydratedComponentReference | null> {
+  const { spec, text } = component;
+
+  // todo: should we validate that text and spec are in sync?
+
+  const digest = await generateDigest(text);
+  // we always want to have a name, so we generate a default one if it is not provided
+  const name = component.name ?? spec.name ?? `component-${digest.slice(0, 8)}`;
+
+  return {
+    ...component,
+    digest,
+    spec,
+    name,
+    // todo: do we need to ensure URL is set, extracted from the text/spec?
+  } satisfies HydratedComponentReference;
+}
+
+/**
+ * Hydrate a component reference from a contentful component reference
+ * @param component - The component reference to hydrate
+ * @returns The hydrated component reference or null if the component reference is invalid
+ */
+async function hydrateFromPartialContentfulComponentReference(
+  component: UnknownComponentReference,
+): Promise<HydratedComponentReference | null> {
+  if (!isPartialContentfulComponentReference(component)) {
+    return null;
+  }
+  // it is ok to fail here, as we will try to fetch the text from the URL or local storage
+  const text = isSpecOnlyComponentReference(component)
+    ? yaml.dump(component.spec)
+    : component.text;
+
+  const spec = isTextOnlyComponentReference(component)
+    ? (yaml.load(component.text) as ComponentSpec)
+    : component.spec;
+
+  if (!text || !spec) {
+    // likely we should see an exception above, but for narrowing types
+    return null;
+  }
+
+  return hydrateFromContentfulComponentReference({
+    ...component,
+    text,
+    spec,
+  });
+}
+
+/**
+ * Normalize stored component reference to ensure that text and spec are in sync.
+ * @param component - The component reference to normalize
+ * @returns The normalized component reference
+ */
+function normalizeStoredComponentReference(component: {
+  text?: string;
+  spec?: ComponentSpec;
+  data?: string;
+}): UnknownComponentReference {
+  // if text or data fields are provided, should return text, taken from `text` or `data` field and ignore `spec`
+
+  if (component.text || component.data) {
+    return {
+      ...component,
+      text: component.text ?? component.data,
+      spec: undefined,
+    };
+  }
+
+  return component;
+}
+
+async function saveHydratedComponentReferenceToStorage(
+  component: HydratedComponentReference,
+) {
+  const id = componentId(component);
+
+  // ensure that the component is not already in storage
+  const existingComponent = await getComponentById(id);
+
+  const createdAt = Date.now();
+  const updatedAt = Date.now();
+
+  await saveComponent({
+    // preserve existing state
+    ...(existingComponent ?? {}),
+    id,
+    url: component.url ?? "",
+    data: component.text,
+    createdAt: existingComponent?.createdAt ?? createdAt,
+    updatedAt,
+  });
+}
+
+function hydrationStrategy<
+  T extends UnknownComponentReference = ComponentReference,
+>(
+  validator: (component: UnknownComponentReference) => component is T,
+  resolutionStrategy: (component: T) => Promise<T | UnknownComponentReference>,
+) {
+  return async (
+    component: UnknownComponentReference,
+    onSuccess?: (component: T) => void,
+  ) => {
+    if (validator(component)) {
+      const result = await resolutionStrategy(component);
+      onSuccess?.(result as T);
+      return result;
+    }
+  };
+}
+
+/**
+ * Hydrate a component reference by fetching the text and spec from the URL or local storage
+ * This is experimental function, that potentially can replace all other methods of getting ComponentRef.
+ *
+ * @param component - The component reference to hydrate
+ * @returns The hydrated component reference or null if the component reference is invalid
+ */
+export const hydrateComponentReference = async (
+  component: ComponentReference,
+): Promise<HydratedComponentReference | null> => {
+  try {
+    let currentComponent: UnknownComponentReference = component;
+
+    const strategies = [
+      hydrationStrategy(
+        isInvalidComponentReference,
+        async (_: UnknownComponentReference) => null,
+      ),
+      hydrationStrategy(
+        isHydratedComponentReference,
+        async (component: HydratedComponentReference) => component,
+      ),
+      hydrationStrategy(
+        isContentfulComponentReference,
+        hydrateFromContentfulComponentReference,
+      ),
+
+      hydrationStrategy(
+        isDiscoverableComponentReference,
+        async (component: DiscoverableComponentReference) => {
+          const storedComponent = await getComponentById(
+            componentId(component),
+          );
+
+          if (storedComponent) {
+            return await hydrateFromPartialContentfulComponentReference({
+              ...component,
+              ...normalizeStoredComponentReference(storedComponent),
+            });
+          }
+
+          return component;
+        },
+      ),
+
+      hydrationStrategy(
+        isTextOnlyComponentReference,
+        hydrateFromPartialContentfulComponentReference,
+      ),
+
+      hydrationStrategy(
+        (component: UnknownComponentReference) =>
+          isNotMaterializedComponentReference(component) &&
+          isLoadableComponentReference(component),
+        async (component: LoadableComponentReference) => {
+          const text = await fetchComponentTextFromUrl(component.url);
+
+          if (text) {
+            return (
+              (await hydrateFromPartialContentfulComponentReference({
+                ...component,
+                // errasing spec, will be restored from text to keep both in sync
+                spec: undefined,
+                text,
+              })) ??
+              // fallback to component as is,
+              component
+            );
+          }
+
+          return component;
+        },
+      ),
+
+      hydrationStrategy(
+        isSpecOnlyComponentReference,
+        hydrateFromPartialContentfulComponentReference,
+      ),
+    ];
+
+    /**
+     * Try hydration strategies in order.
+     * If the component is resolved, save it to the storage and return it.
+     */
+    for (const resolveComponentRef of strategies) {
+      await resolveComponentRef(currentComponent, (component) => {
+        currentComponent = component;
+      });
+
+      if (!currentComponent) {
+        return null;
+      }
+
+      if (isHydratedComponentReference(currentComponent)) {
+        // dont wait for actualizing the cache value, as it is not critical
+        void saveHydratedComponentReferenceToStorage(currentComponent).catch(
+          // todo: handle error
+          console.error,
+        );
+        return currentComponent;
+      }
+    }
+
+    return null;
+  } catch (error) {
+    // todo: handle error
+    console.error(`Error in hydrateComponentReference:`, error);
+    return null;
+  }
 };

--- a/src/services/hydrateComponentReference.test.ts
+++ b/src/services/hydrateComponentReference.test.ts
@@ -1,0 +1,1246 @@
+import { waitFor } from "@testing-library/dom";
+import yaml from "js-yaml";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ComponentSpec } from "@/utils/componentSpec";
+import * as localforage from "@/utils/localforage";
+
+import { hydrateComponentReference } from "./componentService";
+
+vi.mock("@/utils/localforage", () => ({
+  getComponentById: vi.fn(),
+  getComponentByUrl: vi.fn(),
+  saveComponent: vi.fn(),
+}));
+
+describe("hydrateComponentReference()", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  describe("HydratedComponentReference", () => {
+    describe("when reference contains digest, name, spec, and text", () => {
+      it("should return the already hydrated component without modifications", async () => {
+        // Arrange
+        const testDigest = "hydrated123digest456";
+        const { text: componentText, spec: componentSpec } =
+          prepareComponentContent("HydratedComponent", "hydrated:v1");
+
+        const hydratedRef = {
+          digest: testDigest,
+          name: "HydratedComponent",
+          spec: componentSpec,
+          text: componentText,
+        };
+
+        // Act
+        const result = await hydrateComponentReference(hydratedRef);
+
+        // Assert
+        expect(result).not.toBeNull();
+        expect(result?.digest).toBe(testDigest);
+        expect(result?.name).toBe("HydratedComponent");
+        expect(result?.spec).toEqual(componentSpec);
+        expect(result?.text).toBe(componentText);
+        expect(localforage.getComponentByUrl).not.toHaveBeenCalled();
+        expect(localforage.saveComponent).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("DiscoverableComponentReference", () => {
+    describe("when digest is known (component exists in storage)", () => {
+      it("should hydrate component from storage when stored component contains both text and spec", async () => {
+        // Arrange
+        const testDigest = "abc123def456";
+        const { text: componentText, spec: componentSpec } =
+          prepareComponentContent("TestComponent", "test:latest");
+
+        mockGetComponentById({
+          digest: testDigest,
+          url: "https://example.com/component.yaml",
+          spec: componentSpec,
+        });
+
+        const discoverableRef = { digest: testDigest };
+
+        // Act
+        const result = await hydrateComponentReference(discoverableRef);
+
+        // Assert
+        expect(localforage.getComponentById).toHaveBeenCalledWith(
+          `component-${testDigest}`,
+        );
+        expect(result).not.toBeNull();
+        expect(result?.digest).toBeDefined();
+        expect(result?.name).toBe("TestComponent");
+        expect(result?.spec).toEqual(componentSpec);
+        expect(result?.text).toBe(componentText);
+        expect(localforage.saveComponent).toHaveBeenCalled();
+      });
+
+      it("should hydrate component from storage when stored component contains only text", async () => {
+        // Arrange
+        const testDigest = "xyz789abc123";
+
+        const { text: componentText, spec: componentSpec } =
+          prepareComponentContent("AnotherComponent", "another:v2");
+
+        mockGetComponentById({
+          digest: testDigest,
+          text: componentText,
+        });
+
+        const discoverableRef = { digest: testDigest };
+
+        // Act
+        const result = await hydrateComponentReference(discoverableRef);
+
+        // Assert
+        expect(localforage.getComponentById).toHaveBeenCalledWith(
+          `component-${testDigest}`,
+        );
+        expect(result).not.toBeNull();
+        expect(result?.digest).toBeDefined();
+        expect(result?.name).toBe("AnotherComponent");
+        expect(result?.spec).toEqual(componentSpec);
+        expect(result?.text).toBe(componentText);
+      });
+
+      it("should hydrate component from storage when stored component contains only spec", async () => {
+        // Arrange
+        const testDigest = "spec123only456";
+        const { text: componentText, spec: componentSpec } =
+          prepareComponentContent("SpecOnlyComponent", "spec-only:latest");
+
+        mockGetComponentById({
+          digest: testDigest,
+          spec: componentSpec,
+        });
+
+        const discoverableRef = { digest: testDigest };
+
+        // Act
+        const result = await hydrateComponentReference(discoverableRef);
+
+        // Assert
+        expect(localforage.getComponentById).toHaveBeenCalledWith(
+          `component-${testDigest}`,
+        );
+        expect(result).not.toBeNull();
+        expect(result?.digest).toBeDefined();
+        expect(result?.name).toBe("SpecOnlyComponent");
+        expect(result?.spec).toEqual(componentSpec);
+        expect(result?.text).toBe(componentText);
+      });
+
+      it("should generate a default name when spec doesn't have a name", async () => {
+        // Arrange
+        const testDigest = "noname789xyz";
+        const { spec: componentSpec } = prepareComponentContent(
+          undefined,
+          "noname:latest",
+        );
+
+        mockGetComponentById({
+          digest: testDigest,
+          spec: componentSpec,
+        });
+
+        const discoverableRef = { digest: testDigest };
+
+        // Act
+        const result = await hydrateComponentReference(discoverableRef);
+
+        // Assert
+        expect(result).not.toBeNull();
+        expect(result?.name).toMatch(/^component-[a-f0-9]{8}$/); // Should be component-{first 8 chars of digest}
+        expect(result?.spec).toEqual(componentSpec);
+      });
+
+      it("should return null when stored component has invalid data", async () => {
+        // Arrange
+        const testDigest = "invalid123data";
+        mockGetComponentById({
+          digest: testDigest,
+          text: undefined,
+          spec: undefined,
+          data: "",
+        });
+
+        const discoverableRef = { digest: testDigest };
+
+        // Act
+        const result = await hydrateComponentReference(discoverableRef);
+
+        // Assert
+        expect(localforage.getComponentById).toHaveBeenCalledWith(
+          `component-${testDigest}`,
+        );
+        expect(result).toBeNull();
+      });
+
+      it("should preserve existing storage data when saving hydrated component", async () => {
+        // Arrange
+        const testDigest = "preserve123data";
+        const { text: componentText } = prepareComponentContent(
+          "PreserveComponent",
+          "preserve:latest",
+        );
+
+        const existingCreatedAt = Date.now() - 10000;
+        mockGetComponentById({
+          digest: testDigest,
+          url: "https://example.com/component.yaml",
+          text: componentText,
+          createdAt: existingCreatedAt,
+          updatedAt: Date.now() - 5000,
+          customField: "should-be-preserved",
+        });
+
+        const discoverableRef = { digest: testDigest };
+
+        // Act
+        const result = await hydrateComponentReference(discoverableRef);
+
+        // Assert
+        expect(result).not.toBeNull();
+        expect(localforage.saveComponent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: expect.stringMatching(/^component-[a-f0-9]+$/), // Generated digest ID
+            createdAt: existingCreatedAt, // Should preserve original createdAt
+            customField: "should-be-preserved", // Should preserve custom fields
+          }),
+        );
+      });
+    });
+
+    describe("when digest is not known (component not in storage)", () => {
+      it("should return null when component is not found in storage", async () => {
+        // Arrange
+        const testDigest = "notfound123xyz";
+        const discoverableRef = {
+          digest: testDigest,
+        };
+
+        mockGetComponentById();
+
+        // Act
+        const result = await hydrateComponentReference(discoverableRef);
+
+        // Assert
+        expect(localforage.getComponentById).toHaveBeenCalledWith(
+          `component-${testDigest}`,
+        );
+        expect(result).toBeNull();
+      });
+
+      it("should fallback to hydration process by URL", async () => {
+        // Arrange
+        const testDigest = "notfound123xyz";
+        const discoverableRef = {
+          digest: testDigest,
+          url: "https://example.com/component.yaml",
+        };
+
+        const { text: componentText, spec: componentSpec } =
+          prepareComponentContent("NotFoundComponent", "notfound:v1");
+
+        mockGetComponentById();
+        mockGetComponentByUrl({
+          url: "https://example.com/component.yaml",
+          data: componentText,
+        });
+
+        // Act
+        const result = await hydrateComponentReference(discoverableRef);
+
+        // Assert
+        expect(localforage.getComponentById).toHaveBeenCalledWith(
+          `component-${testDigest}`,
+        );
+        expect(result).not.toBeNull();
+        expect(result?.digest).toBeDefined();
+        expect(result?.name).toBe("NotFoundComponent");
+        expect(result?.spec).toEqual(componentSpec);
+        expect(result?.text).toBe(componentText);
+        expect(localforage.saveComponent).toHaveBeenCalled();
+      });
+
+      it("should handle getComponentById throwing an error gracefully", async () => {
+        // Arrange
+        const testDigest = "error123case";
+        const discoverableRef = { digest: testDigest };
+
+        mockGetComponentMockError(new Error("Storage error"));
+
+        // Act
+        const result = await hydrateComponentReference(discoverableRef);
+
+        // Assert
+        expect(localforage.getComponentById).toHaveBeenCalledWith(
+          `component-${testDigest}`,
+        );
+        expect(result).toBeNull();
+      });
+    });
+  });
+
+  describe("LoadableComponentReference", () => {
+    beforeEach(() => {
+      // Mock fetch globally
+      global.fetch = vi.fn();
+    });
+
+    describe("when URL is cached in storage", () => {
+      it("should hydrate component from cached URL data", async () => {
+        // Arrange
+        const testUrl = "https://example.com/component.yaml";
+        const { text: componentText, spec: componentSpec } =
+          prepareComponentContent("CachedComponent", "cached:v1");
+
+        mockGetComponentByUrl({
+          url: testUrl,
+          data: componentText,
+        });
+
+        const loadableRef = { url: testUrl };
+
+        // Act
+        const result = await hydrateComponentReference(loadableRef);
+
+        // Assert
+        expect(localforage.getComponentByUrl).toHaveBeenCalledWith(testUrl);
+        expect(global.fetch).not.toHaveBeenCalled();
+        expect(result).not.toBeNull();
+        expect(result?.digest).toBeDefined();
+        expect(result?.name).toBe("CachedComponent");
+        expect(result?.spec).toEqual(componentSpec);
+        expect(result?.text).toBe(componentText);
+        expect(result?.url).toBe(testUrl);
+        await waitFor(() => {
+          expect(localforage.saveComponent).toHaveBeenCalled();
+        });
+      });
+
+      it("should handle cached component without a name", async () => {
+        // Arrange
+        const testUrl = "https://example.com/noname.yaml";
+        const { text: componentText, spec: componentSpec } =
+          prepareComponentContent(undefined, "noname:latest");
+
+        mockGetComponentByUrl({
+          url: testUrl,
+          data: componentText,
+        });
+
+        const loadableRef = { url: testUrl };
+
+        // Act
+        const result = await hydrateComponentReference(loadableRef);
+
+        // Assert
+        expect(result).not.toBeNull();
+        expect(result?.name).toMatch(/^component-[a-f0-9]{8}$/);
+        expect(result?.spec).toEqual(componentSpec);
+      });
+    });
+
+    describe("when URL is not cached (fetch from network)", () => {
+      it("should fetch and hydrate component from URL", async () => {
+        // Arrange
+        const testUrl = "https://example.com/remote-component.yaml";
+        const { text: componentText, spec: componentSpec } =
+          prepareComponentContent("RemoteComponent", "remote:v2");
+
+        mockGetComponentByUrl(null); // Not cached
+        mockFetchResponse(componentText);
+
+        const loadableRef = { url: testUrl };
+
+        // Act
+        const result = await hydrateComponentReference(loadableRef);
+
+        // Assert
+        expect(localforage.getComponentByUrl).toHaveBeenCalledWith(testUrl);
+        expect(global.fetch).toHaveBeenCalledWith(testUrl);
+        expect(result).not.toBeNull();
+        expect(result?.digest).toBeDefined();
+        expect(result?.name).toBe("RemoteComponent");
+        expect(result?.spec).toEqual(componentSpec);
+        expect(result?.text).toBe(componentText);
+        expect(localforage.saveComponent).toHaveBeenCalled();
+      });
+
+      it("should handle fetch network errors gracefully", async () => {
+        // Arrange
+        const testUrl = "https://example.com/error-component.yaml";
+
+        mockGetComponentByUrl(null); // Not cached
+        mockFetchError(new Error("Network error"));
+
+        const loadableRef = { url: testUrl };
+
+        // Act
+        const result = await hydrateComponentReference(loadableRef);
+
+        // Assert
+        expect(localforage.getComponentByUrl).toHaveBeenCalledWith(testUrl);
+        expect(global.fetch).toHaveBeenCalledWith(testUrl);
+        expect(result).toBeNull();
+        expect(localforage.saveComponent).not.toHaveBeenCalled();
+      });
+
+      it("should handle non-ok fetch responses", async () => {
+        // Arrange
+        const testUrl = "https://example.com/404-component.yaml";
+
+        mockGetComponentByUrl(null); // Not cached
+        mockFetchResponse("", { ok: false, statusText: "Not Found" });
+
+        const loadableRef = { url: testUrl };
+
+        // Act
+        const result = await hydrateComponentReference(loadableRef);
+
+        // Assert
+        expect(localforage.getComponentByUrl).toHaveBeenCalledWith(testUrl);
+        expect(global.fetch).toHaveBeenCalledWith(testUrl);
+        expect(result).toBeNull();
+        expect(localforage.saveComponent).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when remote component text is invalid", () => {
+      it("should return null for invalid YAML", async () => {
+        // Arrange
+        const testUrl = "https://example.com/invalid.yaml";
+        const invalidYaml = "{ invalid: yaml: content }}}";
+
+        mockGetComponentByUrl({
+          url: testUrl,
+          data: invalidYaml,
+        });
+
+        const loadableRef = { url: testUrl };
+
+        // Act
+        const result = await hydrateComponentReference(loadableRef);
+
+        // Assert
+        expect(result).toBeNull();
+        expect(localforage.saveComponent).not.toHaveBeenCalled();
+      });
+
+      it("should return null for empty component text", async () => {
+        // Arrange
+        const testUrl = "https://example.com/empty.yaml";
+
+        mockGetComponentByUrl({
+          url: testUrl,
+          data: "",
+        });
+
+        const loadableRef = { url: testUrl };
+
+        // Act
+        const result = await hydrateComponentReference(loadableRef);
+
+        // Assert
+        expect(result).toBeNull();
+        expect(localforage.saveComponent).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when URL and digest are both present", () => {
+      it("should prioritize digest over URL if component exists by digest", async () => {
+        // Arrange
+        const testUrl = "https://example.com/component.yaml";
+        const testDigest = "priority123test";
+        const { text: componentText, spec: componentSpec } =
+          prepareComponentContent("DigestPriority", "digest:v1");
+
+        mockGetComponentById({
+          digest: testDigest,
+          text: componentText,
+          spec: componentSpec,
+        });
+
+        const mixedRef = { url: testUrl, digest: testDigest };
+
+        // Act
+        const result = await hydrateComponentReference(mixedRef);
+
+        // Assert
+        expect(localforage.getComponentById).toHaveBeenCalledWith(
+          `component-${testDigest}`,
+        );
+        expect(localforage.getComponentByUrl).not.toHaveBeenCalled();
+        expect(global.fetch).not.toHaveBeenCalled();
+        expect(result).not.toBeNull();
+        expect(result?.name).toBe("DigestPriority");
+      });
+
+      it("should fall back to URL if digest not found", async () => {
+        // Arrange
+        const testUrl = "https://example.com/fallback.yaml";
+        const testDigest = "notfound999";
+        const { text: componentText } = prepareComponentContent(
+          "FallbackComponent",
+          "fallback:v1",
+        );
+
+        mockGetComponentById(null); // Digest not found
+        mockGetComponentByUrl({
+          url: testUrl,
+          data: componentText,
+        });
+
+        const mixedRef = { url: testUrl, digest: testDigest };
+
+        // Act
+        const result = await hydrateComponentReference(mixedRef);
+
+        // Assert
+        expect(localforage.getComponentById).toHaveBeenCalledWith(
+          `component-${testDigest}`,
+        );
+        expect(localforage.getComponentByUrl).toHaveBeenCalledWith(testUrl);
+        expect(result).not.toBeNull();
+        expect(result?.name).toBe("FallbackComponent");
+      });
+    });
+
+    describe("when saving hydrated component", () => {
+      it("should preserve URL in saved component", async () => {
+        // Arrange
+        const testUrl = "https://example.com/preserve-url.yaml";
+        const { text: componentText } = prepareComponentContent(
+          "PreserveUrlComponent",
+          "preserve:v1",
+        );
+
+        mockGetComponentByUrl({
+          url: testUrl,
+          data: componentText,
+        });
+
+        const loadableRef = { url: testUrl };
+
+        // Act
+        const result = await hydrateComponentReference(loadableRef);
+
+        // Assert
+        expect(result).not.toBeNull();
+        expect(result?.url).toBe(testUrl);
+        expect(localforage.saveComponent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: testUrl,
+            data: componentText,
+          }),
+        );
+      });
+
+      it("should not overwrite existing component data when saving", async () => {
+        // Arrange
+        const testUrl = "https://example.com/existing.yaml";
+        const { text: componentText } = prepareComponentContent(
+          "ExistingComponent",
+          "existing:v1",
+        );
+
+        const existingCreatedAt = Date.now() - 20000;
+        const existingCustomData = { customField: "preserve-me" };
+
+        mockGetComponentByUrl({
+          url: testUrl,
+          data: componentText,
+        });
+
+        // Mock the existing component lookup during save
+        vi.mocked(localforage.getComponentById).mockResolvedValueOnce(
+          createStoredComponent({
+            digest: "existing-digest",
+            url: testUrl,
+            text: componentText,
+            createdAt: existingCreatedAt,
+            ...existingCustomData,
+          }),
+        );
+
+        const loadableRef = { url: testUrl };
+
+        // Act
+        const result = await hydrateComponentReference(loadableRef);
+
+        // Assert
+        expect(result).not.toBeNull();
+        expect(localforage.saveComponent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            createdAt: existingCreatedAt,
+            customField: "preserve-me",
+          }),
+        );
+      });
+    });
+  });
+
+  describe("PartialContentfulComponentReference", () => {
+    describe("when reference contains text only (TextOnlyComponentReference)", () => {
+      it("should hydrate component from provided text and generate digest", async () => {
+        // Arrange
+        const { text: componentText, spec: componentSpec } =
+          prepareComponentContent("TextComponent", "text:v1");
+
+        // Must have spec === undefined for TextOnlyComponentReference
+        const partialRef = { text: componentText, spec: undefined };
+
+        // Act
+        const result = await hydrateComponentReference(partialRef);
+
+        // Assert
+        expect(result).not.toBeNull();
+        expect(result?.digest).toBeDefined();
+        expect(result?.digest).toMatch(/^[a-f0-9]{64}$/); // SHA-256 hash
+        expect(result?.name).toBe("TextComponent");
+        expect(result?.spec).toEqual(componentSpec);
+        expect(result?.text).toBe(componentText);
+        expect(localforage.saveComponent).toHaveBeenCalled();
+      });
+
+      it("should handle text without component name", async () => {
+        // Arrange
+        const { text: componentText, spec: componentSpec } =
+          prepareComponentContent(undefined, "noname:v1");
+
+        const partialRef = { text: componentText, spec: undefined };
+
+        // Act
+        const result = await hydrateComponentReference(partialRef);
+
+        // Assert
+        expect(result).not.toBeNull();
+        expect(result?.name).toMatch(/^component-[a-f0-9]{8}$/);
+        expect(result?.spec).toEqual(componentSpec);
+        expect(result?.text).toBe(componentText);
+      });
+
+      it("should return null for invalid YAML text", async () => {
+        // Arrange
+        const invalidYaml = "{ invalid: yaml: : content }}}";
+        const partialRef = { text: invalidYaml, spec: undefined };
+
+        // Act
+        const result = await hydrateComponentReference(partialRef);
+
+        // Assert
+        expect(result).toBeNull();
+        expect(localforage.saveComponent).not.toHaveBeenCalled();
+      });
+
+      it("should return null for empty text", async () => {
+        // Arrange
+        const partialRef = { text: "", spec: undefined };
+
+        // Act
+        const result = await hydrateComponentReference(partialRef);
+
+        // Assert
+        expect(result).toBeNull();
+        expect(localforage.saveComponent).not.toHaveBeenCalled();
+      });
+
+      it("should handle text with only whitespace", async () => {
+        // Arrange
+        const partialRef = { text: "   \n\t  ", spec: undefined };
+
+        // Act
+        const result = await hydrateComponentReference(partialRef);
+
+        // Assert
+        expect(result).toBeNull();
+        expect(localforage.saveComponent).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when reference contains spec only (SpecOnlyComponentReference)", () => {
+      it("should hydrate component from provided spec and generate digest", async () => {
+        // Arrange
+        const { text: componentText, spec: componentSpec } =
+          prepareComponentContent("SpecComponent", "spec:v2");
+
+        // Must not have text for SpecOnlyComponentReference
+        const partialRef = { spec: componentSpec, text: undefined };
+
+        // Act
+        const result = await hydrateComponentReference(partialRef);
+
+        // Assert
+        expect(result).not.toBeNull();
+        expect(result?.digest).toBeDefined();
+        expect(result?.digest).toMatch(/^[a-f0-9]{64}$/);
+        expect(result?.name).toBe("SpecComponent");
+        expect(result?.spec).toEqual(componentSpec);
+        expect(result?.text).toBe(componentText);
+        expect(localforage.saveComponent).toHaveBeenCalled();
+      });
+
+      it("should handle spec without component name", async () => {
+        // Arrange
+        const componentSpec = createComponentSpec(undefined, "unnamed:latest");
+        const partialRef = { spec: componentSpec, text: undefined };
+
+        // Act
+        const result = await hydrateComponentReference(partialRef);
+
+        // Assert
+        expect(result).not.toBeNull();
+        expect(result?.name).toMatch(/^component-[a-f0-9]{8}$/);
+        expect(result?.spec).toEqual(componentSpec);
+        expect(result?.text).toBe(yaml.dump(componentSpec));
+      });
+
+      it("should return null for invalid spec object", async () => {
+        // Arrange
+        const invalidSpec = { invalid: "not a valid component spec" } as any;
+        const partialRef = { spec: invalidSpec, text: undefined };
+
+        // Act
+        const result = await hydrateComponentReference(partialRef);
+
+        // Assert
+        expect(result).toBeNull();
+        expect(localforage.saveComponent).not.toHaveBeenCalled();
+      });
+
+      it("should return null for null spec", async () => {
+        // Arrange
+        const partialRef = { spec: null as any, text: undefined };
+
+        // Act
+        const result = await hydrateComponentReference(partialRef);
+
+        // Assert
+        expect(result).toBeNull();
+        expect(localforage.saveComponent).not.toHaveBeenCalled();
+      });
+
+      it("should return null for undefined spec", async () => {
+        // Arrange
+        const partialRef = { spec: undefined as any, text: undefined };
+
+        // Act
+        const result = await hydrateComponentReference(partialRef);
+
+        // Assert
+        expect(result).toBeNull();
+        expect(localforage.saveComponent).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when reference contains text with URL", () => {
+      it("should hydrate from text and preserve URL", async () => {
+        // Arrange
+        const testUrl = "https://example.com/partial.yaml";
+        const { text: componentText, spec: componentSpec } =
+          prepareComponentContent("UrlTextComponent", "urltext:v1");
+
+        // Text-only with URL (spec must be undefined)
+        const partialRef = {
+          text: componentText,
+          url: testUrl,
+          spec: undefined,
+        };
+
+        // Act
+        const result = await hydrateComponentReference(partialRef);
+
+        // Assert
+        expect(result).not.toBeNull();
+        expect(result?.url).toBe(testUrl);
+        expect(result?.name).toBe("UrlTextComponent");
+        expect(result?.spec).toEqual(componentSpec);
+        expect(localforage.saveComponent).toHaveBeenCalled();
+      });
+    });
+
+    describe("when reference contains spec with digest", () => {
+      it("should hydrate from spec and ignore provided digest", async () => {
+        // Arrange
+        const providedDigest = "provideddigest123";
+        const { spec: componentSpec } = prepareComponentContent(
+          "DigestSpecComponent",
+          "digestspec:v1",
+        );
+
+        // Spec-only with digest (text must be undefined)
+        const partialRef = {
+          spec: componentSpec,
+          digest: providedDigest,
+          text: undefined,
+        };
+
+        // Act
+        const result = await hydrateComponentReference(partialRef);
+
+        // Assert
+        expect(result).not.toBeNull();
+        expect(result?.digest).toBeDefined();
+        expect(result?.digest).not.toBe(providedDigest); // Should generate new digest
+        expect(result?.digest).toMatch(/^[a-f0-9]{64}$/); // Should be a SHA-256 hash
+        expect(result?.name).toBe("DigestSpecComponent");
+        expect(result?.spec).toEqual(componentSpec);
+      });
+    });
+
+    describe("error handling", () => {
+      it("should handle crypto.subtle.digest errors gracefully", async () => {
+        // Arrange
+        const { text: componentText } = prepareComponentContent(
+          "ErrorComponent",
+          "error:v1",
+        );
+
+        vi.spyOn(globalThis.crypto.subtle, "digest").mockRejectedValueOnce(
+          new Error("Crypto error"),
+        );
+
+        const partialRef = { text: componentText, spec: undefined };
+
+        // Act
+        const result = await hydrateComponentReference(partialRef);
+
+        // Assert
+        expect(result).toBeNull();
+        expect(localforage.saveComponent).not.toHaveBeenCalled();
+      });
+
+      it("should handle saveComponent errors gracefully", async () => {
+        // Arrange
+        const { text: componentText } = prepareComponentContent(
+          "SaveErrorComponent",
+          "saveerror:v1",
+        );
+
+        vi.mocked(localforage.saveComponent).mockRejectedValueOnce(
+          new Error("Storage error"),
+        );
+
+        const partialRef = { text: componentText, spec: undefined };
+
+        // Act
+        const result = await hydrateComponentReference(partialRef);
+
+        // Assert
+        expect(result).not.toBeNull(); // Should still return the hydrated component
+        expect(result?.name).toBe("SaveErrorComponent");
+        await waitFor(() => {
+          expect(localforage.saveComponent).toHaveBeenCalled();
+        });
+      });
+    });
+  });
+
+  describe("ContentfulComponentReference", () => {
+    describe("when reference contains both text and spec", () => {
+      it("should hydrate component from provided text and spec and generate digest", async () => {
+        // Arrange
+        const { text: componentText, spec: componentSpec } =
+          prepareComponentContent("ContentfulComponent", "contentful:v1");
+
+        const contentfulRef = { text: componentText, spec: componentSpec };
+
+        // Act
+        const result = await hydrateComponentReference(contentfulRef);
+
+        // Assert
+        expect(result).not.toBeNull();
+        expect(result?.digest).toBeDefined();
+        expect(result?.digest).toMatch(/^[a-f0-9]{64}$/); // SHA-256 hash
+        expect(result?.name).toBe("ContentfulComponent");
+        expect(result?.spec).toEqual(componentSpec);
+        expect(result?.text).toBe(componentText);
+        expect(localforage.saveComponent).toHaveBeenCalled();
+      });
+
+      it.todo(
+        "should use text over spec when they differ" /** todo: decide if this case is valid */,
+      );
+
+      it("should handle both text and spec without component name", async () => {
+        // Arrange
+        const { text: componentText, spec: componentSpec } =
+          prepareComponentContent(undefined, "noname:v1");
+
+        const contentfulRef = { text: componentText, spec: componentSpec };
+
+        // Act
+        const result = await hydrateComponentReference(contentfulRef);
+
+        // Assert
+        expect(result).not.toBeNull();
+        expect(result?.name).toMatch(/^component-[a-f0-9]{8}$/);
+        expect(result?.spec).toEqual(componentSpec);
+        expect(result?.text).toBe(yaml.dump(componentSpec)); // Text regenerated from spec
+      });
+
+      it("should preserve URL when provided with text and spec", async () => {
+        // Arrange
+        const testUrl = "https://example.com/contentful.yaml";
+        const { text: componentText, spec: componentSpec } =
+          prepareComponentContent("UrlContentfulComponent", "urlcontentful:v1");
+
+        const contentfulRef = {
+          text: componentText,
+          spec: componentSpec,
+          url: testUrl,
+        };
+
+        // Act
+        const result = await hydrateComponentReference(contentfulRef);
+
+        // Assert
+        expect(result).not.toBeNull();
+        expect(result?.url).toBe(testUrl);
+        expect(result?.name).toBe("UrlContentfulComponent");
+        expect(result?.spec).toEqual(componentSpec);
+        expect(localforage.saveComponent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: testUrl,
+          }),
+        );
+      });
+
+      it("should generate new digest ignoring provided digest", async () => {
+        // Arrange
+        const providedDigest = "provideddigest456";
+        const { text: componentText, spec: componentSpec } =
+          prepareComponentContent("DigestContentfulComponent", "digest:v1");
+
+        const contentfulRef = {
+          text: componentText,
+          spec: componentSpec,
+          digest: providedDigest,
+        };
+
+        // Act
+        const result = await hydrateComponentReference(contentfulRef);
+
+        // Assert
+        expect(result).not.toBeNull();
+        expect(result?.digest).toBeDefined();
+        expect(result?.digest).not.toBe(providedDigest); // Should generate new digest
+        expect(result?.digest).toMatch(/^[a-f0-9]{64}$/);
+        expect(result?.name).toBe("DigestContentfulComponent");
+      });
+
+      it.todo(
+        "should return null when text is invalid YAML but valid spec" /** todo: decide how we should handle this */,
+      );
+
+      it("should handle empty text with valid spec", async () => {
+        // Arrange
+        const { spec: componentSpec } = prepareComponentContent(
+          "EmptyTextComponent",
+          "emptytext:v1",
+        );
+
+        const contentfulRef = {
+          text: "",
+          spec: componentSpec,
+        };
+
+        // Act
+        const result = await hydrateComponentReference(contentfulRef);
+
+        // Assert
+        expect(result).not.toBeNull();
+        expect(result?.name).toBe("EmptyTextComponent");
+        expect(result?.spec).toEqual(componentSpec);
+        expect(result?.text).toBe(yaml.dump(componentSpec)); // Text generated from spec
+      });
+
+      it("should preserve all properties when saving", async () => {
+        // Arrange
+        const testUrl = "https://example.com/preserve-all.yaml";
+        const { text: componentText, spec: componentSpec } =
+          prepareComponentContent("PreserveAllComponent", "preserve:v1");
+
+        const contentfulRef = {
+          text: componentText,
+          spec: componentSpec,
+          url: testUrl,
+          customProp: "should-be-ignored", // Extra properties should be ignored
+        };
+
+        // Act
+        const result = await hydrateComponentReference(contentfulRef);
+
+        // Assert
+        expect(result).not.toBeNull();
+        await waitFor(() => {
+          expect(localforage.saveComponent).toHaveBeenCalledWith(
+            expect.objectContaining({
+              url: testUrl,
+              data: yaml.dump(componentSpec),
+            }),
+          );
+        });
+      });
+
+      it("should handle crypto.subtle.digest errors gracefully", async () => {
+        // Arrange
+        const { text: componentText, spec: componentSpec } =
+          prepareComponentContent("ErrorComponent", "error:v1");
+
+        vi.spyOn(globalThis.crypto.subtle, "digest").mockRejectedValueOnce(
+          new Error("Crypto error"),
+        );
+
+        const contentfulRef = { text: componentText, spec: componentSpec };
+
+        // Act
+        const result = await hydrateComponentReference(contentfulRef);
+
+        // Assert
+        expect(result).toBeNull();
+        expect(localforage.saveComponent).not.toHaveBeenCalled();
+      });
+
+      it("should handle saveComponent errors gracefully", async () => {
+        // Arrange
+        const { text: componentText, spec: componentSpec } =
+          prepareComponentContent("SaveErrorComponent", "saveerror:v1");
+
+        vi.mocked(localforage.saveComponent).mockRejectedValueOnce(
+          new Error("Storage error"),
+        );
+
+        const contentfulRef = { text: componentText, spec: componentSpec };
+
+        // Act
+        const result = await hydrateComponentReference(contentfulRef);
+
+        // Assert
+        expect(result).not.toBeNull(); // Should still return the hydrated component
+        expect(result?.name).toBe("SaveErrorComponent");
+        expect(result?.spec).toEqual(componentSpec);
+        await waitFor(() => {
+          expect(localforage.saveComponent).toHaveBeenCalled();
+        });
+      });
+
+      it("should handle complex nested spec structures", async () => {
+        // Arrange
+        const complexSpec: ComponentSpec = {
+          name: "ComplexComponent",
+          implementation: {
+            container: {
+              image: "complex:latest",
+              command: ["python", "-m", "complex_module"],
+              args: ["--verbose", "--config", "/etc/config.yaml"],
+            },
+          },
+          inputs: [
+            {
+              name: "input1",
+              type: "String",
+              description: "First input",
+            },
+            {
+              name: "input2",
+              type: "Dataset",
+              description: "Second input",
+            },
+          ],
+          outputs: [
+            {
+              name: "output1",
+              type: "Model",
+              description: "First output",
+            },
+          ],
+        };
+        const complexText = yaml.dump(complexSpec);
+
+        const contentfulRef = {
+          text: complexText,
+          spec: complexSpec,
+        };
+
+        // Act
+        const result = await hydrateComponentReference(contentfulRef);
+
+        // Assert
+        expect(result).not.toBeNull();
+        expect(result?.name).toBe("ComplexComponent");
+        expect(result?.spec).toEqual(complexSpec);
+        expect(result?.text).toBe(complexText);
+      });
+
+      it("should handle spec with special characters in name", async () => {
+        // Arrange
+        const { text: componentText, spec: componentSpec } =
+          prepareComponentContent(
+            "Component-With_Special.Characters@123",
+            "special:v1",
+          );
+
+        const contentfulRef = { text: componentText, spec: componentSpec };
+
+        // Act
+        const result = await hydrateComponentReference(contentfulRef);
+
+        // Assert
+        expect(result).not.toBeNull();
+        expect(result?.name).toBe("Component-With_Special.Characters@123");
+        expect(result?.spec).toEqual(componentSpec);
+      });
+
+      it("should handle very large text and spec", async () => {
+        // Arrange
+        const largeDescription = "x".repeat(10000);
+        const largeSpec: ComponentSpec = {
+          name: "LargeComponent",
+          description: largeDescription,
+          implementation: {
+            container: {
+              image: "large:latest",
+            },
+          },
+        };
+        const largeText = yaml.dump(largeSpec);
+
+        const contentfulRef = {
+          text: largeText,
+          spec: largeSpec,
+        };
+
+        // Act
+        const result = await hydrateComponentReference(contentfulRef);
+
+        // Assert
+        expect(result).not.toBeNull();
+        expect(result?.name).toBe("LargeComponent");
+        expect(result?.spec?.description).toBe(largeDescription);
+      });
+    });
+  });
+});
+
+// Helper functions
+function createComponentSpec(
+  name?: string,
+  image = "default:latest",
+): ComponentSpec {
+  const spec: ComponentSpec = {
+    implementation: {
+      container: {
+        image,
+      },
+    },
+  };
+
+  if (name) {
+    spec.name = name;
+  }
+
+  return spec;
+}
+
+function prepareComponentContent(
+  name?: string,
+  image = "default:latest",
+): { text: string; spec: ComponentSpec } {
+  const spec = createComponentSpec(name, image);
+  return {
+    text: yaml.dump(spec),
+    spec,
+  };
+}
+
+function createStoredComponent({
+  digest,
+  url = "",
+  text,
+  spec,
+  data,
+  createdAt = Date.now(),
+  updatedAt = Date.now(),
+  ...rest
+}: {
+  digest: string;
+  url?: string;
+  text?: string;
+  spec?: ComponentSpec;
+  data?: string;
+  createdAt?: number;
+  updatedAt?: number;
+  customField?: string;
+}) {
+  return {
+    id: `component-${digest}`,
+    url,
+    data: data ?? (text || (spec ? yaml.dump(spec) : "")),
+    text,
+    spec,
+    createdAt,
+    updatedAt,
+    ...rest,
+  };
+}
+
+function mockGetComponentById(
+  options?: Parameters<typeof createStoredComponent>[0] | null,
+) {
+  const storedComponent =
+    options && options !== null ? createStoredComponent(options) : null;
+
+  vi.mocked(localforage.getComponentById).mockResolvedValue(storedComponent);
+  return storedComponent;
+}
+
+function mockGetComponentMockError(error: Error) {
+  vi.mocked(localforage.getComponentById).mockRejectedValue(error);
+}
+
+function mockGetComponentByUrl(
+  data:
+    | {
+        url: string;
+        data: string;
+        createdAt?: number;
+        updatedAt?: number;
+      }
+    | null
+    | undefined,
+) {
+  vi.mocked(localforage.getComponentByUrl).mockResolvedValue(
+    data
+      ? {
+          id: `component-url-${Date.now()}`,
+          url: data.url,
+          data: data.data,
+          createdAt: data.createdAt ?? Date.now(),
+          updatedAt: data.updatedAt ?? Date.now(),
+        }
+      : null,
+  );
+}
+
+function mockFetchResponse(
+  text: string,
+  options: { ok?: boolean; statusText?: string } = {},
+) {
+  const response = {
+    ok: options.ok ?? true,
+    statusText: options.statusText ?? "OK",
+    text: vi.fn().mockResolvedValue(text),
+  };
+  vi.mocked(global.fetch).mockResolvedValue(response as unknown as Response);
+}
+
+function mockFetchError(error: Error) {
+  vi.mocked(global.fetch).mockRejectedValue(error);
+}

--- a/src/utils/componentSpec.ts
+++ b/src/utils/componentSpec.ts
@@ -177,6 +177,178 @@ export interface ComponentReference {
   text?: string;
   favorited?: boolean;
 }
+
+export type UnknownComponentReference = ComponentReference | null | undefined;
+
+export type HydratedComponentReference = Omit<
+  ComponentReference,
+  "spec" | "text" | "digest" | "name"
+> & {
+  digest: string;
+  name: string;
+  spec: ComponentSpec;
+  text: string;
+};
+
+type NotMaterializedComponentReference = Omit<
+  ComponentReference,
+  "spec" | "text"
+> & {
+  spec: never;
+  text: never;
+};
+
+export function isNotMaterializedComponentReference(
+  componentReference: UnknownComponentReference,
+): componentReference is NotMaterializedComponentReference {
+  return Boolean(
+    componentReference &&
+      typeof componentReference === "object" &&
+      !componentReference.spec &&
+      !componentReference.text,
+  );
+}
+
+export type DiscoverableComponentReference = Omit<
+  ComponentReference,
+  "digest"
+> & {
+  digest: string;
+};
+
+export function isDiscoverableComponentReference(
+  componentReference: UnknownComponentReference,
+): componentReference is DiscoverableComponentReference {
+  return Boolean(
+    componentReference &&
+      typeof componentReference === "object" &&
+      componentReference.digest !== undefined &&
+      componentReference.digest.length > 0,
+  );
+}
+
+export type LoadableComponentReference = Omit<ComponentReference, "url"> & {
+  url: string;
+};
+
+export function isLoadableComponentReference(
+  componentReference: UnknownComponentReference,
+): componentReference is LoadableComponentReference {
+  return Boolean(
+    componentReference &&
+      typeof componentReference === "object" &&
+      componentReference.url !== undefined &&
+      componentReference.url.length > 0 &&
+      // simple URL validation
+      /^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/i.test(componentReference.url),
+  );
+}
+
+export type ContentfulComponentReference = Omit<
+  ComponentReference,
+  "spec" | "text"
+> & {
+  spec: ComponentSpec;
+  text: string;
+};
+
+export function isContentfulComponentReference(
+  componentReference: UnknownComponentReference,
+): componentReference is ContentfulComponentReference {
+  return Boolean(
+    componentReference &&
+      typeof componentReference === "object" &&
+      componentReference.spec !== undefined &&
+      componentReference.text !== undefined &&
+      isValidComponentSpec(componentReference.spec) &&
+      componentReference.text.length > 0,
+  );
+}
+
+type TextOnlyComponentReference = Omit<ComponentReference, "spec" | "text"> & {
+  spec: never;
+  text: string;
+};
+
+export function isTextOnlyComponentReference(
+  componentReference: UnknownComponentReference,
+): componentReference is TextOnlyComponentReference {
+  return Boolean(
+    componentReference &&
+      typeof componentReference === "object" &&
+      !componentReference.spec &&
+      componentReference.text !== undefined &&
+      componentReference.text.length > 0,
+  );
+}
+
+type SpecOnlyComponentReference = Omit<ComponentReference, "spec"> & {
+  spec: ComponentSpec;
+  text: never;
+};
+
+export function isSpecOnlyComponentReference(
+  componentReference: UnknownComponentReference,
+): componentReference is SpecOnlyComponentReference {
+  return Boolean(
+    componentReference &&
+      typeof componentReference === "object" &&
+      componentReference.spec !== undefined &&
+      isValidComponentSpec(componentReference.spec) &&
+      (!componentReference.text || componentReference.text.length === 0),
+  );
+}
+
+type PartialContentfulComponentReference =
+  | TextOnlyComponentReference
+  | SpecOnlyComponentReference;
+
+export function isPartialContentfulComponentReference(
+  componentReference: UnknownComponentReference,
+): componentReference is PartialContentfulComponentReference {
+  return Boolean(
+    isTextOnlyComponentReference(componentReference) ||
+      isSpecOnlyComponentReference(componentReference),
+  );
+}
+
+export function isHydratedComponentReference(
+  componentReference: UnknownComponentReference,
+): componentReference is HydratedComponentReference {
+  return Boolean(
+    componentReference &&
+      typeof componentReference === "object" &&
+      componentReference.spec !== undefined &&
+      componentReference.text !== undefined &&
+      isValidComponentSpec(componentReference.spec) &&
+      componentReference.text.length > 0 &&
+      componentReference.digest !== undefined &&
+      componentReference.digest.length > 0 &&
+      componentReference.name !== undefined &&
+      componentReference.name.length > 0,
+  );
+}
+
+type InvalidComponentReference = Omit<ComponentReference, "spec" | "text"> & {
+  url: never;
+  digest: never;
+  spec: never;
+  text: never;
+};
+
+export function isInvalidComponentReference(
+  componentReference: UnknownComponentReference,
+): componentReference is InvalidComponentReference {
+  return Boolean(
+    !componentReference ||
+      typeof componentReference !== "object" ||
+      (!isLoadableComponentReference(componentReference) &&
+        !isDiscoverableComponentReference(componentReference) &&
+        !componentReference.spec &&
+        !componentReference.text),
+  );
+}
+
 /**
  * Represents the component argument value that comes from the graph component input.
  */


### PR DESCRIPTION
## Description

Added a new hook `useHydrateComponentReference` to fetch and hydrate component references from URLs or local storage. This hook uses React Query for data fetching with 1-hour caching to improve performance.

Also implemented the underlying `hydrateComponentReference` service function that handles the actual component hydration logic, including:

- Fetching component specs from URLs
- Parsing YAML text into component specs
- Generating digests for components
- Caching components in local storage
- Handling various error cases

## Overall flow

```
flowchart TD
    Start([start]) --> S1{Strategy 1:<br/>isInvalidComponentReference?}
    
    
    S1 -->|YES<br/><br/>Returns null| ReturnNull[Return null]
    S1 -->|NO| S2
    
    S2{Strategy 2:<br/>isHydratedComponentReference?} 
    S2 -->|YES<br/><br/>All fields already present:<br/>• text: existing<br/>• spec: existing<br/>• digest: existing<br/>• name: existing<br/>• url: existing| CheckHydrated1
    S2 -->|NO| S3
    
    S3{Strategy 3:<br/>isContentfulComponentReference?}
    S3 -->|YES<br/><br/>Has both text AND spec| Hydrate1[hydrateFromContentfulComponentReference<br/><br/>• digest: generateDigest from text<br/>• name: component.name ?? spec.name ?? default<br/>• text: from component<br/>• spec: from component<br/>• url: from component if exists]
    S3 -->|NO| S4
    
    Hydrate1 --> CheckHydrated1
    
    S4{Strategy 4:<br/>isDiscoverableComponentReference?}
    S4 -->|YES<br/><br/>Has digest| Storage1[getComponentById<br/>using digest]
    S4 -->|NO| S5
    
    Storage1 --> StorageFound{Found in<br/>storage?}
    StorageFound -->|YES| Normalize[normalizeStoredComponentReference<br/><br/>Prefer text over spec]
    StorageFound -->|NO| S5[Proceed to other strategies]
    
    Normalize --> Hydrate2[hydrateFromPartialContentfulComponentReference<br/><br/>• text: from storage or yaml.dump spec<br/>• spec: from storage or yaml.load text<br/>• digest: generateDigest from text<br/>• name: component.name ?? spec.name ?? default<br/>• url: from component if exists]
    
    Hydrate2 --> CheckHydrated1
    
    
    S5{Strategy 5:<br/>isTextOnlyComponentReference?}
    S5 -->|YES<br/><br/>Has text but no spec| Hydrate3[hydrateFromPartialContentfulComponentReference<br/><br/>• text: from component<br/>• spec: yaml.load from text<br/>• digest: generateDigest from text<br/>• name: component.name ?? spec.name ?? default<br/>• url: from component if exists]
    S5 -->|NO| S6
    
    Hydrate3 --> CheckHydrated1
    
    S6{Strategy 6:<br/>isNotMaterializedComponentReference<br/>AND isLoadableComponentReference?}
    S6 -->|YES<br/><br/>Has URL but no text/spec| Network[fetchComponentTextFromUrl]
    S6 -->|NO| S7
    
    Network --> Cache[Check cache:<br/>getComponentByUrl]
    Cache --> CacheHit{Cache<br/>hit?}
    CacheHit -->|YES| UseCache[Return cached text]
    CacheHit -->|NO| HTTPFetch[Network: fetch URL]
    
    HTTPFetch --> TextFetched{Text<br/>fetched?}
    UseCache --> TextFetched
    
    TextFetched -->|YES| Hydrate4[hydrateFromPartialContentfulComponentReference<br/><br/>• text: fetched text<br/>• spec: yaml.load from text<br/>• digest: generateDigest from text<br/>• name: component.name ?? spec.name ?? default<br/>• url: from component]
    TextFetched -->|NO| S7[Proceed to other strategies]
    
    Hydrate4 --> CheckHydrated1
    
    S7{Strategy 7:<br/>isSpecOnlyComponentReference?}
    S7 -->|YES<br/><br/>Has spec but no text| Hydrate5[hydrateFromPartialContentfulComponentReference<br/><br/>• text: yaml.dump from spec<br/>• spec: from component<br/>• digest: generateDigest from text<br/>• name: component.name ?? spec.name ?? default<br/>• url: from component if exists]
    S7 -->|NO| CheckHydrated1
    
    Hydrate5 --> CheckHydrated1
    
    CheckHydrated1{isHydratedComponentReference?}
    CheckHydrated1 -->|YES| SaveStorage[saveHydratedComponentReferenceToStorage<br/><br/>Save to local storage<br/>async - don't wait]
    CheckHydrated1 -->|NO| ReturnNull[Return null]
    
    SaveStorage --> Success[Return HydratedComponentReference]
    
    ReturnNull --> End([End])
    
    Success --> End
    
    style Start fill:#e1f5e1, color:black
    style End fill:#ffe1e1, color:black
    style Success fill:#d4edda, color:black
    style ReturnNull fill:#f8d7da, color:black
   
```

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

The PR includes comprehensive tests for both the hook and service function. You can run the tests with:

```
npm test src/hooks/useHydrateComponentReference.test.tsx
npm test src/services/componentService.test.ts
```

To use the hook in a component:

```
const componentRef = useHydrateComponentReference({
  url: "https://example.com/component.yaml"
});
```

## Additional Comments

This implementation is marked as experimental and could potentially replace other methods of getting component references in the future.