### PR TITLE
Error page for Pipeline Editor

### DIFF
--- a/src/routes/Editor/Editor.tsx
+++ b/src/routes/Editor/Editor.tsx
@@ -4,12 +4,34 @@ import { DndContext } from "@dnd-kit/core";
 import { ReactFlowProvider } from "@xyflow/react";
 
 import PipelineEditor from "@/components/Editor/PipelineEditor";
+import { InfoBox } from "@/components/shared/InfoBox";
+import { BlockStack } from "@/components/ui/layout";
+import { Text } from "@/components/ui/typography";
 import { useLoadComponentSpecFromPath } from "@/hooks/useLoadComponentSpecFromPath";
 import { useBackend } from "@/providers/BackendProvider";
 
 const Editor = () => {
   const { backendUrl } = useBackend();
-  const { componentSpec } = useLoadComponentSpecFromPath(backendUrl);
+  const { componentSpec, error } = useLoadComponentSpecFromPath(backendUrl);
+
+  if (error) {
+    return (
+      <BlockStack
+        align="center"
+        inlineAlign="center"
+        gap="4"
+        className="h-full"
+      >
+        <InfoBox variant="error" title="Error loading pipeline">
+          {error}
+        </InfoBox>
+        <Text tone="subdued" size="sm">
+          Tip: Pipelines are stored locally and are not shareable by URL. To
+          share a pipeline it needs to be exported.
+        </Text>
+      </BlockStack>
+    );
+  }
 
   if (!componentSpec) {
     return <div>Loading...</div>;


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Adds an error page to pipelines that have an error when loading e.g. the pipeline does not exist at the given url


This is most useful when users try to share pipelines via url, as they are stored locally so trying to load them from a url won't work (currently results in an infinite loading spinner)

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
n/a

## Type of Change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->
<img width="1274" height="1067" alt="image" src="https://github.com/user-attachments/assets/f48213e1-db56-44ed-be1b-5d19ed2c3cb2" />


## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
1. load a pipeline from your list. success
2. modify the url so it does not match any pipelines you have. error page

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
