### PR TITLE
Move New Annotation Button to Section Header

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsEditor.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsEditor.tsx
@@ -1,3 +1,6 @@
+import { PlusCircleIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
 import type { AnnotationConfig, Annotations } from "@/types/annotations";
 
 import { AnnotationsInput } from "./AnnotationsInput";
@@ -12,6 +15,7 @@ interface AnnotationsEditorProps {
   newRows: Array<{ key: string; value: string }>;
   onNewRowBlur: (idx: number, newRow: { key: string; value: string }) => void;
   onRemoveNewRow: (idx: number) => void;
+  onAddNewRow: () => void;
 }
 
 const COMMON_ANNOTATIONS: AnnotationConfig[] = [
@@ -33,6 +37,7 @@ export const AnnotationsEditor = ({
   newRows,
   onNewRowBlur,
   onRemoveNewRow,
+  onAddNewRow,
 }: AnnotationsEditorProps) => {
   const remainingAnnotations = Object.entries(annotations).filter(
     ([key]) =>
@@ -42,7 +47,19 @@ export const AnnotationsEditor = ({
 
   return (
     <div className="h-auto flex flex-col gap-2">
-      <h3>Other Annotations</h3>
+      <div className="flex justify-between items-center">
+        <h3>Other Annotations</h3>
+
+        <Button
+          onClick={onAddNewRow}
+          variant="ghost"
+          className="w-fit"
+          type="button"
+        >
+          <PlusCircleIcon className="h-4 w-4" />
+          New
+        </Button>
+      </div>
 
       {COMMON_ANNOTATIONS.map((config) => (
         <div key={config.annotation} className="flex items-center gap-2">

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsSection.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/AnnotationsEditor/AnnotationsSection.tsx
@@ -1,7 +1,5 @@
-import { PlusCircleIcon } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 
-import { Button } from "@/components/ui/button";
 import useToastNotification from "@/hooks/useToastNotification";
 import type { Annotations } from "@/types/annotations";
 import type { TaskSpec } from "@/utils/componentSpec";
@@ -116,39 +114,25 @@ export const AnnotationsSection = ({
   }, [rawAnnotations]);
 
   return (
-    <>
-      <div className="h-auto flex flex-col gap-2 overflow-y-auto pr-4 py-2 overflow-visible">
-        <ComputeResourcesEditor
-          annotations={annotations}
-          onChange={handleValueChange}
-          onBlur={handleValueBlur}
-        />
-
-        <hr className="border-t border-dashed border-gray-200 my-4" />
-
-        <AnnotationsEditor
-          annotations={annotations}
-          onChange={handleValueChange}
-          onBlur={handleValueBlur}
-          onRemove={handleRemove}
-          newRows={newRows}
-          onNewRowBlur={handleNewRowBlur}
-          onRemoveNewRow={handleRemoveNewRow}
-        />
-      </div>
+    <div className="h-auto flex flex-col gap-2 overflow-y-auto pr-4 py-2 overflow-visible">
+      <ComputeResourcesEditor
+        annotations={annotations}
+        onChange={handleValueChange}
+        onBlur={handleValueBlur}
+      />
 
       <hr className="border-t border-dashed border-gray-200 my-4" />
-      <div className="flex gap-2 justify-end mt-4">
-        <Button
-          onClick={handleAddNewRow}
-          variant="ghost"
-          className="w-fit"
-          type="button"
-        >
-          <PlusCircleIcon className="h-4 w-4" />
-          New
-        </Button>
-      </div>
-    </>
+
+      <AnnotationsEditor
+        annotations={annotations}
+        onChange={handleValueChange}
+        onBlur={handleValueBlur}
+        onRemove={handleRemove}
+        newRows={newRows}
+        onNewRowBlur={handleNewRowBlur}
+        onRemoveNewRow={handleRemoveNewRow}
+        onAddNewRow={handleAddNewRow}
+      />
+    </div>
   );
 };


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Moves the "new" button that adds a new empty annotation row to the header. Behaviour is otherwise unchanged.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.dev/user-attachments/assets/b0cf19ef-317c-4cc4-8c58-72082d71f558.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
