### PR TITLE
InputNode Save-on-Blur

### DIFF
--- a/src/components/Editor/InputValueEditor/FormFields/FormFields.tsx
+++ b/src/components/Editor/InputValueEditor/FormFields/FormFields.tsx
@@ -7,6 +7,7 @@ import { Icon } from "@/components/ui/icon";
 import { Input } from "@/components/ui/input";
 import { BlockStack, InlineStack } from "@/components/ui/layout";
 import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
 
 export type FormFieldAction = {
   icon: keyof typeof icons;
@@ -27,8 +28,12 @@ const FormField = ({
   children: ReactNode;
 }) => (
   <BlockStack>
-    <InlineStack align="space-between" blockAlign="center">
-      <label htmlFor={id} className="text-xs text-muted-foreground mb-1">
+    <InlineStack
+      align="space-between"
+      blockAlign="center"
+      className="w-full mb-1"
+    >
+      <label htmlFor={id} className="text-xs text-muted-foreground">
         {label}
       </label>
       {actions?.map(
@@ -41,7 +46,7 @@ const FormField = ({
               disabled={action.disabled}
               size="min"
             >
-              <Icon name={action.icon} className="size-3" />
+              <Icon name={action.icon} size="xs" />
             </Button>
           ),
       )}
@@ -53,11 +58,13 @@ const FormField = ({
 const NameField = ({
   inputName,
   onNameChange,
+  onBlur,
   error,
   disabled,
 }: {
   inputName: string;
   onNameChange: (value: string) => void;
+  onBlur?: () => void;
   error?: string | null;
   disabled?: boolean;
 }) => (
@@ -68,15 +75,19 @@ const NameField = ({
       type="text"
       value={inputName}
       onChange={(e) => onNameChange(e.target.value)}
-      className={`text-sm ${error ? "border-red-500 focus:border-red-500" : ""}`}
+      onBlur={onBlur}
+      className={cn("text-sm", {
+        "border-red-500 focus:border-red-500": !!error,
+      })}
     />
-    {error && <div className="text-xs text-red-500 mt-1">{error}</div>}
+    {!!error && <div className="text-xs text-red-500 mt-1">{error}</div>}
   </FormField>
 );
 
 const TextField = ({
   inputValue,
   onInputChange,
+  onBlur,
   placeholder,
   disabled,
   inputName,
@@ -84,6 +95,7 @@ const TextField = ({
 }: {
   inputValue: string;
   onInputChange: (value: string) => void;
+  onBlur?: () => void;
   placeholder: string;
   disabled: boolean;
   inputName: string;
@@ -98,6 +110,7 @@ const TextField = ({
       id={`input-value-${inputName}`}
       value={inputValue}
       onChange={(e) => onInputChange(e.target.value)}
+      onBlur={onBlur}
       placeholder={placeholder}
       disabled={disabled}
       className="text-sm"
@@ -108,11 +121,13 @@ const TextField = ({
 const OptionalField = ({
   inputName,
   onInputChange,
+  onBlur,
   disabled = false,
   inputValue,
 }: {
   inputName: string;
   onInputChange: (checked: boolean) => void;
+  onBlur?: () => void;
   disabled?: boolean;
   inputValue: boolean;
 }) => (
@@ -121,6 +136,7 @@ const OptionalField = ({
       id={`input-optional-${inputName}`}
       checked={inputValue}
       onCheckedChange={onInputChange}
+      onBlur={onBlur}
       disabled={disabled}
       className="h-5 w-5 border-gray-300 focus:ring-2 focus:ring-primary-500 transition-colors"
     />
@@ -136,12 +152,14 @@ const OptionalField = ({
 const TypeField = ({
   inputValue,
   onInputChange,
+  onBlur,
   placeholder,
   disabled,
   inputName,
 }: {
   inputValue: string;
   onInputChange: (value: string) => void;
+  onBlur?: () => void;
   placeholder: string;
   disabled?: boolean;
   inputName: string;
@@ -151,6 +169,7 @@ const TypeField = ({
       id={`input-type-${inputName}`}
       value={inputValue}
       onChange={(e) => onInputChange(e.target.value)}
+      onBlur={onBlur}
       placeholder={placeholder}
       disabled={disabled}
       className="text-sm"

--- a/src/components/Editor/PipelineDetails.tsx
+++ b/src/components/Editor/PipelineDetails.tsx
@@ -95,8 +95,7 @@ const PipelineDetails = () => {
       <InputValueEditor
         key={input.name}
         input={input}
-        onSave={deselectNode}
-        onCancel={handleCancel}
+        onClose={handleCancel}
       />,
     );
   };

--- a/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
@@ -1,6 +1,6 @@
 import { useLocation } from "@tanstack/react-router";
 import { Handle, Position, useReactFlow } from "@xyflow/react";
-import { memo, useCallback, useEffect } from "react";
+import { memo, useCallback, useEffect, useMemo } from "react";
 
 import { InputValueEditor } from "@/components/Editor/InputValueEditor/InputValueEditor";
 import { OutputNameEditor } from "@/components/Editor/OutputNameEditor";
@@ -44,12 +44,14 @@ const IONode = ({ type, data, selected = false }: IONodeProps) => {
       : "border-violet-300 bg-violet-100";
   const borderColor = selected ? selectedBorderColor : defaultBorderColor;
 
-  const input = componentSpec.inputs?.find(
-    (input) => input.name === data.label,
+  const input = useMemo(
+    () => componentSpec.inputs?.find((input) => input.name === data.label),
+    [componentSpec.inputs, data.label],
   );
 
-  const output = componentSpec.outputs?.find(
-    (output) => output.name === data.label,
+  const output = useMemo(
+    () => componentSpec.outputs?.find((output) => output.name === data.label),
+    [componentSpec.outputs, data.label],
   );
 
   const deselectNode = useCallback(() => {
@@ -64,9 +66,8 @@ const IONode = ({ type, data, selected = false }: IONodeProps) => {
           <InputValueEditor
             input={input}
             key={input.name}
-            onSave={deselectNode}
             disabled={!isPipelineEditor}
-            onCancel={deselectNode}
+            onClose={deselectNode}
           />,
         );
       }
@@ -88,7 +89,7 @@ const IONode = ({ type, data, selected = false }: IONodeProps) => {
         );
       }
     }
-  }, [selected]);
+  }, [input, selected]);
 
   const {
     outputName: outputConnectedValue,

--- a/src/components/ui/icon.tsx
+++ b/src/components/ui/icon.tsx
@@ -6,11 +6,11 @@ import { cn } from "@/lib/utils";
 const iconVariants = cva("", {
   variants: {
     size: {
-      xs: "w-3 h-3",
-      sm: "w-3.5 h-3.5",
-      md: "w-4 h-4",
+      xs: "!w-3 !h-3",
+      sm: "!w-3.5 !h-3.5",
+      md: "!w-4 !h-4",
       lg: "!w-5 !h-5",
-      fill: "w-full h-full",
+      fill: "!w-full !h-full",
     },
   },
 });


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Converts InputValueEditor into a save-on-blur component to align it with the rest of the patterns used elsewhere in the app and hook it into the autosave system.

Removes the "Save" button; fields will now save automatically when blurred. Renamed "Cancel" to "Close"

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Progresses https://github.com/Shopify/oasis-frontend/issues/239

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

![image.png](https://app.graphite.dev/user-attachments/assets/b8cbacb0-8e09-4aa2-bba5-f18cca11cc28.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
