### PR TITLE
Fix long argument strings overflow replace dialog

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/ConfirmationDialogs/ReplaceConfirmation.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/ConfirmationDialogs/ReplaceConfirmation.tsx
@@ -45,10 +45,14 @@ export function getReplaceConfirmationDetails(
                 Linked node will be disconnected
               </TooltipContent>
             </Tooltip>
-            <span className="font-bold">{input.name}</span>
-            <span className="font-light ml-1">{`(${input.type})`}</span>
-            <span>:</span>
-            <span className="ml-1">{argument.value}</span>
+            <div className="flex items-baseline flex-wrap">
+              <span className="font-bold break-words">{input.name}</span>
+              <span className="font-light break-words ml-1">{`(${input.type})`}</span>
+              <span className="flex-shrink-0">:</span>
+              <div className="break-all text-wrap overflow-hidden ml-1">
+                {argument.value}
+              </div>
+            </div>
           </div>
         );
       })}


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Fixes and issue where text would overflow off the dialog when argument values are very long.

Solution is not _amazing_ but it will do for now as a quick fix.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Closes https://github.com/Shopify/oasis-frontend/issues/208

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

Before:
<img width="1272" height="545" alt="image" src="https://github.com/user-attachments/assets/d4067b26-09f7-41e2-9044-aabeb803b3af" />


After:
<img width="563" height="466" alt="image" src="https://github.com/user-attachments/assets/eecf3ba9-3b78-4044-ba60-af62aad3c30b" />


## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
