### PR TITLE
Fix IO Node Positioning Bug

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/utils/updateNodePosition.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/updateNodePosition.ts
@@ -1,10 +1,15 @@
 import type { Node } from "@xyflow/react";
 
-import type { ComponentSpec } from "@/utils/componentSpec";
-
-const nodeIdToTaskId = (id: string) => id.replace(/^task_/, "");
-const nodeIdToInputName = (id: string) => id.replace(/^input_/, "");
-const nodeIdToOutputName = (id: string) => id.replace(/^output_/, "");
+import {
+  type ComponentSpec,
+  isGraphImplementation,
+} from "@/utils/componentSpec";
+import {
+  nodeIdToInputName,
+  nodeIdToOutputName,
+  nodeIdToTaskId,
+} from "@/utils/nodes/nodeIdUtils";
+import { setPositionInAnnotations } from "@/utils/nodes/setPositionInAnnotations";
 
 export const updateNodePositions = (
   updatedNodes: Node[],
@@ -12,9 +17,13 @@ export const updateNodePositions = (
 ) => {
   const newComponentSpec = { ...componentSpec };
 
-  if (!("graph" in componentSpec.implementation)) {
+  if (!isGraphImplementation(newComponentSpec.implementation)) {
     throw new Error("Component spec is not a graph");
   }
+
+  const updatedGraphSpec = {
+    ...newComponentSpec.implementation.graph,
+  };
 
   for (const node of updatedNodes) {
     const newPosition = {
@@ -22,94 +31,67 @@ export const updateNodePositions = (
       y: node.position.y,
     };
 
-    if (!("graph" in newComponentSpec.implementation)) {
-      throw new Error("Implementation does not contain a graph");
-    }
-
-    const graphSpec = newComponentSpec.implementation.graph;
-
     if (node.type === "task") {
       const taskId = nodeIdToTaskId(node.id);
-      if (graphSpec.tasks[taskId]) {
-        const taskSpec = { ...graphSpec.tasks[taskId] };
+      if (updatedGraphSpec.tasks[taskId]) {
+        const taskSpec = { ...updatedGraphSpec.tasks[taskId] };
 
-        const currentPosition = JSON.parse(
-          (taskSpec.annotations?.["editor.position"] as string) || "{}",
+        const annotations = taskSpec.annotations || {};
+
+        const updatedAnnotations = setPositionInAnnotations(
+          annotations,
+          newPosition,
         );
-        const updatedPosition = {
-          ...currentPosition,
-          ...newPosition,
+
+        const newTaskSpec = {
+          ...taskSpec,
+          annotations: updatedAnnotations,
         };
 
-        const updatedPositionAnnotation = JSON.stringify(updatedPosition);
+        updatedGraphSpec.tasks[taskId] = newTaskSpec;
 
-        taskSpec.annotations = {
-          ...taskSpec.annotations,
-          "editor.position": updatedPositionAnnotation,
-        };
-
-        const newGraphSpec = {
-          ...graphSpec,
-          tasks: {
-            ...graphSpec.tasks,
-            [taskId]: taskSpec,
-          },
-        };
-
-        newComponentSpec.implementation.graph = newGraphSpec;
+        newComponentSpec.implementation.graph = updatedGraphSpec;
       }
     } else if (node.type === "input") {
       const inputName = nodeIdToInputName(node.id);
-      const inputs = [...(componentSpec.inputs || [])];
+      const inputs = [...(newComponentSpec.inputs || [])];
       const inputIndex = inputs.findIndex((input) => input.name === inputName);
 
       if (inputIndex >= 0) {
-        const currentPosition = JSON.parse(
-          (inputs[inputIndex].annotations?.["editor.position"] as string) ||
-            "{}",
-        );
-        const updatedPosition = {
-          ...currentPosition,
-          ...newPosition,
-        };
+        const annotations = inputs[inputIndex].annotations || {};
 
-        const updatedPositionAnnotation = JSON.stringify(updatedPosition);
+        const updatedAnnotations = setPositionInAnnotations(
+          annotations,
+          newPosition,
+        );
 
         inputs[inputIndex] = {
           ...inputs[inputIndex],
-          annotations: {
-            ...inputs[inputIndex].annotations,
-            "editor.position": updatedPositionAnnotation,
-          },
+          annotations: updatedAnnotations,
         };
+
         newComponentSpec.inputs = inputs;
       }
     } else if (node.type === "output") {
       const outputName = nodeIdToOutputName(node.id);
-      const outputs = [...(componentSpec.outputs || [])];
+      const outputs = [...(newComponentSpec.outputs || [])];
       const outputIndex = outputs.findIndex(
         (output) => output.name === outputName,
       );
 
       if (outputIndex >= 0) {
-        const currentPosition = JSON.parse(
-          (outputs[outputIndex].annotations?.["editor.position"] as string) ||
-            "{}",
-        );
-        const updatedPosition = {
-          ...currentPosition,
-          ...newPosition,
-        };
+        const annotations = outputs[outputIndex].annotations || {};
 
-        const updatedPositionAnnotation = JSON.stringify(updatedPosition);
+        const updatedAnnotations = setPositionInAnnotations(
+          annotations,
+          newPosition,
+        );
 
         outputs[outputIndex] = {
           ...outputs[outputIndex],
-          annotations: {
-            ...outputs[outputIndex].annotations,
-            "editor.position": updatedPositionAnnotation,
-          },
+          annotations: updatedAnnotations,
         };
+
         newComponentSpec.outputs = outputs;
       }
     }


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Fix a bug where only the last IO node in a group of nodes will have its position updated.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Progresses Shopify/oasis-frontend#148

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
1. Create a group of IO nodes on the canvas
2. Select the group using multi-select
3. Move the group to a new location on the canvas
4. Nodes will move to new location (compare: on current master/production all but one will return to their original position)

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
