### PR TITLE
publish component from my components

### DIFF
--- a/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
+++ b/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
@@ -9,6 +9,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -17,6 +18,8 @@ import type { ComponentReference } from "@/utils/componentSpec";
 
 import InfoIconButton from "../Buttons/InfoIconButton";
 import { InfoBox } from "../InfoBox";
+import { PublishComponent } from "../ManageComponent/PublishComponent";
+import { useBetaFlagValue } from "../Settings/useBetaFlags";
 import { withSuspenseWrapper } from "../SuspenseWrapper";
 import { TaskDetails, TaskImplementation, TaskIO } from "../TaskDetails";
 
@@ -62,6 +65,10 @@ const ComponentDetailsDialog = withSuspenseWrapper(
     actions = [],
     onDelete,
   }: ComponentDetailsProps) => {
+    const remoteComponentLibrarySearchEnabled = useBetaFlagValue(
+      "remote-component-library-search",
+    );
+
     const componentRef = useHydrateComponentReference(component);
 
     if (!componentRef) {
@@ -73,6 +80,9 @@ const ComponentDetailsDialog = withSuspenseWrapper(
     }
 
     const { url, spec: componentSpec, digest: componentDigest } = componentRef;
+
+    const hasPublishSection =
+      remoteComponentLibrarySearchEnabled && component.owned;
 
     return (
       <>
@@ -103,6 +113,13 @@ const ComponentDetailsDialog = withSuspenseWrapper(
                 <Code className="h-4 w-4" />
                 Implementation
               </TabsTrigger>
+
+              {hasPublishSection ? (
+                <TabsTrigger value="publish" className="flex-1">
+                  <Icon name="LibraryBig" />
+                  Publish
+                </TabsTrigger>
+              ) : null}
             </TabsList>
 
             <div className="overflow-hidden h-[40vh]">
@@ -127,6 +144,15 @@ const ComponentDetailsDialog = withSuspenseWrapper(
                   componentSpec={componentSpec}
                 />
               </TabsContent>
+
+              {hasPublishSection ? (
+                <TabsContent value="publish" className="h-full">
+                  <PublishComponent
+                    component={componentRef}
+                    displayName={displayName}
+                  />
+                </TabsContent>
+              ) : null}
             </div>
           </Tabs>
         )}

--- a/src/components/shared/ManageComponent/ComponentHistoryTimeline.tsx
+++ b/src/components/shared/ManageComponent/ComponentHistoryTimeline.tsx
@@ -1,0 +1,205 @@
+import type { ComponentProps, PropsWithChildren } from "react";
+
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Heading, Text } from "@/components/ui/typography";
+import { useHydrateComponentReference } from "@/hooks/useHydrateComponentReference";
+import { cn } from "@/lib/utils";
+import type {
+  ComponentReferenceWithDigest,
+  HydratedComponentReference,
+} from "@/utils/componentSpec";
+
+import { withSuspenseWrapper } from "../SuspenseWrapper";
+import { ComponentQuickDetailsDialogTrigger } from "./ComponentQuickDetailsDialog";
+import { ComponentUsageCount } from "./ComponentUsageCount";
+import { DeprecatePublishedComponentButton } from "./DeprecatePublishedComponentButton";
+import { PublishComponentButton } from "./PublishComponentButton";
+import { TrimmedDigest } from "./TrimmedDigest";
+
+const ComponentHistoryTimelineItem = ({
+  icon,
+  iconClassName,
+  children,
+}: PropsWithChildren<{
+  icon: ComponentProps<typeof Icon>["name"];
+  iconClassName?: string;
+}>) => {
+  return (
+    <li className="relative">
+      <InlineStack align="center" blockAlign="start" gap="3">
+        <Icon
+          name={icon}
+          size="xs"
+          className={cn(
+            "relative z-10 flex-shrink-0 bg-background rounded-full translate-y-0.5",
+            iconClassName,
+          )}
+        />
+
+        <BlockStack gap="1" className="flex-1 min-w-0" align="start">
+          {children}
+        </BlockStack>
+      </InlineStack>
+    </li>
+  );
+};
+
+const ComponentHistoryTimelineSkeleton = () => {
+  return (
+    <BlockStack gap="2">
+      <Heading level={2}>Publish History</Heading>
+      <BlockStack gap="2">
+        <Skeleton size="full" />
+        <Skeleton size="half" />
+        <Skeleton size="full" />
+        <Skeleton size="half" />
+      </BlockStack>
+    </BlockStack>
+  );
+};
+
+export const ComponentHistoryTimeline = withSuspenseWrapper(
+  ({
+    history,
+    currentComponent,
+    currentUserName,
+    onChange,
+  }: {
+    history: ComponentReferenceWithDigest[];
+    currentComponent: HydratedComponentReference;
+    currentUserName?: string;
+    onChange?: () => void;
+  }) => {
+    const lastComponentInHistory =
+      history.length === 0 ? undefined : history[history.length - 1];
+    const lastHydratedComponent = useHydrateComponentReference(
+      lastComponentInHistory ?? {},
+    );
+
+    const isPotentiallyOutdated = Boolean(
+      history.length > 0 &&
+        history.find((c) => c.digest === currentComponent.digest) !==
+          history[history.length - 1],
+    );
+
+    const isPotentialNewRelease =
+      lastHydratedComponent &&
+      lastComponentInHistory &&
+      !history.find((c) => c.digest === currentComponent.digest) &&
+      lastComponentInHistory.name === currentComponent.name &&
+      !lastComponentInHistory.deprecated &&
+      lastComponentInHistory.published_by === currentUserName;
+
+    const isFirstPublish = history.length === 0;
+
+    return (
+      <BlockStack gap="2">
+        <Heading level={2}>Publish History</Heading>
+        <BlockStack className="relative">
+          {/* Timeline line - absolute positioned */}
+          <div
+            className={cn("absolute left-[5px] top-0 bottom-0 w-0.5 bg-border")}
+            aria-hidden="true"
+          />
+          <BlockStack gap="2" as="ul" className="relative">
+            {history.map((item, index, { length }) => {
+              const isMostRecent = index === length - 1;
+              const isMatchCurrentComponent =
+                item.digest === currentComponent.digest;
+
+              const icon = [
+                isMostRecent && "CircleDot",
+                isMatchCurrentComponent && "OctagonAlert",
+                "Circle",
+              ].find(Boolean) as ComponentProps<typeof Icon>["name"];
+
+              return (
+                <ComponentHistoryTimelineItem key={item.digest} icon={icon}>
+                  <InlineStack gap="1" blockAlign="center">
+                    <ComponentQuickDetailsDialogTrigger component={item} />
+                    <Text size="xs">by {item.published_by}</Text>
+
+                    {isMatchCurrentComponent && isPotentiallyOutdated ? (
+                      <Text size="xs" tone="critical">
+                        | You have an outdated version of this component in your
+                        library.
+                      </Text>
+                    ) : null}
+                  </InlineStack>
+                  <ComponentUsageCount digest={item.digest}>
+                    {(count) => (
+                      <Text size="xs" tone="subdued">
+                        Used {count} times in this Pipeline.
+                      </Text>
+                    )}
+                  </ComponentUsageCount>
+                </ComponentHistoryTimelineItem>
+              );
+            })}
+            {isPotentialNewRelease || isFirstPublish ? (
+              <ComponentHistoryTimelineItem
+                icon="CircleFadingArrowUp"
+                iconClassName="text-green-500"
+              >
+                <BlockStack gap="1">
+                  <InlineStack gap="1">
+                    <TrimmedDigest
+                      digest={currentComponent.digest}
+                      weight="semibold"
+                    />
+                    <Text size="xs" tone="subdued">
+                      {isFirstPublish
+                        ? "| this component has not been published yet"
+                        : "| you have a version of this component that is not published yet"}
+                    </Text>
+                  </InlineStack>
+                  <InlineStack gap="1" blockAlign="center">
+                    {isPotentialNewRelease ? (
+                      <DeprecatePublishedComponentButton
+                        predecessorComponent={lastHydratedComponent}
+                        successorComponent={currentComponent}
+                        onSuccess={onChange}
+                      />
+                    ) : null}
+                    {isFirstPublish ? (
+                      <PublishComponentButton
+                        component={currentComponent}
+                        onSuccess={onChange}
+                      />
+                    ) : null}
+                  </InlineStack>
+                </BlockStack>
+              </ComponentHistoryTimelineItem>
+            ) : null}
+
+            {!isFirstPublish && !isPotentiallyOutdated ? (
+              <ComponentHistoryTimelineItem
+                icon="CircleDashed"
+                iconClassName="text-gray-500"
+              >
+                <InlineStack gap="1" blockAlign="center">
+                  <Text size="xs" tone="subdued">
+                    To release a new version, drop the new component YAML file
+                    on the Pipeline Editor.
+                  </Text>
+                  {/* I commented out the ImportComponent because of behavior divergence. */}
+                  {/* This use case will be addressed in future PRs. */}
+                  {/* <ImportComponent
+                    triggerComponent={
+                      <Button variant="secondary" size="xs">
+                        Release new version?
+                      </Button>
+                    }
+                  /> */}
+                </InlineStack>
+              </ComponentHistoryTimelineItem>
+            ) : null}
+          </BlockStack>
+        </BlockStack>
+      </BlockStack>
+    );
+  },
+  ComponentHistoryTimelineSkeleton,
+);

--- a/src/components/shared/ManageComponent/ComponentQualityCard.tsx
+++ b/src/components/shared/ManageComponent/ComponentQualityCard.tsx
@@ -1,0 +1,126 @@
+import { type PropsWithChildren } from "react";
+
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Heading, Text } from "@/components/ui/typography";
+import type { HydratedComponentReference } from "@/utils/componentSpec";
+
+const ComponentSpecCheckStatement = ({
+  isValid,
+  validLabel,
+  invalidLabel,
+  children,
+}: PropsWithChildren<{
+  isValid: boolean;
+  validLabel: string;
+  invalidLabel: string;
+}>) => {
+  return (
+    <InlineStack gap="2" align="start" blockAlign="center">
+      {isValid ? (
+        <Icon name="Check" className="text-green-500" />
+      ) : (
+        <Icon name="OctagonAlert" className="text-yellow-500" />
+      )}
+      <Text as="span" size="sm">
+        {isValid ? validLabel : invalidLabel}
+      </Text>
+      {children}
+    </InlineStack>
+  );
+};
+
+export const ComponentQualityCard = ({
+  component,
+}: {
+  component: HydratedComponentReference;
+}) => {
+  const {
+    hasName,
+    hasDescription,
+    inputsValid,
+    outputsValid,
+    invalidInputs,
+    invalidOutputs,
+  } = checkComponentQuality(component);
+
+  return (
+    <BlockStack gap="2">
+      <Heading level={2}>ComponentSpec quality check</Heading>
+      <Text as="p" size="xs" tone="subdued">
+        Although following the ComponentSpec quality standard is not strictly
+        required for publishing, we strongly encourage you to adhere to it.
+        High-quality specifications help ensure your component is
+        well-documented, maintainable, and easily reusable by others in your
+        workspace. Meeting these standards improves discoverability and
+        collaboration across teams.
+      </Text>
+      <BlockStack gap="1" className="border-l pl-2">
+        <ComponentSpecCheckStatement
+          isValid={hasName}
+          validLabel="Component has a name"
+          invalidLabel="Component is missing a name"
+        />
+
+        <ComponentSpecCheckStatement
+          isValid={hasDescription}
+          validLabel="Component has a description"
+          invalidLabel="Component is missing a description"
+        />
+
+        <ComponentSpecCheckStatement
+          isValid={inputsValid}
+          validLabel="All inputs have Type and Description"
+          invalidLabel="Missing Type or Description for inputs"
+        >
+          <Text tone="critical" size="xs">
+            {invalidInputs.map((i) => i.name).join(", ")}
+          </Text>
+        </ComponentSpecCheckStatement>
+
+        <ComponentSpecCheckStatement
+          isValid={outputsValid}
+          validLabel="All outputs have Type and Description"
+          invalidLabel="Missing Type or Description for outputs"
+        >
+          <Text tone="critical" size="xs">
+            {invalidOutputs.map((o) => o.name).join(", ")}
+          </Text>
+        </ComponentSpecCheckStatement>
+      </BlockStack>
+    </BlockStack>
+  );
+};
+
+function checkComponentQuality(component: HydratedComponentReference) {
+  const { spec: componentSpec } = component;
+
+  // Check if all inputs have Type and Description
+  const invalidInputs =
+    componentSpec.inputs?.filter(
+      (input) => !input.type || !input.description,
+    ) ?? [];
+  const inputsValid = invalidInputs.length === 0;
+
+  // Check if all outputs have Type and Description
+  const invalidOutputs =
+    componentSpec.outputs?.filter(
+      (output) => !output.type || !output.description,
+    ) ?? [];
+  const outputsValid = invalidOutputs.length === 0;
+
+  // Check if component has a description
+  const hasDescription = !!componentSpec.description;
+
+  // Check if component has a name
+  const hasName = !!component.name;
+
+  return {
+    hasName,
+    hasDescription,
+    inputsValid,
+    outputsValid,
+    invalidInputs,
+    invalidOutputs,
+  };
+}

--- a/src/components/shared/ManageComponent/ComponentQuickDetailsDialog.tsx
+++ b/src/components/shared/ManageComponent/ComponentQuickDetailsDialog.tsx
@@ -1,0 +1,113 @@
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { BlockStack } from "@/components/ui/layout";
+import { Spinner } from "@/components/ui/spinner";
+import { Text } from "@/components/ui/typography";
+import { useHydrateComponentReference } from "@/hooks/useHydrateComponentReference";
+import type { ComponentReferenceWithDigest } from "@/utils/componentSpec";
+
+import { withSuspenseWrapper } from "../SuspenseWrapper";
+import TaskImplementation from "../TaskDetails/Implementation";
+import { ComponentSpecProperty } from "./ComponentSpecProperty";
+import { trimDigest } from "./utils/digest";
+
+export const ComponentQuickDetailsDialogTrigger = ({
+  component,
+}: {
+  component: ComponentReferenceWithDigest;
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        variant="link-info"
+        size="inline-xs"
+        onClick={() => setIsOpen(true)}
+      >
+        {trimDigest(component.digest)}
+      </Button>
+      {/* not showing the dialog prevents excessive requests */}
+      {isOpen ? (
+        <ComponentQuickDetailsDialog
+          component={component}
+          open={isOpen}
+          onOpenChange={setIsOpen}
+        />
+      ) : null}
+    </>
+  );
+};
+
+const ComponentQuickDetailsDialogSkeleton = () => {
+  /**
+   * this appears as a tiny spinner inline, next to the trigger.
+   */
+  return <Spinner size={10} />;
+};
+
+const ComponentQuickDetailsDialog = withSuspenseWrapper(
+  ({
+    component,
+    open,
+    onOpenChange,
+  }: {
+    component: ComponentReferenceWithDigest;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+  }) => {
+    const hydratedComponent = useHydrateComponentReference(component);
+
+    if (!hydratedComponent) {
+      return null;
+    }
+
+    const displayName = hydratedComponent.name;
+
+    return (
+      <Dialog modal open={open} onOpenChange={onOpenChange}>
+        <DialogContent
+          className="max-w-2xl min-w-2xl overflow-hidden"
+          aria-label={`${displayName} component details`}
+        >
+          <DialogDescription className="hidden">
+            Implementation details for the &quot;{displayName}&quot; component
+            of version {trimDigest(hydratedComponent.digest)}.
+          </DialogDescription>
+          <DialogTitle className="flex items-center gap-2 mr-5">
+            <Text>
+              {displayName}: {trimDigest(hydratedComponent.digest)}
+            </Text>
+          </DialogTitle>
+
+          <BlockStack gap="1" className="h-[400px]" align="stretch">
+            <ComponentSpecProperty
+              label="Digest"
+              value={hydratedComponent.digest}
+            />
+
+            <TaskImplementation
+              displayName={displayName}
+              componentSpec={hydratedComponent.spec}
+            />
+          </BlockStack>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="secondary">Close</Button>
+            </DialogClose>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
+  },
+  ComponentQuickDetailsDialogSkeleton,
+);

--- a/src/components/shared/ManageComponent/ComponentSpecProperty.tsx
+++ b/src/components/shared/ManageComponent/ComponentSpecProperty.tsx
@@ -1,0 +1,41 @@
+import { InlineStack } from "@/components/ui/layout";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Text } from "@/components/ui/typography";
+
+export const ComponentSpecProperty = ({
+  label,
+  value,
+  tooltip,
+}: {
+  label: string;
+  value?: string;
+  tooltip?: string;
+}) => {
+  if (!value) {
+    return null;
+  }
+
+  return (
+    <InlineStack gap="1">
+      <Text as="span" size="xs" weight="semibold">
+        {`${label}:`}
+      </Text>
+      <Text as="span" size="xs">
+        {tooltip ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Text tone="info">{value}</Text>
+            </TooltipTrigger>
+            <TooltipContent>{tooltip}</TooltipContent>
+          </Tooltip>
+        ) : (
+          value
+        )}
+      </Text>
+    </InlineStack>
+  );
+};

