### PR TITLE
Add AutoSaveProvider

### DIFF
--- a/src/components/Editor/PipelineEditor.tsx
+++ b/src/components/Editor/PipelineEditor.tsx
@@ -16,6 +16,7 @@ import {
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
 import { Spinner } from "@/components/ui/spinner";
+import { AutoSaveProvider } from "@/providers/AutoSaveProvider";
 import { ComponentLibraryProvider } from "@/providers/ComponentLibraryProvider";
 import { ForcedSearchProvider } from "@/providers/ComponentLibraryProvider/ForcedSearchProvider";
 import {
@@ -62,39 +63,41 @@ const PipelineEditor = () => {
   }
 
   return (
-    <PipelineRunsProvider pipelineName={componentSpec.name || ""}>
-      <NodesOverlayProvider>
-        <ContextPanelProvider defaultContent={<PipelineDetails />}>
-          <ForcedSearchProvider>
-            <ComponentLibraryProvider>
-              <FlowSidebar />
-              <ResizablePanelGroup direction="horizontal">
-                <ResizablePanel>
-                  <div className="reactflow-wrapper relative">
-                    <FlowCanvas {...flowConfig}>
-                      <MiniMap position="bottom-left" pannable />
-                      <FlowControls
-                        className="ml-[224px]! mb-[24px]!"
-                        config={flowConfig}
-                        updateConfig={updateFlowConfig}
-                        showInteractive={false}
-                      />
-                      <Background gap={GRID_SIZE} className="bg-slate-50!" />
-                    </FlowCanvas>
+    <AutoSaveProvider>
+      <PipelineRunsProvider pipelineName={componentSpec.name || ""}>
+        <NodesOverlayProvider>
+          <ContextPanelProvider defaultContent={<PipelineDetails />}>
+            <ForcedSearchProvider>
+              <ComponentLibraryProvider>
+                <FlowSidebar />
+                <ResizablePanelGroup direction="horizontal">
+                  <ResizablePanel>
+                    <div className="reactflow-wrapper relative">
+                      <FlowCanvas {...flowConfig}>
+                        <MiniMap position="bottom-left" pannable />
+                        <FlowControls
+                          className="ml-[224px]! mb-[24px]!"
+                          config={flowConfig}
+                          updateConfig={updateFlowConfig}
+                          showInteractive={false}
+                        />
+                        <Background gap={GRID_SIZE} className="bg-slate-50!" />
+                      </FlowCanvas>
 
-                    <div className="absolute bottom-0 right-0 p-4">
-                      <UndoRedo />
+                      <div className="absolute bottom-0 right-0 p-4">
+                        <UndoRedo />
+                      </div>
                     </div>
-                  </div>
-                </ResizablePanel>
-                <ResizableHandle />
-                <CollapsibleContextPanel />
-              </ResizablePanelGroup>
-            </ComponentLibraryProvider>
-          </ForcedSearchProvider>
-        </ContextPanelProvider>
-      </NodesOverlayProvider>
-    </PipelineRunsProvider>
+                  </ResizablePanel>
+                  <ResizableHandle />
+                  <CollapsibleContextPanel />
+                </ResizablePanelGroup>
+              </ComponentLibraryProvider>
+            </ForcedSearchProvider>
+          </ContextPanelProvider>
+        </NodesOverlayProvider>
+      </PipelineRunsProvider>
+    </AutoSaveProvider>
   );
 };
 

--- a/src/components/shared/ReactFlow/FlowSidebar/sections/FileActions.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/FileActions.tsx
@@ -17,6 +17,7 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 import useToastNotification from "@/hooks/useToastNotification";
 import { cn } from "@/lib/utils";
+import { useAutoSaveStatus } from "@/providers/AutoSaveProvider";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import { EDITOR_PATH } from "@/routes/router";
 import { getPipelineFile, useSavePipeline } from "@/services/pipelineService";
@@ -24,7 +25,8 @@ import { componentSpecToYaml } from "@/utils/componentStore";
 import { formatRelativeTime } from "@/utils/date";
 
 const FileActions = ({ isOpen }: { isOpen: boolean }) => {
-  const { componentSpec, autoSaveStatus } = useComponentSpec();
+  const { componentSpec } = useComponentSpec();
+  const { autoSaveStatus } = useAutoSaveStatus();
   const { savePipeline } = useSavePipeline(componentSpec);
   const notify = useToastNotification();
   const navigate = useNavigate();

--- a/src/providers/AutoSaveProvider.tsx
+++ b/src/providers/AutoSaveProvider.tsx
@@ -1,0 +1,58 @@
+import equal from "fast-deep-equal";
+import { type ReactNode, useEffect, useState } from "react";
+
+import { type AutoSaveStatus, useAutoSave } from "@/hooks/useAutoSave";
+import {
+  createRequiredContext,
+  useRequiredContext,
+} from "@/hooks/useRequiredContext";
+import {
+  EMPTY_GRAPH_COMPONENT_SPEC,
+  useComponentSpec,
+} from "@/providers/ComponentSpecProvider";
+import { AUTOSAVE_DEBOUNCE_TIME_MS } from "@/utils/constants";
+
+interface AutoSaveContextType {
+  autoSaveStatus: AutoSaveStatus;
+}
+
+const AutoSaveContext =
+  createRequiredContext<AutoSaveContextType>("AutosaveProvider");
+
+export const AutoSaveProvider = ({ children }: { children: ReactNode }) => {
+  const { componentSpec, saveComponentSpec, isLoading } = useComponentSpec();
+
+  const [isEmptySpec, setIsEmptySpec] = useState(
+    equal(componentSpec, EMPTY_GRAPH_COMPONENT_SPEC),
+  );
+
+  const shouldAutoSave =
+    !isLoading && componentSpec && !!componentSpec.name && !isEmptySpec;
+
+  useEffect(() => {
+    setIsEmptySpec(equal(componentSpec, EMPTY_GRAPH_COMPONENT_SPEC));
+  }, [componentSpec]);
+
+  const autoSaveStatus = useAutoSave(
+    async (spec) => {
+      if (spec.name) {
+        saveComponentSpec(spec.name);
+      }
+    },
+    componentSpec,
+    AUTOSAVE_DEBOUNCE_TIME_MS,
+    shouldAutoSave,
+  );
+
+  const value = { autoSaveStatus };
+
+  return (
+    <AutoSaveContext.Provider value={value}>
+      {children}
+    </AutoSaveContext.Provider>
+  );
+};
+
+export const useAutoSaveStatus = () => {
+  return useRequiredContext(AutoSaveContext);
+};

--- a/src/providers/ComponentSpecProvider.tsx
+++ b/src/providers/ComponentSpecProvider.tsx
@@ -1,20 +1,8 @@
-import equal from "fast-deep-equal";
-import {
-  type ReactNode,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { type ReactNode, useCallback, useMemo, useRef, useState } from "react";
 
-import { type AutoSaveStatus, useAutoSave } from "@/hooks/useAutoSave";
 import { type UndoRedo, useUndoRedo } from "@/hooks/useUndoRedo";
 import { loadPipelineByName } from "@/services/pipelineService";
-import {
-  AUTOSAVE_DEBOUNCE_TIME_MS,
-  USER_PIPELINES_LIST_NAME,
-} from "@/utils/constants";
+import { USER_PIPELINES_LIST_NAME } from "@/utils/constants";
 import { prepareComponentRefForEditor } from "@/utils/prepareComponentRefForEditor";
 
 import {
@@ -53,7 +41,6 @@ interface ComponentSpecContextType {
   taskStatusMap: Map<string, string>;
   setTaskStatusMap: (taskStatusMap: Map<string, string>) => void;
   undoRedo: UndoRedo;
-  autoSaveStatus: AutoSaveStatus;
 }
 
 const ComponentSpecContext = createRequiredContext<ComponentSpecContextType>(
@@ -78,9 +65,6 @@ export const ComponentSpecProvider = ({
   );
 
   const [isLoading, setIsLoading] = useState(!!spec);
-  const [isEmptySpec, setIsEmptySpec] = useState(
-    equal(componentSpec, EMPTY_GRAPH_COMPONENT_SPEC),
-  );
 
   const undoRedo = useUndoRedo(componentSpec, setComponentSpec);
   const undoRedoRef = useRef(undoRedo);
@@ -160,34 +144,11 @@ export const ComponentSpecProvider = ({
     }));
   }, []);
 
-  const shouldAutoSave =
-    !isLoading &&
-    !readOnly &&
-    componentSpec &&
-    !!componentSpec.name &&
-    !isEmptySpec;
-
-  const autoSaveStatus = useAutoSave(
-    async (spec) => {
-      if (spec.name) {
-        saveComponentSpec(spec.name);
-      }
-    },
-    componentSpec,
-    AUTOSAVE_DEBOUNCE_TIME_MS,
-    shouldAutoSave,
-  );
-
-  useEffect(() => {
-    setIsEmptySpec(equal(componentSpec, EMPTY_GRAPH_COMPONENT_SPEC));
-  }, [componentSpec]);
-
   const value = useMemo(
     () => ({
       componentSpec,
       graphSpec,
       taskStatusMap,
-      autoSaveStatus,
       isLoading,
       refetch,
       setComponentSpec,
@@ -201,7 +162,6 @@ export const ComponentSpecProvider = ({
       componentSpec,
       graphSpec,
       taskStatusMap,
-      autoSaveStatus,
       isLoading,
       refetch,
       setComponentSpec,


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Moves Autosave out of ComponentSpec Provider and into its own AutoSaveProvider.

This means we can now pull autosave state without updating the entire ComponentSpecProvider and all of its consumers.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Cleanup/Refactor

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

App should continue to work as previously.

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->

Looking at ComponentSpecProvider I may (separately) also do a similar thing for `undoRedo`
