### PR TITLE
Bulk Actions on Pipeline List

### DIFF
--- a/src/components/Home/PipelineSection/BulkActionsBar.tsx
+++ b/src/components/Home/PipelineSection/BulkActionsBar.tsx
@@ -1,0 +1,73 @@
+import { useCallback } from "react";
+
+import { ConfirmationDialog } from "@/components/shared/Dialogs";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { InlineStack } from "@/components/ui/layout";
+import useToastNotification from "@/hooks/useToastNotification";
+import { deletePipeline } from "@/services/pipelineService";
+import { getErrorMessage, pluralize } from "@/utils/string";
+
+interface BulkActionsBarProps {
+  selectedPipelines: string[];
+  onDeleteSuccess: () => void;
+  onClearSelection: () => void;
+}
+
+const BulkActionsBar = ({
+  selectedPipelines,
+  onDeleteSuccess,
+  onClearSelection,
+}: BulkActionsBarProps) => {
+  const notify = useToastNotification();
+
+  const handleBulkDelete = useCallback(async () => {
+    const deletePromises = selectedPipelines.map((pipelineName) =>
+      deletePipeline(pipelineName),
+    );
+
+    try {
+      await Promise.all(deletePromises);
+      onDeleteSuccess();
+      notify(
+        `${selectedPipelines.length} pipelines successfully deleted`,
+        "success",
+      );
+    } catch (error) {
+      const errorMessage = getErrorMessage(error);
+      notify("Failed to delete some pipelines: " + errorMessage, "error");
+    }
+  }, [selectedPipelines, onDeleteSuccess]);
+
+  return (
+    <div className="fixed bottom-4 left-1/2 transform -translate-x-1/2 bg-background border border-border rounded-lg shadow-lg p-4 z-50">
+      <InlineStack gap="4" blockAlign="center">
+        <span className="text-sm font-medium">
+          {selectedPipelines.length}{" "}
+          {pluralize(selectedPipelines.length, "pipeline")} selected
+        </span>
+
+        <InlineStack gap="2" blockAlign="center">
+          <ConfirmationDialog
+            trigger={
+              <Button variant="destructive" size="sm">
+                <Icon name="Trash2" />
+                Delete {selectedPipelines.length}{" "}
+                {pluralize(selectedPipelines.length, "item")}
+              </Button>
+            }
+            title={`Delete ${selectedPipelines.length} ${pluralize(selectedPipelines.length, "pipeline")}?`}
+            description={`Are you sure you want to delete ${selectedPipelines.length === 1 ? "this pipeline" : "these pipelines"}? Existing pipeline runs will not be impacted. This action cannot be undone.`}
+            onConfirm={handleBulkDelete}
+          />
+
+          <Button variant="ghost" size="sm" onClick={onClearSelection}>
+            <Icon name="X" />
+          </Button>
+        </InlineStack>
+      </InlineStack>
+    </div>
+  );
+};
+
+export default BulkActionsBar;

--- a/src/components/Home/PipelineSection/PipelineRow/PipelineRow.tsx
+++ b/src/components/Home/PipelineSection/PipelineRow/PipelineRow.tsx
@@ -6,6 +6,7 @@ import { ConfirmationDialog } from "@/components/shared/Dialogs";
 import RunOverview from "@/components/shared/RunOverview";
 import StatusIcon from "@/components/shared/Status/StatusIcon";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Popover,
   PopoverContent,
@@ -26,12 +27,16 @@ interface PipelineRowProps {
   name?: string;
   modificationTime?: Date;
   onDelete?: () => void;
+  isSelected?: boolean;
+  onSelect?: (checked: boolean) => void;
 }
 
 const PipelineRow = ({
   name,
   modificationTime,
   onDelete,
+  isSelected = false,
+  onSelect,
 }: PipelineRowProps) => {
   const { backendUrl } = useBackend();
   const navigate = useNavigate();
@@ -52,6 +57,13 @@ const PipelineRow = ({
     [navigate, name],
   );
 
+  const handleCheckboxChange = useCallback(
+    (checked: boolean) => {
+      onSelect?.(checked);
+    },
+    [onSelect],
+  );
+
   const confirmPipelineDelete = useCallback(async () => {
     if (!name) return;
 
@@ -61,6 +73,11 @@ const PipelineRow = ({
 
     await deletePipeline(name, deleteCallback);
   }, [name]);
+
+  const handleClick = useCallback((e: MouseEvent) => {
+    // Prevent row click when clicking on the checkbox
+    e.stopPropagation();
+  }, []);
 
   const formattedDate = useMemo(() => {
     if (!modificationTime) return "N/A";
@@ -73,6 +90,14 @@ const PipelineRow = ({
         className="cursor-pointer hover:bg-muted/50 group"
         onClick={handleRowClick}
       >
+        <TableCell onClick={(e) => e.stopPropagation()}>
+          <Checkbox
+            data-checkbox
+            checked={isSelected}
+            onCheckedChange={handleCheckboxChange}
+            onClick={handleClick}
+          />
+        </TableCell>
         <TableCell>
           <a href={`${EDITOR_PATH}/${name}`} className="hover:underline">
             {name}

--- a/src/services/pipelineService.ts
+++ b/src/services/pipelineService.ts
@@ -18,10 +18,10 @@ import {
 } from "@/utils/componentStore";
 import { USER_PIPELINES_LIST_NAME } from "@/utils/constants";
 
-export const deletePipeline = async (name: string, onDelete: () => void) => {
+export const deletePipeline = async (name: string, onDelete?: () => void) => {
   try {
     await deleteComponentFileFromList(USER_PIPELINES_LIST_NAME, name);
-    onDelete();
+    onDelete?.();
   } catch (error) {
     console.error("Error deleting pipeline:", error);
   }

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -69,11 +69,27 @@ function createStringList(
   );
 }
 
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  } else if (typeof error === "string") {
+    return error;
+  } else {
+    return "An unknown error occurred";
+  }
+}
+
+function pluralize(count: number, singular: string, plural?: string) {
+  return count === 1 ? singular : plural || `${singular}s`;
+}
+
 export {
   copyToClipboard,
   createStringList,
   formatBytes,
   formatJsonValue,
+  getErrorMessage,
   getValue,
+  pluralize,
   removeTrailingDateFromTitle,
 };


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Adds checkboxes and bulk actions to the pipeline list. Users can now select multiple pipelines and delete them.

Bulk actions are access by an action bar that appears at the bottom of the screen when some checkboxes have been selected


## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

User requested

## Type of Change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->
<img width="1581" height="1259" alt="image" src="https://github.com/user-attachments/assets/727a4eab-e407-4a54-a762-979480607abf" />



## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
1. Navigate to the pipeline list
2. select some pipelines using the checkboxes
4. delete the pipelines
5. (de)select all using the checkbox at the top of the table

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