--- a/src/components/shared/ManageComponent/ComponentUsageCount.tsx
+++ b/src/components/shared/ManageComponent/ComponentUsageCount.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+
+import { withSuspenseWrapper } from "../SuspenseWrapper";
+import { useComponentCanvasTasks } from "./hooks/useComponentCanvasTasks";
+
+export const ComponentUsageCount = withSuspenseWrapper(
+  ({
+    digest,
+    children,
+  }: {
+    digest: string;
+    children: (count: number) => ReactNode;
+  }) => {
+    const tasksOnCanvas = useComponentCanvasTasks(digest);
+
+    if (tasksOnCanvas.length === 0) {
+      return null;
+    }
+
+    return children(tasksOnCanvas.length);
+  },
+);

--- a/src/components/shared/ManageComponent/DeprecatePublishedComponentButton.tsx
+++ b/src/components/shared/ManageComponent/DeprecatePublishedComponentButton.tsx
@@ -1,0 +1,152 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useMemo } from "react";
+
+import { Button } from "@/components/ui/button";
+import { BlockStack } from "@/components/ui/layout";
+import { Spinner } from "@/components/ui/spinner";
+import { Text } from "@/components/ui/typography";
+import useConfirmationDialog from "@/hooks/useConfirmationDialog";
+import useToastNotification from "@/hooks/useToastNotification";
+import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
+import type { HydratedComponentReference } from "@/utils/componentSpec";
+
+import ConfirmationDialog from "../Dialogs/ConfirmationDialog";
+import { InfoBox } from "../InfoBox";
+import { ComponentQualityCard } from "./ComponentQualityCard";
+
+/**
+ * Delete a published component.
+ * If a successor component is provided, it will be published instead of deprecated.
+ *
+ * @param predecessorComponent - The component to delete (deprecate).
+ * @param successorComponent - The component to publish instead of deprecated.
+ * @param onSuccess - Callback function to be called when the mutation is successful.
+ * @returns A button to delete the component.
+ */
+export const DeprecatePublishedComponentButton = ({
+  predecessorComponent,
+  successorComponent,
+  onSuccess,
+}: {
+  predecessorComponent: HydratedComponentReference;
+  successorComponent?: HydratedComponentReference;
+  onSuccess?: () => void;
+}) => {
+  const {
+    handlers: confirmationHandlers,
+    triggerDialog: triggerConfirmation,
+    ...confirmationProps
+  } = useConfirmationDialog();
+  const { getComponentLibrary } = useComponentLibrary();
+  const publishedComponentsLibrary = getComponentLibrary(
+    "published_components",
+  );
+  const queryClient = useQueryClient();
+  const notify = useToastNotification();
+
+  // strings and content for the confirmation dialog
+  const { title, description, content, successMessage, buttonLabel } =
+    useMemo(() => {
+      if (successorComponent) {
+        return {
+          buttonLabel: "Release new version",
+          title: predecessorComponent.name,
+          description:
+            "Are you sure you want to release a new version of this component?",
+          successMessage: "Component updated successfully",
+          content: (
+            <BlockStack gap="1">
+              <Text as="p" size="xs" tone="subdued">
+                This will create a new version of the component with the same
+                name. The previous version will be marked as deprecated. In
+                search results, the new version will be listed. Users who have
+                already used the previous version will still be able to use it
+                or upgrade to the new version.
+              </Text>
+              <ComponentQualityCard component={successorComponent} />
+            </BlockStack>
+          ),
+        };
+      }
+
+      return {
+        buttonLabel: "Deprecate component",
+        title: predecessorComponent.name,
+        description: "Are you sure you want to deprecate this component?",
+        successMessage: "Component deprecated successfully",
+        content: (
+          <Text as="p" size="sm">
+            This will deprecate the component and it will no longer be available
+            in search results. The component will still be available in the
+            component library for users who have already used it.
+          </Text>
+        ),
+      };
+    }, [successorComponent, predecessorComponent]);
+
+  const {
+    mutate: deletePublishedComponent,
+    isPending,
+    isError,
+    error,
+  } = useMutation({
+    mutationFn: async () => {
+      await publishedComponentsLibrary.removeComponent(predecessorComponent, {
+        supersedeBy: successorComponent,
+      });
+    },
+    onSuccess: () => {
+      notify(successMessage, "success");
+      if (successorComponent) {
+        queryClient.invalidateQueries({
+          queryKey: [
+            "component-library",
+            "published",
+            "has",
+            successorComponent.digest,
+          ],
+        });
+      }
+      onSuccess?.();
+    },
+    onError: (error) => {
+      notify(`Failed to update component: ${error.message}`, "error");
+    },
+  });
+
+  const confirmProcess = useCallback(async () => {
+    const confirmed = await triggerConfirmation({
+      title,
+      description,
+      content,
+    });
+
+    if (confirmed) {
+      deletePublishedComponent();
+    }
+  }, [
+    title,
+    description,
+    content,
+    triggerConfirmation,
+    deletePublishedComponent,
+  ]);
+
+  return (
+    <>
+      <Button disabled={isPending} onClick={confirmProcess} size="xs">
+        {buttonLabel} {isPending ? <Spinner /> : null}
+      </Button>
+      {isError && (
+        <InfoBox title="Error" variant="error">
+          {error.message}
+        </InfoBox>
+      )}
+      <ConfirmationDialog
+        {...confirmationProps}
+        onConfirm={() => confirmationHandlers?.onConfirm()}
+        onCancel={() => confirmationHandlers?.onCancel()}
+      />
+    </>
+  );
+};

