### PR TITLE
Fix Unconnected IO Nodes only have type: Any

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
@@ -90,11 +90,10 @@ const IONode = ({ type, data, selected = false }: IONodeProps) => {
     }
   }, [input, output, selected]);
 
-  const {
-    outputName: outputConnectedValue,
-    outputType: outputConnectedType,
-    taskId: outputConnectedTaskId,
-  } = getOutputConnectedDetails(graphSpec, data.label);
+  const connectedOutput = getOutputConnectedDetails(graphSpec, data.label);
+  const outputConnectedValue = connectedOutput.outputName;
+  const outputConnectedType = connectedOutput.outputType;
+  const outputConnectedTaskId = connectedOutput.taskId;
 
   const handleDefaultClassName =
     "!w-[12px] !h-[12px] !border-0! !w-[12px] !h-[12px] transform-none! cursor-pointer bg-gray-500! border-none!";
@@ -115,14 +114,14 @@ const IONode = ({ type, data, selected = false }: IONodeProps) => {
         {/* type */}
         <div className="text-xs text-slate-700 font-mono truncate max-w-[250px]">
           <span className="font-bold text-slate-700">Type:</span>{" "}
-          {type === "input"
-            ? input?.type?.toString() || "Any"
-            : outputConnectedType || output?.type?.toString() || "Any"}
+          {outputConnectedType ?? data.type ?? "Any"}
         </div>
 
-        <span className="font-bold text-slate-700">
-          {outputConnectedTaskId}
-        </span>
+        {!!outputConnectedTaskId && (
+          <span className="font-bold text-slate-700">
+            {outputConnectedTaskId}
+          </span>
+        )}
 
         {/* value */}
         <div className={cn("flex flex-col gap-3 p-2 bg-white rounded-lg")}>
@@ -150,7 +149,7 @@ const IONode = ({ type, data, selected = false }: IONodeProps) => {
               )}
             >
               <span className="font-bold text-slate-700">From:</span>{" "}
-              {outputConnectedValue || "Not connected"}
+              {outputConnectedValue ?? "Not connected"}
             </div>
           )}
           <Handle

--- a/src/components/shared/ReactFlow/FlowCanvas/utils/getOutputConnectedDetails.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/utils/getOutputConnectedDetails.ts
@@ -1,15 +1,17 @@
+import type { GraphSpec } from "@/utils/componentSpec";
+
 /**
  * Returns the connected output value (outputName) for a given output name from a graphSpec's outputValues.
  * Returns undefined if not connected.
  */
 export interface OutputConnectedDetails {
-  outputName: string;
-  outputType: string;
-  taskId: string;
+  outputName?: string;
+  outputType?: string;
+  taskId?: string;
 }
 
 export function getOutputConnectedDetails(
-  graphSpec: any,
+  graphSpec: GraphSpec,
   outputName: string,
 ): OutputConnectedDetails {
   if (graphSpec?.outputValues) {
@@ -23,18 +25,20 @@ export function getOutputConnectedDetails(
         graphSpec.tasks[
           outputValue.taskOutput.taskId
         ]?.componentRef?.spec?.outputs?.find(
-          (output: any) => output.name === outputValue.taskOutput.outputName,
+          (output) => output.name === outputValue.taskOutput.outputName,
         )?.type || "Any";
+
       return {
         outputName: outputValue.taskOutput.outputName,
-        outputType: type,
+        outputType: type as string,
         taskId: outputValue.taskOutput.taskId,
       };
     }
   }
+
   return {
-    outputName: "Not connected",
-    outputType: "Any",
-    taskId: "",
+    outputName: undefined,
+    outputType: undefined,
+    taskId: undefined,
   };
 }


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Fixes a bug with IO Nodes where the node would always display "Type: Any" when not connected, even if the user entered a type in the box.

Also amends a few TypeScript Types in related methods.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
