### PR TITLE
Fix Broken Node Input Highlighting

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeInputs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeInputs.tsx
@@ -98,7 +98,7 @@ export function TaskNodeInputs({
       const input = inputs.find((i) => i.name === inputName);
       toggleHighlightRelatedHandles(selected, input);
     },
-    [inputs, state, toggleHighlightRelatedHandles],
+    [inputs, state.readOnly, toggleHighlightRelatedHandles],
   );
 
   const checkHighlight = useCallback(

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeOutputs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeOutputs.tsx
@@ -40,7 +40,8 @@ export function TaskNodeOutputs({
   const outputsWithTaskInput = outputs.filter((output) =>
     edges.some(
       (edge) =>
-        edge.source === nodeId && edge.sourceHandle === `output_${output.name}`,
+        edge.source === nodeId &&
+        edge.sourceHandle === outputNameToNodeId(output.name),
     ),
   );
 
@@ -90,7 +91,7 @@ export function TaskNodeOutputs({
       const output = outputs.find((o) => o.name === outputName);
       toggleHighlightRelatedHandles(selected, output);
     },
-    [outputs, state, toggleHighlightRelatedHandles],
+    [outputs, state.readOnly, toggleHighlightRelatedHandles],
   );
 
   const checkHighlight = useCallback(


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Fixes a bug where clicking on an input node may not highlight relevant nodes or apply filters to the component library.

The issue was causes by updates to the node state in the relevant output nodes, resulting in the applied changes being cleared. Now the required `state` dependency is more narrow to focus only on the readonly prop that is needed

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

This bug was identified while investigating https://github.com/Shopify/oasis-frontend/issues/216

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