--- a/src/components/shared/ManageComponent/PublishComponent.test.tsx
+++ b/src/components/shared/ManageComponent/PublishComponent.test.tsx
@@ -1,0 +1,152 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import yaml from "js-yaml";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { HydratedComponentReference } from "@/utils/componentSpec";
+
+import { PublishComponent } from "./PublishComponent";
+
+// Mock the hooks
+vi.mock("./hooks/useUserDetails", () => ({
+  useUserDetails: vi.fn(() => ({
+    data: {
+      name: "TestUser",
+      permissions: {
+        read: true,
+        write: true,
+      },
+    },
+  })),
+}));
+
+vi.mock("./hooks/usePublishedComponentHistory", () => ({
+  usePublishedComponentHistory: vi.fn(() => ({
+    data: [], // Empty history for first publish scenario
+    refetch: vi.fn(),
+  })),
+}));
+
+vi.mock("@/hooks/useHydrateComponentReference", () => ({
+  useHydrateComponentReference: vi.fn((component) => component),
+}));
+
+vi.mock("@/providers/ComponentLibraryProvider", () => ({
+  useComponentLibrary: vi.fn(() => ({
+    getComponentLibrary: vi.fn(() => ({
+      addComponent: vi.fn(),
+    })),
+  })),
+}));
+
+// Create a test wrapper with QueryClient
+const TestWrapper = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe("<PublishComponent />", () => {
+  let mockComponent: HydratedComponentReference;
+
+  beforeEach(() => {
+    const spec = {
+      name: "test-component",
+      description: "Test component description",
+      implementation: {
+        graph: {
+          tasks: {},
+        },
+      },
+      metadata: {
+        annotations: {
+          author: "Test Author",
+        },
+      },
+    };
+    mockComponent = {
+      name: "test-component",
+      digest: "sha256:abc123def456",
+      spec,
+      text: yaml.dump(spec),
+    };
+  });
+
+  test("should display publish button when there is no component history", async () => {
+    render(
+      <TestWrapper>
+        <PublishComponent
+          component={mockComponent}
+          displayName="Test Component"
+        />
+      </TestWrapper>,
+    );
+
+    // Wait for the component to render
+    await waitFor(() => {
+      expect(screen.getByText("Component Review")).toBeInTheDocument();
+    });
+
+    // Check that component properties are displayed
+    expect(screen.getByText("Test Author")).toBeInTheDocument();
+    expect(screen.getByText("test-component")).toBeInTheDocument();
+    expect(screen.getByText("Test component description")).toBeInTheDocument();
+    // Using getAllByText since the digest appears in multiple places (property and tooltip)
+    const digestElements = screen.getAllByText("sha256:abc123def456");
+    expect(digestElements.length).toBeGreaterThan(0);
+    expect(screen.getByText("TestUser")).toBeInTheDocument();
+
+    // Check that the publish button is visible
+    const publishButton = await screen.findByTestId("publish-component-button");
+    expect(publishButton).toBeInTheDocument();
+    expect(publishButton).toHaveTextContent("Publish component");
+    expect(publishButton).not.toBeDisabled();
+
+    // Check that the "not published yet" message is shown
+    expect(
+      screen.getByText(/this component has not been published yet/i),
+    ).toBeInTheDocument();
+  });
+
+  test("should display the component description text", () => {
+    render(
+      <TestWrapper>
+        <PublishComponent
+          component={mockComponent}
+          displayName="Test Component"
+        />
+      </TestWrapper>,
+    );
+
+    // Check that the description about published components is shown
+    expect(
+      screen.getByText(/Published Components are shared components/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/available to all users in the workspace/i),
+    ).toBeInTheDocument();
+  });
+
+  test("should have the component review container", async () => {
+    render(
+      <TestWrapper>
+        <PublishComponent
+          component={mockComponent}
+          displayName="Test Component"
+        />
+      </TestWrapper>,
+    );
+
+    // Wait for and check the component review container
+    await waitFor(() => {
+      const reviewContainer = screen.getByTestId("component-review-container");
+      expect(reviewContainer).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/shared/ManageComponent/PublishComponent.tsx
+++ b/src/components/shared/ManageComponent/PublishComponent.tsx
@@ -1,0 +1,99 @@
+import { Separator } from "@radix-ui/react-separator";
+import { useCallback } from "react";
+
+import { BlockStack } from "@/components/ui/layout";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Heading, Paragraph } from "@/components/ui/typography";
+import type { HydratedComponentReference } from "@/utils/componentSpec";
+
+import { withSuspenseWrapper } from "../SuspenseWrapper";
+import { ComponentHistoryTimeline } from "./ComponentHistoryTimeline";
+import { ComponentSpecProperty } from "./ComponentSpecProperty";
+import { usePublishedComponentHistory } from "./hooks/usePublishedComponentHistory";
+import { useUserDetails } from "./hooks/useUserDetails";
+
+interface ComponentPublishProps {
+  component: HydratedComponentReference;
+  displayName: string;
+}
+
+const ComponentPublishDescription = () => {
+  return (
+    <Paragraph size="xs" tone="subdued">
+      Published Components are shared components that are available to all users
+      in the workspace. By publishing, you make this component discoverable and
+      reusable by others through the component library. Once published, the
+      component will appear in the components search result for easy access and
+      collaboration.
+    </Paragraph>
+  );
+};
+
+const PublishComponentSkeleton = () => {
+  return (
+    <BlockStack gap="3">
+      <ComponentPublishDescription />
+      <Skeleton size="half" />
+      <Skeleton size="full" />
+      <Skeleton size="half" />
+      <Skeleton size="full" />
+    </BlockStack>
+  );
+};
+
+export const PublishComponent = withSuspenseWrapper(
+  ({ component }: ComponentPublishProps) => {
+    const { data: currentUserDetails } = useUserDetails();
+
+    const { data: history, refetch: refetchHistory } =
+      usePublishedComponentHistory(component, currentUserDetails.name);
+
+    const onChange = useCallback(() => {
+      refetchHistory();
+    }, [refetchHistory]);
+
+    return (
+      <ScrollArea className="h-full">
+        <BlockStack inlineAlign="space-between" className="h-full" gap="3">
+          <ComponentPublishDescription />
+
+          <BlockStack
+            gap="2"
+            className="border rounded-md p-2 h-full"
+            data-testid="component-review-container"
+          >
+            <Heading level={2}>Component Review</Heading>
+
+            <BlockStack gap="1" className="border-l pl-2">
+              <ComponentSpecProperty
+                label="Author"
+                value={component.spec.metadata?.annotations?.author}
+              />
+              <ComponentSpecProperty label="Name" value={component.name} />
+              <ComponentSpecProperty
+                label="Description"
+                value={component.spec.description}
+              />
+              <ComponentSpecProperty label="Digest" value={component.digest} />
+              <Separator />
+              <ComponentSpecProperty
+                label="Published by"
+                value={currentUserDetails.name}
+                tooltip="Your current user name"
+              />
+            </BlockStack>
+
+            <ComponentHistoryTimeline
+              history={history}
+              currentComponent={component}
+              currentUserName={currentUserDetails.name}
+              onChange={onChange}
+            />
+          </BlockStack>
+        </BlockStack>
+      </ScrollArea>
+    );
+  },
+  PublishComponentSkeleton,
+);

--- a/src/components/shared/ManageComponent/PublishComponentButton.tsx
+++ b/src/components/shared/ManageComponent/PublishComponentButton.tsx
@@ -1,0 +1,103 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useMemo } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import useConfirmationDialog from "@/hooks/useConfirmationDialog";
+import useToastNotification from "@/hooks/useToastNotification";
+import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
+import type { HydratedComponentReference } from "@/utils/componentSpec";
+
+import ConfirmationDialog from "../Dialogs/ConfirmationDialog";
+import { InfoBox } from "../InfoBox";
+import { ComponentQualityCard } from "./ComponentQualityCard";
+
+/**
+ * Publish a component.
+ *
+ * @param component - The component to publish.
+ * @param onSuccess - Callback function to be called when the mutation is successful.
+ * @returns A button to publish the component.
+ */
+export const PublishComponentButton = ({
+  component,
+  onSuccess,
+}: {
+  component: HydratedComponentReference;
+  onSuccess?: () => void;
+}) => {
+  const {
+    handlers: confirmationHandlers,
+    triggerDialog: triggerConfirmation,
+    ...confirmationProps
+  } = useConfirmationDialog();
+  const { getComponentLibrary } = useComponentLibrary();
+  const publishedComponentsLibrary = getComponentLibrary(
+    "published_components",
+  );
+  const queryClient = useQueryClient();
+  const notify = useToastNotification();
+  const {
+    mutate: publishComponent,
+    isPending,
+    isError,
+    error,
+  } = useMutation({
+    mutationFn: async () => {
+      await publishedComponentsLibrary.addComponent(component);
+    },
+    onSuccess: () => {
+      notify("Component published successfully", "success");
+      queryClient.invalidateQueries({
+        queryKey: ["component-library", "published", "has", component.digest],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["componentLibrary", "publishedComponents"],
+      });
+      onSuccess?.();
+    },
+    onError: (error) => {
+      notify(`Failed to publish component: ${error.message}`, "error");
+    },
+  });
+
+  const confirmationContent = useMemo(
+    () => <ComponentQualityCard component={component} />,
+    [component],
+  );
+
+  const confirmProcess = useCallback(async () => {
+    const confirmed = await triggerConfirmation({
+      title: "Publish component",
+      description: "",
+      content: confirmationContent,
+    });
+
+    if (confirmed) {
+      publishComponent();
+    }
+  }, [triggerConfirmation, publishComponent, confirmationContent]);
+
+  return (
+    <>
+      <Button
+        disabled={isPending}
+        onClick={confirmProcess}
+        size="xs"
+        data-testid="publish-component-button"
+      >
+        Publish component {isPending ? <Spinner /> : null}
+      </Button>
+      {isError && (
+        <InfoBox title="Error" variant="error">
+          {error.message}
+        </InfoBox>
+      )}
+      <ConfirmationDialog
+        {...confirmationProps}
+        onConfirm={() => confirmationHandlers?.onConfirm()}
+        onCancel={() => confirmationHandlers?.onCancel()}
+      />
+    </>
+  );
+};

--- a/src/components/shared/ManageComponent/TrimmedDigest.tsx
+++ b/src/components/shared/ManageComponent/TrimmedDigest.tsx
@@ -1,0 +1,30 @@
+import type { ComponentProps } from "react";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Text } from "@/components/ui/typography";
+
+import { trimDigest } from "./utils/digest";
+
+export const TrimmedDigest = ({
+  digest,
+  ...props
+}: {
+  digest: string;
+} & ComponentProps<typeof Text>) => {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Text size="xs" font="mono" {...props}>
+          {trimDigest(digest)}
+        </Text>
+      </TooltipTrigger>
+      <TooltipContent>
+        <span>{digest}</span>
+      </TooltipContent>
+    </Tooltip>
+  );
+};

--- a/src/components/shared/ManageComponent/hooks/useComponentCanvasTasks.ts
+++ b/src/components/shared/ManageComponent/hooks/useComponentCanvasTasks.ts
@@ -1,0 +1,21 @@
+import { useMemo } from "react";
+
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+
+/**
+ * Returns the tasks on the canvas that use the component with the given digest.
+ *
+ * @param digest - The digest of the component to find tasks for.
+ * @returns The tasks on the canvas that use the component with the given digest.
+ */
+export function useComponentCanvasTasks(digest: string) {
+  const { graphSpec } = useComponentSpec();
+
+  return useMemo(
+    () =>
+      Object.values(graphSpec?.tasks).filter(
+        (task) => task.componentRef.digest === digest,
+      ),
+    [graphSpec, digest],
+  );
+}

--- a/src/components/shared/ManageComponent/hooks/usePublishedComponentHistory.ts
+++ b/src/components/shared/ManageComponent/hooks/usePublishedComponentHistory.ts
@@ -1,0 +1,88 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
+import {
+  type ComponentReference,
+  type ComponentReferenceWithDigest,
+  type HydratedComponentReference,
+  isDiscoverableComponentReference,
+} from "@/utils/componentSpec";
+
+import { hasSupersededBy } from "../types";
+
+/**
+ * Hook to get the history of a published component
+ * @param componentRef - The component reference to get the history of
+ * @param userName - The name of the user to get the history for
+ * @returns The history of the component
+ */
+export const usePublishedComponentHistory = (
+  componentRef: HydratedComponentReference,
+  userName: string,
+) => {
+  const { getComponentLibrary } = useComponentLibrary();
+  const publishedComponentsLibrary = getComponentLibrary(
+    "published_components",
+  );
+
+  return useSuspenseQuery({
+    queryKey: ["component-library", "published", "history", componentRef.name],
+    queryFn: async () => {
+      const components = await publishedComponentsLibrary.getComponents({
+        searchTerm: componentRef.name,
+        filters: ["name", "deprecated"],
+      });
+
+      /**
+       * Assuming that component name never changed
+       */
+      const history = buildComponentHistory(
+        components.components ?? [],
+        componentRef,
+        userName,
+      );
+
+      return history;
+    },
+  });
+};
+
+function buildComponentHistory(
+  componentVersions: ComponentReference[],
+  component: HydratedComponentReference,
+  userName: string,
+) {
+  const relatedComponents = componentVersions
+    .filter((c) => c.name === component.name && c.published_by === userName)
+    .filter((c) => isDiscoverableComponentReference(c));
+
+  const index = new Map<string, ComponentReferenceWithDigest>(
+    relatedComponents
+      .filter((c) => hasSupersededBy(c))
+      .map((c) => [c.superseded_by, c]),
+  );
+
+  /**
+   * [
+   *  {a, supersededBy: b}
+   *  {b, supersededBy: c}
+   *  {c, supersededBy: d}
+   * ] => [d, c, b, a]
+   */
+  const lastList = relatedComponents.filter((c) => !c.superseded_by);
+
+  if (lastList.length !== 1) {
+    return [];
+  }
+
+  const timeline: ComponentReferenceWithDigest[] = [];
+
+  let current: ComponentReferenceWithDigest | undefined = lastList[0];
+  while (current) {
+    timeline.unshift(current);
+    const predecessor = index.get(current.digest);
+    current = predecessor;
+  }
+
+  return timeline;
+}

--- a/src/components/shared/ManageComponent/hooks/useUserDetails.ts
+++ b/src/components/shared/ManageComponent/hooks/useUserDetails.ts
@@ -1,0 +1,11 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+import { getUserDetails } from "../utils/user";
+
+export function useUserDetails() {
+  return useSuspenseQuery({
+    queryKey: ["user"],
+    staleTime: 1000 * 60 * 60 * 0.5, // 30 minutes
+    queryFn: () => getUserDetails(),
+  });
+}

--- a/src/components/shared/ManageComponent/types.ts
+++ b/src/components/shared/ManageComponent/types.ts
@@ -1,0 +1,10 @@
+import type { ComponentReference } from "@/utils/componentSpec";
+
+/**
+ * Type guard to check if a component has a superseded_by field
+ */
+export function hasSupersededBy(
+  c: ComponentReference,
+): c is ComponentReference & { superseded_by: string } {
+  return Boolean(c.superseded_by);
+}

--- a/src/components/shared/ManageComponent/utils/digest.ts
+++ b/src/components/shared/ManageComponent/utils/digest.ts
@@ -1,0 +1,9 @@
+/**
+ * Trim a digest to 8 first characters.
+ *
+ * @param digest - The digest to trim.
+ * @returns The trimmed digest.
+ */
+export function trimDigest(digest: string) {
+  return digest.slice(0, 8);
+}

--- a/src/components/shared/ManageComponent/utils/user.ts
+++ b/src/components/shared/ManageComponent/utils/user.ts
@@ -1,0 +1,100 @@
+import { testGetUserDetailsApiTestGetUserDetailsGet } from "@/api/sdk.gen";
+
+interface UserDetails {
+  name: string;
+  permissions: {
+    read?: boolean;
+    write?: boolean;
+    admin?: boolean;
+    [key: string]: boolean | undefined;
+  };
+}
+
+function parseUserDetails(userDetailsStr: string): UserDetails | null {
+  if (!userDetailsStr || typeof userDetailsStr !== "string") {
+    return null;
+  }
+
+  try {
+    // Check if the string starts with "UserDetails("
+    if (!userDetailsStr.startsWith("UserDetails(")) {
+      return null;
+    }
+
+    // Extract the content between the outer parentheses
+    const match = userDetailsStr.match(/^UserDetails\((.*)\)$/);
+    if (!match) {
+      return null;
+    }
+
+    const content = match[1];
+
+    // Parse name field
+    const nameMatch = content.match(/name='([^']*)'|name="([^"]*)"/);
+    if (!nameMatch) {
+      return null;
+    }
+    const name = nameMatch[1] || nameMatch[2];
+
+    // Parse permissions field
+    const permissionsMatch = content.match(/permissions=\{([^}]*)\}/);
+    if (!permissionsMatch) {
+      // If no permissions found, return with empty permissions
+      return { name, permissions: {} };
+    }
+
+    const permissionsStr = permissionsMatch[1];
+    const permissions: UserDetails["permissions"] = {};
+
+    // Parse each permission key-value pair
+    const permissionPairs = permissionsStr
+      .split(",")
+      .map((pair) => pair.trim());
+
+    for (const pair of permissionPairs) {
+      if (!pair) continue;
+
+      // Match both single and double quotes for keys
+      const pairMatch = pair.match(
+        /['"]?(\w+)['"]?\s*:\s*(True|False|true|false)/i,
+      );
+      if (pairMatch) {
+        const key = pairMatch[1];
+        const value = pairMatch[2].toLowerCase() === "true";
+        permissions[key] = value;
+      }
+    }
+
+    return {
+      name,
+      permissions,
+    };
+  } catch (error) {
+    console.error("Failed to parse UserDetails string:", error);
+    return null;
+  }
+}
+
+/**
+ * Get the user details from the server.
+ *
+ * This API is available only on a proprietary version
+ * todo: figure out how to get the user details on a public version
+ *
+ * @returns The user details.
+ */
+export async function getUserDetails() {
+  const user = await testGetUserDetailsApiTestGetUserDetailsGet();
+
+  if (user?.response.status !== 200) {
+    return { name: "Unknown", permissions: {} };
+  }
+
+  const userDetails = parseUserDetails(user?.data as string);
+
+  if (!userDetails) {
+    return { name: "Unknown", permissions: {} };
+  }
+
+  return userDetails;
+}

--- a/src/components/shared/ReactFlow/FlowSidebar/components/FolderItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/FolderItem.tsx
@@ -62,7 +62,7 @@ const FolderItem = ({ folder, icon }: FolderItemProps) => {
                 if (isValidElement(component)) {
                   return component;
                 }
-                const key = `${folder.name}-component-${component.name || component?.spec?.name || component.url || idx}`;
+                const key = `${folder.name}-component-${component.digest ?? component?.spec?.name ?? component.url ?? idx}`;
                 // If the component has a spec render the component, otherwise, render using URL
                 if (component.spec) {
                   return <ComponentMarkup key={key} component={component} />;

--- a/src/components/shared/ReactFlow/FlowSidebar/components/PublishedComponentsSearch.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/PublishedComponentsSearch.tsx
@@ -258,7 +258,7 @@ const SearchResults = ({ searchResult }: SearchResultsProps) => {
                 ) : null}
                 {folder.components.map((component) => (
                   <ComponentMarkup
-                    key={component.digest}
+                    key={`${folder.name}-${component.digest}-${component.name}`}
                     component={component}
                   />
                 ))}

--- a/src/utils/componentSpec.ts
+++ b/src/utils/componentSpec.ts
@@ -181,6 +181,7 @@ export interface ComponentReference extends ComponentReferenceBase {
   favorited?: boolean;
   published_by?: string;
   deprecated?: boolean;
+  superseded_by?: string;
   owned?: boolean;
 }
 

--- a/tests/e2e/fixtures/components/test-component-a.component.v1.yaml
+++ b/tests/e2e/fixtures/components/test-component-a.component.v1.yaml
@@ -1,0 +1,217 @@
+name: Test component {NAME_PLACEHOLDER}
+metadata:
+  annotations:
+    cloud_pipelines.net: "true"
+    components new regenerate python-function-component: "true"
+    python_original_code_path: src/test-component-a.py
+    python_original_code: |
+      #!/usr/bin/env python3
+      def test_component_a(input_string: str, mode: str = "standard") -> str:
+          import logging
+          import os
+          import sys
+
+          """Test component A. Version {VERSION_PLACEHOLDER}.
+
+          Args:
+              input_string: The string to process
+              mode: Processing mode - either "debug" or "standard" (default: "standard")
+
+          Returns:
+              A transformed version of the input string based on the mode
+          """
+          # Validate mode
+          if mode not in ["debug", "standard"]:
+              raise ValueError(f"Invalid mode: '{mode}'. Must be 'debug' or 'standard'")
+
+          # Set up logging
+          logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s", stream=sys.stdout)
+          logger = logging.getLogger(__name__)
+
+          # Log the input
+          logger.info(f"Processing input: '{input_string}' in {mode} mode")
+
+          # Log some environment variables (only in debug mode)
+          if mode == "debug":
+              logger.info("=== Environment Variables ===")
+              env_vars = ["USER", "HOME", "SHELL", "PWD", "LANG", "PATH"]
+              for var in env_vars:
+                  value = os.environ.get(var)
+                  if value:
+                      if var == "PATH":
+                          # PATH can be very long, just show count
+                          logger.info(f"{var}: {len(value.split(':'))} paths")
+                      else:
+                          logger.info(f"{var}: {value}")
+              logger.info(f"Total environment variables: {len(os.environ)}")
+
+          # Transform the string
+          stripped = input_string.strip()
+          reversed_str = stripped[::-1]
+          uppercase = stripped.upper()
+          word_count = len(stripped.split())
+          char_count = len(stripped)
+
+          # Create result based on mode
+          if mode == "debug":
+              # Debug mode: return detailed information
+              result = (
+                  f"[DEBUG] Original: '{stripped}' | "
+                  f"Reversed: '{reversed_str}' | "
+                  f"Uppercase: '{uppercase}' | "
+                  f"Words: {word_count}, Chars: {char_count} | "
+                  f"Env vars: {len(os.environ)}"
+              )
+          elif mode == "standard":
+              # Standard mode: return simplified information
+              result = f"Processed: '{uppercase}' ({word_count} words)"
+          else:
+              raise ValueError(f"Invalid mode: '{mode}'. Must be 'debug' or 'standard'")
+
+          logger.info("Processing complete")
+
+          return result
+    component_yaml_path: src/test-component-a.component.yaml
+    python_dependencies: '["google-cloud-bigquery==3.26.0", "google-cloud-bigquery-storage==2.29.1",
+      "pyarrow==19.0.1", "pandas==2.2.1", "lightgbm==4.3.0", "numpy>=1.26.0", "setuptools==69.2.0",
+      "scikit-learn==1.5.0", "comet-ml==3.49.10", "google-cloud-secret-manager==2.18.0",
+      "urllib3<2.0.0", "db-dtypes>=1.3.1", "sympy>=1.12"]'
+    git_relative_dir: .
+    git_local_branch: main
+    git_local_sha: e21f92f7e1f55102c97ea965272153f6f580e299
+    git_remote_url: https://github.com/Shopify/shop-promise-modeling.git
+    git_remote_branch: main
+    git_remote_sha: c9d9d4f4cc2ecd5b025e9b06e050d1ed85cc5fc7
+inputs:
+- {name: input_string, type: String}
+- {name: mode, type: String, default: standard, optional: true}
+outputs:
+- {name: Output, type: String}
+implementation:
+  container:
+    image: us-docker.pkg.dev/shopify-docker-images/containers/apps/production/shop-promise-modeling:main
+    command:
+    - sh
+    - -c
+    - (PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet --no-warn-script-location
+      'google-cloud-bigquery==3.26.0' 'google-cloud-bigquery-storage==2.29.1' 'pyarrow==19.0.1'
+      'pandas==2.2.1' 'lightgbm==4.3.0' 'numpy>=1.26.0' 'setuptools==69.2.0' 'scikit-learn==1.5.0'
+      'comet-ml==3.49.10' 'google-cloud-secret-manager==2.18.0' 'urllib3<2.0.0' 'db-dtypes>=1.3.1'
+      'sympy>=1.12' || PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet
+      --no-warn-script-location 'google-cloud-bigquery==3.26.0' 'google-cloud-bigquery-storage==2.29.1'
+      'pyarrow==19.0.1' 'pandas==2.2.1' 'lightgbm==4.3.0' 'numpy>=1.26.0' 'setuptools==69.2.0'
+      'scikit-learn==1.5.0' 'comet-ml==3.49.10' 'google-cloud-secret-manager==2.18.0'
+      'urllib3<2.0.0' 'db-dtypes>=1.3.1' 'sympy>=1.12' --user) && "$0" "$@"
+    - sh
+    - -ec
+    - |
+      program_path=$(mktemp)
+      printf "%s" "$0" > "$program_path"
+      python3 -u "$program_path" "$@"
+    - |
+      def test_component_a(input_string, mode = "standard"):
+          import logging
+          import os
+          import sys
+
+          """Test component A. Version 1.
+
+          Args:
+              input_string: The string to process
+              mode: Processing mode - either "debug" or "standard" (default: "standard")
+
+          Returns:
+              A transformed version of the input string based on the mode
+          """
+          # Validate mode
+          if mode not in ["debug", "standard"]:
+              raise ValueError(f"Invalid mode: '{mode}'. Must be 'debug' or 'standard'")
+
+          # Set up logging
+          logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s", stream=sys.stdout)
+          logger = logging.getLogger(__name__)
+
+          # Log the input
+          logger.info(f"Processing input: '{input_string}' in {mode} mode")
+
+          # Log some environment variables (only in debug mode)
+          if mode == "debug":
+              logger.info("=== Environment Variables ===")
+              env_vars = ["USER", "HOME", "SHELL", "PWD", "LANG", "PATH"]
+              for var in env_vars:
+                  value = os.environ.get(var)
+                  if value:
+                      if var == "PATH":
+                          # PATH can be very long, just show count
+                          logger.info(f"{var}: {len(value.split(':'))} paths")
+                      else:
+                          logger.info(f"{var}: {value}")
+              logger.info(f"Total environment variables: {len(os.environ)}")
+
+          # Transform the string
+          stripped = input_string.strip()
+          reversed_str = stripped[::-1]
+          uppercase = stripped.upper()
+          word_count = len(stripped.split())
+          char_count = len(stripped)
+
+          # Create result based on mode
+          if mode == "debug":
+              # Debug mode: return detailed information
+              result = (
+                  f"[DEBUG] Original: '{stripped}' | "
+                  f"Reversed: '{reversed_str}' | "
+                  f"Uppercase: '{uppercase}' | "
+                  f"Words: {word_count}, Chars: {char_count} | "
+                  f"Env vars: {len(os.environ)}"
+              )
+          elif mode == "standard":
+              # Standard mode: return simplified information
+              result = f"Processed: '{uppercase}' ({word_count} words)"
+          else:
+              raise ValueError(f"Invalid mode: '{mode}'. Must be 'debug' or 'standard'")
+
+          logger.info("Processing complete")
+
+          return result
+
+      def _serialize_str(str_value: str) -> str:
+          if not isinstance(str_value, str):
+              raise TypeError('Value "{}" has type "{}" instead of str.'.format(str(str_value), str(type(str_value))))
+          return str_value
+
+      import argparse
+      _parser = argparse.ArgumentParser(prog='Test component a', description='')
+      _parser.add_argument("--input-string", dest="input_string", type=str, required=True, default=argparse.SUPPRESS)
+      _parser.add_argument("--mode", dest="mode", type=str, required=False, default=argparse.SUPPRESS)
+      _parser.add_argument("----output-paths", dest="_output_paths", type=str, nargs=1)
+      _parsed_args = vars(_parser.parse_args())
+      _output_files = _parsed_args.pop("_output_paths", [])
+
+      _outputs = test_component_a(**_parsed_args)
+
+      _outputs = [_outputs]
+
+      _output_serializers = [
+          _serialize_str,
+
+      ]
+
+      import os
+      for idx, output_file in enumerate(_output_files):
+          try:
+              os.makedirs(os.path.dirname(output_file))
+          except OSError:
+              pass
+          with open(output_file, "w") as f:
+              f.write(_output_serializers[idx](_outputs[idx]))
+    args:
+    - --input-string
+    - {inputValue: input_string}
+    - if:
+        cond: {isPresent: mode}
+        then:
+        - --mode
+        - {inputValue: mode}
+    - '----output-paths'
+    - {outputPath: Output}

--- a/tests/e2e/published-componentlifecycle.spec.ts
+++ b/tests/e2e/published-componentlifecycle.spec.ts
@@ -1,0 +1,125 @@
+import { expect, type Page, test } from "@playwright/test";
+import { readFileSync } from "fs";
+
+import {
+  createNewPipeline,
+  locateComponentInFolder,
+  locateFolderByName,
+  openComponentLibFolder,
+} from "./helpers";
+
+/**
+ * Due to the time it takes to load the library, the tests are run in serial
+ *  and one page is used for all the tests.
+ *
+ * So every test must clean up after itself
+ */
+test.describe.configure({ mode: "serial" });
+
+test.describe("Published Component Library - Lifecycle", () => {
+  let page: Page;
+
+  const componentName = Math.random().toString(36).substring(2, 15);
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    // Create new pipeline and wait for it to load
+    await createNewPipeline(page);
+
+    // open personal preferences
+    await page.getByTestId("personal-preferences-button").click();
+
+    // close personal preferences
+    const dialog = await page.getByTestId("personal-preferences-dialog");
+    await dialog.getByTestId("remote-component-library-search-switch").click();
+    await dialog.getByTestId("close-button").click();
+
+    await locateFolderByName(page, "Standard library");
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test("drop new component to canvas and publish it", async () => {
+    // Read your file into a buffer.
+    const buffer = readFileSync(
+      "tests/e2e/fixtures/components/test-component-a.component.v1.yaml",
+    );
+
+    /**
+     * This test requires component to be generated dynamically, so no backend mock is needed
+     */
+    const modifiedComponentText = buffer
+      .toString()
+      .replace(
+        "{VERSION_PLACEHOLDER}",
+        Math.random().toString(36).substring(2, 15),
+      )
+      .replace("{NAME_PLACEHOLDER}", componentName);
+
+    const base64ModifiedComponentText = Buffer.from(
+      modifiedComponentText,
+    ).toString("base64");
+
+    // Create the DataTransfer and File
+    const dataTransfer = await page.evaluateHandle(
+      async ({ bufferData, localFileName, localFileType }) => {
+        const dt = new DataTransfer();
+
+        const blobData = await fetch(bufferData).then((res) => res.blob());
+
+        const file = new File([blobData], localFileName, {
+          type: localFileType,
+        });
+        dt.items.add(file);
+        return dt;
+      },
+      {
+        bufferData: `data:application/octet-stream;base64,${base64ModifiedComponentText}`,
+        localFileName: "test-component-a.component.v1.yaml",
+        localFileType: "application/yaml",
+      },
+    );
+    // Now dispatch
+    await page.dispatchEvent(`[data-testid="rf__wrapper"]`, "drop", {
+      dataTransfer,
+    });
+
+    const userComponentsFolder = await openComponentLibFolder(
+      page,
+      "User Components",
+    );
+    const component = await locateComponentInFolder(
+      userComponentsFolder,
+      `Test component ${componentName}`,
+    );
+    expect(component).toBeVisible();
+
+    const infoButton = await component.getByTestId("info-icon-button");
+    await infoButton.click();
+
+    await page.waitForSelector(`[data-testid="component-details-tabs"]`);
+    const dialog = await page.getByRole("dialog");
+
+    const dialogHeader = await dialog.locator('[data-slot="dialog-header"]');
+
+    expect(dialogHeader).toHaveText(`Test component ${componentName}`);
+
+    const publishButton = await page
+      .locator(`[role="tablist"]`)
+      .getByText("Publish");
+    await publishButton.click();
+
+    await dialog.getByTestId("component-review-container");
+
+    await page.waitForSelector(`[data-testid="publish-component-button"]`);
+
+    const publishComponentButton = await dialog.getByTestId(
+      "publish-component-button",
+    );
+    expect(publishComponentButton).toBeVisible();
+
+    await dialog.locator('[data-slot="dialog-close"]').click();
+  });
+});


### PR DESCRIPTION
## Description

Added a new "Publish" tab to the Component Details Dialog that allows users to publish components to a shared library. This feature enables component sharing across the workspace, making components discoverable and reusable by other users.

The implementation includes:

- A new PublishComponent component with component history timeline
- Component quality checks to ensure published components are well-documented
- Ability to release new versions of components and deprecate existing ones
- User details utility for tracking component authorship

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

https://github.com/user-attachments/assets/31dd1221-4df4-49f2-af25-756b36480105

1. Open a component in the Component Details Dialog
2. Navigate to the new "Publish" tab
3. Review component details and publish history
4. Test publishing a component, releasing a new version, or deprecating an existing one

I used this sequence of components: 

[test-component-a.component.v1.yaml](https://github.com/user-attachments/files/22126004/test-component-a.component.v1.yaml)
[test-component-a.component.v2.yaml](https://github.com/user-attachments/files/22126005/test-component-a.component.v2.yaml)
[test-component-a.component.v3.yaml](https://github.com/user-attachments/files/22126006/test-component-a.component.v3.yaml)


## Additional Comments

This feature is behind the "remote-component-library-search" beta flag. The tab will only appear for components that are owned by the current user.

Feature partially covered with unit and e2e tests.