### PR TITLE
upgrade path for published components

### DIFF
--- a/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
+++ b/src/components/shared/Dialogs/ComponentDetailsDialog.tsx
@@ -1,5 +1,5 @@
 import { Code, InfoIcon, ListFilter } from "lucide-react";
-import { type ReactNode } from "react";
+import { type ReactNode, useMemo, useState } from "react";
 
 import {
   Dialog,
@@ -19,9 +19,11 @@ import type { ComponentReference } from "@/utils/componentSpec";
 import InfoIconButton from "../Buttons/InfoIconButton";
 import { InfoBox } from "../InfoBox";
 import { PublishComponent } from "../ManageComponent/PublishComponent";
+import { PublishedComponentDetails } from "../ManageComponent/PublishedComponentDetails";
 import { useBetaFlagValue } from "../Settings/useBetaFlags";
 import { withSuspenseWrapper } from "../SuspenseWrapper";
 import { TaskDetails, TaskImplementation, TaskIO } from "../TaskDetails";
+import { DialogContext } from "./dialog.context";
 
 interface ComponentDetailsProps {
   component: ComponentReference;
@@ -32,7 +34,7 @@ interface ComponentDetailsProps {
   onDelete?: () => void;
 }
 
-const ComponentDetailsSkeleton = () => {
+const ComponentDetailsDialogContentSkeleton = () => {
   return (
     <BlockStack className="h-full" gap="3">
       <BlockStack>
@@ -58,7 +60,7 @@ const ComponentDetailsSkeleton = () => {
   );
 };
 
-const ComponentDetailsDialog = withSuspenseWrapper(
+const ComponentDetailsDialogContent = withSuspenseWrapper(
   ({
     component,
     displayName,
@@ -124,6 +126,10 @@ const ComponentDetailsDialog = withSuspenseWrapper(
 
             <div className="overflow-hidden h-[40vh]">
               <TabsContent value="details" className="h-full">
+                {remoteComponentLibrarySearchEnabled ? (
+                  <PublishedComponentDetails component={componentRef} />
+                ) : null}
+
                 <TaskDetails
                   displayName={displayName}
                   componentSpec={componentSpec}
@@ -159,7 +165,7 @@ const ComponentDetailsDialog = withSuspenseWrapper(
       </>
     );
   },
-  ComponentDetailsSkeleton,
+  ComponentDetailsDialogContentSkeleton,
 );
 
 const ComponentDetails = ({
@@ -170,16 +176,28 @@ const ComponentDetails = ({
   onClose,
   onDelete,
 }: ComponentDetailsProps) => {
+  const [open, setOpen] = useState(false);
   const dialogTriggerButton = trigger || <InfoIconButton />;
 
   const onOpenChange = (open: boolean) => {
+    setOpen(open);
     if (!open) {
       onClose?.();
     }
   };
 
+  const dialogContextValue = useMemo(
+    () => ({
+      name: "ComponentDetails",
+      close: () => {
+        setOpen(false);
+      },
+    }),
+    [],
+  );
+
   return (
-    <Dialog modal onOpenChange={onOpenChange}>
+    <Dialog modal open={open} onOpenChange={onOpenChange}>
       <DialogTrigger asChild>{dialogTriggerButton}</DialogTrigger>
 
       <DialogDescription
@@ -198,14 +216,16 @@ const ComponentDetails = ({
           </DialogTitle>
         </DialogHeader>
 
-        <ComponentDetailsDialog
-          component={component}
-          displayName={displayName}
-          trigger={dialogTriggerButton}
-          actions={actions}
-          onClose={onClose}
-          onDelete={onDelete}
-        />
+        <DialogContext.Provider value={dialogContextValue}>
+          <ComponentDetailsDialogContent
+            component={component}
+            displayName={displayName}
+            trigger={dialogTriggerButton}
+            actions={actions}
+            onClose={onClose}
+            onDelete={onDelete}
+          />
+        </DialogContext.Provider>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/shared/Dialogs/dialog.context.tsx
+++ b/src/components/shared/Dialogs/dialog.context.tsx
@@ -1,0 +1,14 @@
+import { createContext, useContext } from "react";
+
+interface DialogContextType {
+  name: string;
+  close: () => void;
+}
+
+export const DialogContext = createContext<DialogContextType | undefined>(
+  undefined,
+);
+
+export const useDialogContext = () => {
+  return useContext(DialogContext);
+};

--- a/src/components/shared/ManageComponent/ComponentHistoryTimeline.tsx
+++ b/src/components/shared/ManageComponent/ComponentHistoryTimeline.tsx
@@ -1,5 +1,6 @@
-import type { ComponentProps, PropsWithChildren } from "react";
+import { type ComponentProps, type PropsWithChildren } from "react";
 
+import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -15,6 +16,7 @@ import { withSuspenseWrapper } from "../SuspenseWrapper";
 import { ComponentQuickDetailsDialogTrigger } from "./ComponentQuickDetailsDialog";
 import { ComponentUsageCount } from "./ComponentUsageCount";
 import { DeprecatePublishedComponentButton } from "./DeprecatePublishedComponentButton";
+import { useForceUpdateTasks } from "./hooks/useForceUpdateTasks";
 import { PublishComponentButton } from "./PublishComponentButton";
 import { TrimmedDigest } from "./TrimmedDigest";
 
@@ -72,6 +74,8 @@ export const ComponentHistoryTimeline = withSuspenseWrapper(
     currentUserName?: string;
     onChange?: () => void;
   }) => {
+    const onForceUpdate = useForceUpdateTasks(currentComponent);
+
     const lastComponentInHistory =
       history.length === 0 ? undefined : history[history.length - 1];
     const lastHydratedComponent = useHydrateComponentReference(
@@ -128,10 +132,20 @@ export const ComponentHistoryTimeline = withSuspenseWrapper(
                       </Text>
                     ) : null}
                   </InlineStack>
+
                   <ComponentUsageCount digest={item.digest}>
                     {(count) => (
                       <Text size="xs" tone="subdued">
                         Used {count} times in this Pipeline.
+                        {isMostRecent ? null : (
+                          <Button
+                            variant="secondary"
+                            size="xs"
+                            onClick={() => onForceUpdate(item.digest)}
+                          >
+                            Review tasks
+                          </Button>
+                        )}
                       </Text>
                     )}
                   </ComponentUsageCount>

--- a/src/components/shared/ManageComponent/PublishedComponentBadge.tsx
+++ b/src/components/shared/ManageComponent/PublishedComponentBadge.tsx
@@ -1,0 +1,61 @@
+import type { PropsWithChildren } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { InlineStack } from "@/components/ui/layout";
+import { cn } from "@/lib/utils";
+import type { ComponentReference } from "@/utils/componentSpec";
+
+import { ComponentDetailsDialog } from "../Dialogs";
+import { withSuspenseWrapper } from "../SuspenseWrapper";
+import { useHasPublishedComponent } from "./hooks/useHasPublishedComponent";
+import { useOutdatedComponents } from "./hooks/useOutdatedComponents";
+
+function PublishedComponentBadgeSkeleton() {
+  /**
+   * Display nothing when loading
+   */
+  return null;
+}
+
+export const PublishedComponentBadge = withSuspenseWrapper(
+  ({
+    children,
+    componentRef,
+  }: PropsWithChildren<{ componentRef: ComponentReference }>) => {
+    const { data: outdatedComponents } = useOutdatedComponents([componentRef]);
+    const { data: isPublished } = useHasPublishedComponent(componentRef);
+
+    const isOutdated = outdatedComponents.length > 0;
+
+    return (
+      <InlineStack className="relative min-w-20" blockAlign="start">
+        <ComponentDetailsDialog
+          displayName={componentRef.name ?? "Details"}
+          component={componentRef}
+          trigger={
+            <Button
+              variant="ghost"
+              size="inline-xs"
+              className={cn(
+                "p-0.5",
+                isOutdated
+                  ? "text-orange-500 hover:text-orange-700"
+                  : "text-muted-foreground hover:text-gray-800",
+              )}
+            >
+              <InlineStack gap="1">
+                <Icon
+                  name={isOutdated ? "BookAlert" : "BookCheck"}
+                  className={cn(!isPublished && "invisible")}
+                />
+                {children}
+              </InlineStack>
+            </Button>
+          }
+        />
+      </InlineStack>
+    );
+  },
+  PublishedComponentBadgeSkeleton,
+);

--- a/src/components/shared/ManageComponent/PublishedComponentDetails.tsx
+++ b/src/components/shared/ManageComponent/PublishedComponentDetails.tsx
@@ -1,0 +1,95 @@
+import { useCallback, useMemo } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import { Spinner } from "@/components/ui/spinner";
+import { Heading, Paragraph, Text } from "@/components/ui/typography";
+import type { HydratedComponentReference } from "@/utils/componentSpec";
+
+import { withSuspenseWrapper } from "../SuspenseWrapper";
+import { ComponentUsageCount } from "./ComponentUsageCount";
+import { useForceUpdateTasks } from "./hooks/useForceUpdateTasks";
+import { useHasPublishedComponent } from "./hooks/useHasPublishedComponent";
+import { useOutdatedComponents } from "./hooks/useOutdatedComponents";
+import { TrimmedDigest } from "./TrimmedDigest";
+
+const PublishedComponentDetailsSkeleton = () => {
+  return (
+    <InlineStack gap="1" blockAlign="center" align="center">
+      <Spinner size={10} />
+      <Text size="xs" tone="subdued">
+        Looking for updates...
+      </Text>
+    </InlineStack>
+  );
+};
+
+export const PublishedComponentDetails = withSuspenseWrapper(
+  ({ component }: { component: HydratedComponentReference }) => {
+    const { data: isPublished } = useHasPublishedComponent(component);
+    const { data: outdatedComponents } = useOutdatedComponents([component]);
+
+    const outdatedComponentIndex = useMemo(
+      () => new Map(outdatedComponents.map(([c, m]) => [c.digest, m])),
+      [outdatedComponents],
+    );
+
+    const onForceUpdate = useForceUpdateTasks(
+      outdatedComponentIndex.get(component.digest) ?? null,
+    );
+
+    const onUpdateTasks = useCallback(() => {
+      onForceUpdate(component.digest);
+    }, [onForceUpdate, component.digest]);
+
+    if (!isPublished) {
+      return null;
+    }
+
+    const isOutdated = outdatedComponentIndex.has(component.digest);
+
+    return (
+      <BlockStack className="w-full py-2 my-2 border rounded-md">
+        <InlineStack
+          blockAlign="start"
+          align="space-between"
+          className="w-full"
+          gap="1"
+        >
+          <BlockStack
+            className="w-[10%] p-2"
+            inlineAlign="center"
+            align="center"
+          >
+            <Icon name="BookCheck" size="fill" />
+          </BlockStack>
+          <BlockStack className="w-[85%]">
+            <Heading level={2}>This is a published component</Heading>
+            <InlineStack gap="1" align="center">
+              <TrimmedDigest digest={component.digest} tone="info" />
+              <ComponentUsageCount digest={component.digest}>
+                {(count) => (
+                  <Text size="xs" tone="subdued">
+                    | Used {count} times in this Pipeline.
+                  </Text>
+                )}
+              </ComponentUsageCount>
+            </InlineStack>
+            {isOutdated ? (
+              <InlineStack gap="1" blockAlign="center" align="center">
+                <Paragraph size="xs" tone="critical">
+                  There is a newer version of this component available.
+                </Paragraph>
+                <Button variant="secondary" size="xs" onClick={onUpdateTasks}>
+                  Review tasks
+                </Button>
+              </InlineStack>
+            ) : null}
+          </BlockStack>
+        </InlineStack>
+      </BlockStack>
+    );
+  },
+  PublishedComponentDetailsSkeleton,
+);

--- a/src/components/shared/ManageComponent/hooks/useAllPublishedComponents.ts
+++ b/src/components/shared/ManageComponent/hooks/useAllPublishedComponents.ts
@@ -1,0 +1,26 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
+
+export function useAllPublishedComponents() {
+  const { getComponentLibrary } = useComponentLibrary();
+  const publishedComponentsLibrary = getComponentLibrary(
+    "published_components",
+  );
+
+  /**
+   * API does not provide a way to get all the most recent versions of components.
+   * In future as Backend API evolves, we can replace this hook.
+   */
+  return useSuspenseQuery({
+    queryKey: ["component-library", "published", "all-components"],
+    staleTime: 1000 * 60 * 5,
+    queryFn: () => {
+      return publishedComponentsLibrary.getComponents({
+        // use a wildcard to bypass the search term validation
+        searchTerm: "***",
+        filters: ["deprecated"],
+      });
+    },
+  });
+}

--- a/src/components/shared/ManageComponent/hooks/useForceUpdateTasks.ts
+++ b/src/components/shared/ManageComponent/hooks/useForceUpdateTasks.ts
@@ -1,0 +1,53 @@
+import { useCallback } from "react";
+
+import type { HydratedComponentReference } from "@/utils/componentSpec";
+
+import { useDialogContext } from "../../Dialogs/dialog.context";
+import { useNodesOverlay } from "../../ReactFlow/NodesOverlay/NodesOverlayProvider";
+
+export function useForceUpdateTasks(
+  currentComponent: HydratedComponentReference | null,
+) {
+  const dialogContext = useDialogContext();
+  const { notifyNode, getNodeIdsByDigest, fitNodeIntoView } = useNodesOverlay();
+
+  return useCallback(
+    async (digest: string) => {
+      if (!currentComponent) {
+        return;
+      }
+
+      const nodeIds = getNodeIdsByDigest(digest);
+
+      if (nodeIds.length === 0) {
+        return;
+      }
+
+      const nodeId = nodeIds.pop();
+
+      if (!nodeId) {
+        return;
+      }
+
+      // close current dialog?
+      dialogContext?.close();
+
+      await fitNodeIntoView(nodeId);
+
+      notifyNode(nodeId, {
+        type: "update-overlay",
+        data: {
+          replaceWith: currentComponent,
+          ids: nodeIds,
+        },
+      });
+    },
+    [
+      dialogContext,
+      getNodeIdsByDigest,
+      fitNodeIntoView,
+      notifyNode,
+      currentComponent,
+    ],
+  );
+}

--- a/src/components/shared/ManageComponent/hooks/useHasPublishedComponent.ts
+++ b/src/components/shared/ManageComponent/hooks/useHasPublishedComponent.ts
@@ -1,0 +1,23 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+import { useComponentLibrary } from "@/providers/ComponentLibraryProvider";
+import type { ComponentReference } from "@/utils/componentSpec";
+
+/**
+ * Hook to check if a component is published in the published components library
+ * @param componentRef - The component reference to check if it is published
+ * @returns A boolean indicating if the component is published
+ */
+export const useHasPublishedComponent = (componentRef: ComponentReference) => {
+  const { getComponentLibrary } = useComponentLibrary();
+  const publishedComponentsLibrary = getComponentLibrary(
+    "published_components",
+  );
+
+  return useSuspenseQuery({
+    // todo: id of the component?
+    // todo: consistent queryKey naming practice
+    queryKey: ["has-component", componentRef.digest],
+    queryFn: () => publishedComponentsLibrary.hasComponent(componentRef),
+  });
+};

--- a/src/components/shared/ManageComponent/hooks/useOutdatedComponents.ts
+++ b/src/components/shared/ManageComponent/hooks/useOutdatedComponents.ts
@@ -1,0 +1,88 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+import { hydrateComponentReference } from "@/services/componentService";
+import {
+  type ComponentReference,
+  type ComponentReferenceWithDigest,
+  type HydratedComponentReference,
+  isDiscoverableComponentReference,
+  isHydratedComponentReference,
+} from "@/utils/componentSpec";
+
+import { hasSupersededBy } from "../types";
+import { useAllPublishedComponents } from "./useAllPublishedComponents";
+
+async function hydrateAllComponents(
+  components: ComponentReference[],
+): Promise<HydratedComponentReference[]> {
+  return (
+    await Promise.all(components.map((c) => hydrateComponentReference(c)))
+  ).filter(isHydratedComponentReference);
+}
+
+/**
+ * Hook to get the outdated components in the graph
+ *
+ * @param usedComponents - The components that are used in the graph
+ * @returns
+ */
+export function useOutdatedComponents(usedComponents: ComponentReference[]) {
+  const { data: publishedComponents } = useAllPublishedComponents();
+
+  return useSuspenseQuery({
+    queryKey: ["outdated-components", usedComponents],
+    staleTime: 1000 * 60 * 5,
+    queryFn: async () => {
+      const mostRecentComponents = await findMostRecentComponents(
+        publishedComponents.components ?? [],
+      );
+
+      const hydratedComponents = await hydrateAllComponents(usedComponents);
+
+      return hydratedComponents
+        .filter(
+          (c) =>
+            isDiscoverableComponentReference(c) &&
+            mostRecentComponents.has(c.digest),
+        )
+        .map(
+          (c) =>
+            [
+              c,
+              mostRecentComponents.get(c.digest) as HydratedComponentReference,
+            ] as const,
+        );
+    },
+  });
+}
+
+async function findMostRecentComponents(
+  components: ComponentReference[],
+): Promise<Map<string, HydratedComponentReference>> {
+  const componentsWithDigest = components.filter((c) =>
+    isDiscoverableComponentReference(c),
+  );
+
+  const supersededIndex = new Map<string, ComponentReferenceWithDigest>(
+    componentsWithDigest
+      .filter((c) => hasSupersededBy(c))
+      .map((c) => [c.superseded_by, c]),
+  );
+
+  const mostRecentComponents = new Map<string, HydratedComponentReference>();
+
+  const leafList = componentsWithDigest.filter((c) => !c.superseded_by);
+
+  for (const leaf of leafList) {
+    let current: ComponentReferenceWithDigest | undefined = supersededIndex.get(
+      leaf.digest,
+    );
+    const hydratedLeaf = await hydrateComponentReference(leaf);
+    while (current && hydratedLeaf) {
+      mostRecentComponents.set(current.digest, hydratedLeaf);
+      current = supersededIndex.get(current.digest);
+    }
+  }
+
+  return mostRecentComponents;
+}

--- a/src/components/shared/ReactFlow/FlowCanvas/ConfirmationDialogs/UpgradeComponent.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/ConfirmationDialogs/UpgradeComponent.tsx
@@ -1,4 +1,3 @@
-import { type Node } from "@xyflow/react";
 import { Unlink } from "lucide-react";
 
 import {
@@ -12,12 +11,13 @@ import type { InputSpec, TaskSpec } from "@/utils/componentSpec";
 import { getArgumentDetails, thisCannotBeUndone } from "./shared";
 
 export function getUpgradeConfirmationDetails(
-  replacedNode: Node,
+  taskId: string,
+  taskSpec: TaskSpec | undefined,
   newComponentDigest: string,
   lostInputs: InputSpec[],
 ) {
-  const oldTaskId = replacedNode.data.taskId as string;
-  const oldTaskSpec = replacedNode.data.taskSpec as TaskSpec | undefined;
+  const oldTaskId = taskId;
+  const oldTaskSpec = taskSpec;
   const oldTaskInputs = oldTaskSpec?.componentRef.spec?.inputs;
   const oldTaskArguments = oldTaskSpec?.arguments;
   const oldTaskDigest = oldTaskSpec?.componentRef.digest;

--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -508,7 +508,7 @@ const FlowCanvas = ({
         }
 
         const { updatedGraphSpec, lostInputs, newTaskId } = replaceTaskNode(
-          replaceTarget,
+          replaceTarget.data.taskId as string,
           droppedTask.componentRef,
           graphSpec,
         );
@@ -652,7 +652,7 @@ const FlowCanvas = ({
       // Custom components don't have a componentRef.url so they are currently excluded from bulk operations
       if (taskSpec?.componentRef && taskSpec.componentRef.url) {
         const { updatedGraphSpec, lostInputs } = replaceTaskNode(
-          node,
+          node.data.taskId as string,
           taskSpec.componentRef,
           newGraphSpec,
         );

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/UpgradeNodePopover.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/UpgradeNodePopover.tsx
@@ -1,0 +1,116 @@
+import { type ComponentProps, useCallback, useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { BlockStack, InlineStack } from "@/components/ui/layout";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Heading } from "@/components/ui/typography";
+import { useComponentSpec } from "@/providers/ComponentSpecProvider";
+import type { TaskNodeContextType } from "@/providers/TaskNodeProvider";
+
+import {
+  type UpdateOverlayMessage,
+  useNodesOverlay,
+} from "../../../NodesOverlay/NodesOverlayProvider";
+import { getUpgradeConfirmationDetails } from "../../ConfirmationDialogs/UpgradeComponent";
+import { replaceTaskNode } from "../../utils/replaceTaskNode";
+
+/**
+ * Popover that appears when a task is upgraded.
+ *
+ * @param currentNode - The current task node
+ * @param ids - The ids of the nodes to upgrade
+ * @param replaceWith - The component reference to replace the task with
+ * @param onOpenChange - The function to call when the popover is opened or closed
+ * @param props - The props for the popover
+ *
+ * @returns The UpgradeNodePopover component
+ */
+export const UpgradeNodePopover = ({
+  currentNode,
+  ids,
+  replaceWith,
+  onOpenChange,
+  ...props
+}: ComponentProps<typeof Popover> &
+  UpdateOverlayMessage["data"] & {
+    currentNode: TaskNodeContextType;
+  }) => {
+  const [open, setOpen] = useState(true);
+  const { taskId, taskSpec } = currentNode;
+  const { graphSpec, updateGraphSpec } = useComponentSpec();
+  const { notifyNode, fitNodeIntoView } = useNodesOverlay();
+
+  const updatePreview = useMemo(() => {
+    return replaceTaskNode(taskId, replaceWith, graphSpec);
+  }, [taskId, replaceWith, graphSpec]);
+
+  const markup = useMemo(() => {
+    const { content } = getUpgradeConfirmationDetails(
+      taskId,
+      taskSpec,
+      replaceWith.digest,
+      updatePreview.lostInputs,
+    );
+
+    return content;
+  }, [taskId, taskSpec, replaceWith, updatePreview.lostInputs]);
+
+  const handleOpenChange = useCallback(() => {
+    setOpen(false);
+    onOpenChange?.(false);
+  }, [onOpenChange]);
+
+  const handleNext = useCallback(async () => {
+    handleOpenChange();
+
+    if (ids.length === 0) {
+      return;
+    }
+
+    const nodeId = ids.pop();
+
+    if (!nodeId) {
+      return;
+    }
+
+    await fitNodeIntoView(nodeId);
+
+    notifyNode(nodeId, {
+      type: "update-overlay",
+      data: {
+        replaceWith,
+        ids,
+      },
+    });
+  }, [fitNodeIntoView, ids, replaceWith, notifyNode, handleOpenChange]);
+
+  const handleApplyAndNext = useCallback(async () => {
+    updateGraphSpec(updatePreview.updatedGraphSpec);
+
+    void handleNext();
+  }, [handleNext, updatePreview.updatedGraphSpec, updateGraphSpec]);
+
+  return (
+    <Popover {...props} open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger />
+      <PopoverContent>
+        <BlockStack gap="2">
+          <Heading level={2}>Upgrade task</Heading>
+          {markup}
+          <InlineStack align="space-between" className="w-full">
+            <Button onClick={handleNext} variant="secondary" size="xs">
+              Skip
+            </Button>
+            <Button onClick={handleApplyAndNext} variant="default" size="xs">
+              {ids.length > 0 ? "Accept and move to next task" : "Accept"}
+            </Button>
+          </InlineStack>
+        </BlockStack>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/replaceTaskNode.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/replaceTaskNode.ts
@@ -1,5 +1,3 @@
-import type { Node } from "@xyflow/react";
-
 import type {
   ArgumentType,
   ComponentReference,
@@ -11,7 +9,7 @@ import { deepClone } from "@/utils/deepClone";
 import { getUniqueTaskName } from "@/utils/unique";
 
 export const replaceTaskNode = (
-  nodeToReplace: Node,
+  taskId: string,
   newComponentRef: ComponentReference,
   graphSpec: GraphSpec,
 ) => {
@@ -22,7 +20,7 @@ export const replaceTaskNode = (
   const newTaskOutputs = newComponentRef.spec?.outputs;
   const newTaskId = getUniqueTaskName(graphSpec, taskName);
 
-  const oldTaskId = nodeToReplace.data.taskId as string;
+  const oldTaskId = taskId;
   const oldTask = deepClone(updatedGraphSpec.tasks[oldTaskId]) as TaskSpec;
   const oldTaskInputs = oldTask.componentRef.spec?.inputs;
 

--- a/src/components/shared/ReactFlow/NodesOverlay/NodesOverlayProvider.test.tsx
+++ b/src/components/shared/ReactFlow/NodesOverlay/NodesOverlayProvider.test.tsx
@@ -2,7 +2,10 @@ import { act, render, renderHook, screen } from "@testing-library/react";
 import type { ReactFlowInstance } from "@xyflow/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { ComponentReference, TaskSpec } from "@/utils/componentSpec";
+import type {
+  HydratedComponentReference,
+  TaskSpec,
+} from "@/utils/componentSpec";
 
 import {
   NodesOverlayProvider,
@@ -29,7 +32,7 @@ describe("NodesOverlayProvider", () => {
     arguments: {},
   } as TaskSpec;
 
-  const mockHydratedComponentRef: ComponentReference = {
+  const mockHydratedComponentRef: HydratedComponentReference = {
     digest: "digest-456",
     name: "updated-component",
     version: "2.0.0",
@@ -38,7 +41,7 @@ describe("NodesOverlayProvider", () => {
       implementation: { container: { image: "test:latest" } },
     },
     text: "component: updated-component",
-  } as unknown as ComponentReference;
+  } as unknown as HydratedComponentReference;
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/hooks/useNodeCallbacks.ts
+++ b/src/hooks/useNodeCallbacks.ts
@@ -11,7 +11,7 @@ import { replaceTaskNode } from "@/components/shared/ReactFlow/FlowCanvas/utils/
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import type { Annotations } from "@/types/annotations";
 import type { NodeAndTaskId } from "@/types/taskNode";
-import type { ComponentReference } from "@/utils/componentSpec";
+import type { ComponentReference, TaskSpec } from "@/utils/componentSpec";
 import type { ArgumentType } from "@/utils/componentSpec";
 
 import type { TriggerDialogProps } from "./useConfirmationDialog";
@@ -164,7 +164,7 @@ export const useNodeCallbacks = ({
       }
 
       const { updatedGraphSpec, lostInputs } = replaceTaskNode(
-        node,
+        node.data.taskId as string,
         newComponentRef,
         graphSpec,
       );
@@ -175,7 +175,8 @@ export const useNodeCallbacks = ({
       }
 
       const dialogData = getUpgradeConfirmationDetails(
-        node,
+        node.data.taskId as string,
+        node.data.taskSpec as TaskSpec | undefined,
         newComponentRef.digest,
         lostInputs,
       );

--- a/src/providers/ComponentLibraryProvider/libraries/publishedComponentsLibrary.ts
+++ b/src/providers/ComponentLibraryProvider/libraries/publishedComponentsLibrary.ts
@@ -12,6 +12,7 @@ import { hydrateComponentReference } from "@/services/componentService";
 import type { ComponentFolder } from "@/types/componentLibrary";
 import {
   type ComponentReference,
+  type ComponentReferenceWithDigest,
   isDiscoverableComponentReference,
 } from "@/utils/componentSpec";
 import type { ComponentReferenceWithSpec } from "@/utils/componentStore";
@@ -241,8 +242,11 @@ export class PublishedComponentsLibrary implements Library {
           published_by: component.published_by,
           superseded_by: component.superseded_by,
           deprecated: component.deprecated,
-        }) as ComponentReference,
+        }) as ComponentReferenceWithDigest,
     );
+
+    // warming up the cache
+    components.forEach((component) => this.#knownDigests.add(component.digest));
 
     return {
       name: "Published Components",

--- a/src/utils/componentStore.ts
+++ b/src/utils/componentStore.ts
@@ -432,6 +432,7 @@ const findDuplicateComponent = async (
       const existingComponentName = fileEntry.componentRef.spec.name;
 
       if (existingComponentName === targetComponentName) {
+        // TODO: This check causing some behavior divergence with ComponentService.
         // Found a component with the same name, now check if content is identical
         if (fileEntry.componentRef.text === componentRef.text) {
           return fileEntry; // Exact duplicate found


### PR DESCRIPTION
## Description

Added functionality to detect and upgrade published components within the pipeline. This PR introduces a new UI for displaying published component details, checking for updates, and upgrading tasks to newer component versions.

Key changes:
- Added a published component badge to task nodes
- Created a component details panel showing published status and version information
- Implemented a force update mechanism to upgrade tasks using outdated components
- Added a dialog context to manage component detail dialogs
- Created a popover UI for upgrading nodes with confirmation workflow

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions


https://github.com/user-attachments/assets/4dd23b11-6bdb-4090-ba3f-47f930de5d8b



1. Enable the "remote-component-library-search" beta flag
2. Create a task using a published component
3. Verify the published component badge appears on the task
4. Open component details to see published status
5. Test the upgrade workflow by clicking "Upgrade?" when a newer version is available

## Additional Comments

This feature is behind the "remote-component-library-search" beta flag and builds on the existing component library infrastructure.