### PR TITLE
Fix Pipeline Rename Operation Resulting in Clones

### DIFF
--- a/src/components/Editor/RenamePipeline.tsx
+++ b/src/components/Editor/RenamePipeline.tsx
@@ -11,7 +11,7 @@ import { USER_PIPELINES_LIST_NAME } from "@/utils/constants";
 import { PipelineNameDialog } from "../shared/Dialogs";
 
 const RenamePipeline = () => {
-  const { componentSpec } = useComponentSpec();
+  const { componentSpec, saveComponentSpec } = useComponentSpec();
   const notify = useToastNotification();
   const navigate = useNavigate();
 
@@ -36,6 +36,8 @@ const RenamePipeline = () => {
       name,
       pathname,
     );
+
+    await saveComponentSpec(name);
 
     const urlName = encodeURIComponent(name);
     const url = APP_ROUTES.PIPELINE_EDITOR.replace("$name", urlName);


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Fixes an issue where renaming a pipeline results in the user being redirected to the new pipeline URL but with an outdated spec. It also fixes a related issue where renaming a pipeline may create a clone of the pipeline rather than editing the existing version.


The issue was caused by the renaming function not including an explicit save call for the spec with the updated name. Previously it was relying on the autosave feature but as this has been updated and changed over time it was no longer fit for this purposes. An explicit save has now been added after the pipeline file has been renamed.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Closes https://github.com/Shopify/oasis-frontend/issues/220

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
