### PR TITLE
Bugfix Export Pipeline button using outdated spec

### DIFF
--- a/src/components/shared/ReactFlow/FlowSidebar/sections/SettingsAndActions.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/SettingsAndActions.tsx
@@ -64,7 +64,7 @@ const SettingsAndActions = ({ isOpen }: { isOpen: boolean }) => {
         ? componentSpecToYaml(componentSpecRef.current)
         : "";
     }
-  }, [componentSpecRef]);
+  }, [componentSpecRef.current]);
 
   const componentTextBlob = new Blob([componentText], { type: "text/yaml" });
   const filename = componentSpec?.name


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Fixes an issue where the "Export pipeline" button was exporting outdated pipelines (i.e. ignoring the most recent edits)

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Closes https://github.com/Shopify/oasis-frontend/issues/221

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
