### PR TITLE
Fix IO Node Desync on Undo-Redo

### DIFF
--- a/src/components/Editor/IOEditor/InputValueEditor/FormFields/FormFields.tsx
+++ b/src/components/Editor/IOEditor/InputValueEditor/FormFields/FormFields.tsx
@@ -61,12 +61,14 @@ const NameField = ({
   onBlur,
   error,
   disabled,
+  autoFocus = false,
 }: {
   inputName: string;
   onNameChange: (value: string) => void;
   onBlur?: () => void;
   error?: string | null;
   disabled?: boolean;
+  autoFocus?: boolean;
 }) => (
   <FormField label="Name" id={`input-name-${inputName}`}>
     <Input
@@ -79,6 +81,7 @@ const NameField = ({
       className={cn("text-sm", {
         "border-red-500 focus:border-red-500": !!error,
       })}
+      autoFocus={autoFocus}
     />
     {!!error && <div className="text-xs text-red-500 mt-1">{error}</div>}
   </FormField>

--- a/src/components/Editor/IOEditor/InputValueEditor/InputValueEditor.tsx
+++ b/src/components/Editor/IOEditor/InputValueEditor/InputValueEditor.tsx
@@ -194,6 +194,7 @@ export const InputValueEditor = ({
         onBlur={handleBlur}
         error={validationError}
         disabled={disabled}
+        autoFocus={!disabled}
       />
 
       <TextField

--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -22,6 +22,7 @@ import useConfirmationDialog from "@/hooks/useConfirmationDialog";
 import { useCopyPaste } from "@/hooks/useCopyPaste";
 import { useGhostNode } from "@/hooks/useGhostNode";
 import { useHintNode } from "@/hooks/useHintNode";
+import { useIOSelectionPersistence } from "@/hooks/useIOSelectionPersistence";
 import { useNodeCallbacks } from "@/hooks/useNodeCallbacks";
 import useToastNotification from "@/hooks/useToastNotification";
 import { cn } from "@/lib/utils";
@@ -104,6 +105,9 @@ const FlowCanvas = ({
     useNodesOverlay();
   const { componentSpec, setComponentSpec, graphSpec, updateGraphSpec } =
     useComponentSpec();
+  const { preserveIOSelectionOnSpecChange, resetPrevSpec } =
+    useIOSelectionPersistence();
+
   const { edges, onEdgesChange } = useComponentSpecToEdges(componentSpec);
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
 
@@ -721,10 +725,15 @@ const FlowCanvas = ({
   );
 
   useEffect(() => {
-    // Update ReactFlow based on the component spec
+    preserveIOSelectionOnSpecChange(componentSpec);
     updateReactFlow(componentSpec);
     initialCanvasLoaded.current = true;
-  }, [componentSpec, replaceTarget]);
+  }, [componentSpec, preserveIOSelectionOnSpecChange]);
+
+  // Reset when loading a new component file
+  useEffect(() => {
+    resetPrevSpec();
+  }, [componentSpec?.name, resetPrevSpec]);
 
   const fitView = useCallback(() => {
     if (reactFlowInstance) {

--- a/src/hooks/useIOSelectionPersistence.test.ts
+++ b/src/hooks/useIOSelectionPersistence.test.ts
@@ -1,0 +1,338 @@
+import { act, renderHook } from "@testing-library/react";
+import type { Node } from "@xyflow/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  ComponentSpec,
+  InputSpec,
+  OutputSpec,
+} from "@/utils/componentSpec";
+
+import { useIOSelectionPersistence } from "./useIOSelectionPersistence";
+
+// Mock only the ReactFlow hook we need
+const mockSetNodes = vi.fn();
+const mockGetNodes = vi.fn();
+
+vi.mock("@xyflow/react", () => ({
+  useReactFlow: () => ({
+    setNodes: mockSetNodes,
+    getNodes: mockGetNodes,
+  }),
+}));
+
+// Helper function to create mock nodes
+const createMockNode = (
+  id: string,
+  type: "input" | "output" | "task",
+  label: string,
+  selected = false,
+) => ({
+  id,
+  type,
+  position: { x: 0, y: 0 },
+  data: { label },
+  selected,
+});
+
+// Helper function to create mock component specs
+const createMockComponentSpec = (
+  inputs?: InputSpec[],
+  outputs?: OutputSpec[],
+): ComponentSpec => ({
+  name: "test-component",
+  inputs,
+  outputs,
+  implementation: {
+    container: {
+      image: "test-image",
+    },
+  },
+});
+
+describe("useIOSelectionPersistence - Selection Transfer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.requestAnimationFrame = vi.fn((cb) => {
+      cb(0);
+      return 0;
+    });
+  });
+
+  describe("input name changes", () => {
+    it("should transfer selection when input name changes", async () => {
+      const { result } = renderHook(() => useIOSelectionPersistence());
+
+      // Set initial spec with original input name
+      const initialSpec = createMockComponentSpec([
+        { name: "original_input", type: "string" },
+      ]);
+
+      act(() => {
+        result.current.preserveIOSelectionOnSpecChange(initialSpec);
+      });
+
+      // Mock nodes with selected input using original name
+      const mockNodes = [
+        createMockNode("input-0", "input", "original_input", true),
+      ];
+      mockGetNodes.mockReturnValue(mockNodes);
+
+      // New spec with renamed input
+      const newSpec = createMockComponentSpec([
+        { name: "renamed_input", type: "string" },
+      ]);
+
+      await act(async () => {
+        result.current.preserveIOSelectionOnSpecChange(newSpec);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      // Verify setNodes was called
+      expect(mockSetNodes).toHaveBeenCalledWith(expect.any(Function));
+
+      // Test the callback with new nodes that have the renamed input
+      const setNodesCallback = mockSetNodes.mock.calls[0][0];
+      const newNodes = [
+        createMockNode("input-0", "input", "renamed_input", false),
+      ];
+
+      const updatedNodes = setNodesCallback(newNodes);
+      const renamedInput = updatedNodes.find(
+        (node: Node) => node.id === "input-0",
+      );
+
+      // Selection should be preserved on the renamed input
+      expect(renamedInput?.selected).toBe(true);
+    });
+
+    it("should call setNodes but not restore selection when input is removed", async () => {
+      const { result } = renderHook(() => useIOSelectionPersistence());
+
+      // Set initial spec with input
+      const initialSpec = createMockComponentSpec([
+        { name: "input_to_remove", type: "string" },
+      ]);
+
+      act(() => {
+        result.current.preserveIOSelectionOnSpecChange(initialSpec);
+      });
+
+      // Mock nodes with selected input
+      const mockNodes = [
+        createMockNode("input-0", "input", "input_to_remove", true),
+      ];
+      mockGetNodes.mockReturnValue(mockNodes);
+
+      // New spec with no inputs
+      const newSpec = createMockComponentSpec([]);
+
+      await act(async () => {
+        result.current.preserveIOSelectionOnSpecChange(newSpec);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      // Should call setNodes because there were selected IO nodes to process
+      expect(mockSetNodes).toHaveBeenCalledWith(expect.any(Function));
+
+      // Test the callback - it should not restore selection since the input doesn't exist
+      const setNodesCallback = mockSetNodes.mock.calls[0][0];
+      const newNodes: Node[] = []; // No nodes since no inputs in new spec
+
+      const updatedNodes = setNodesCallback(newNodes);
+
+      // Should return empty array since no nodes match
+      expect(updatedNodes).toEqual([]);
+    });
+
+    it("should preserve selection for unchanged input names", async () => {
+      const { result } = renderHook(() => useIOSelectionPersistence());
+
+      // Set initial spec
+      const initialSpec = createMockComponentSpec([
+        { name: "unchanged_input", type: "string" },
+      ]);
+
+      act(() => {
+        result.current.preserveIOSelectionOnSpecChange(initialSpec);
+      });
+
+      // Mock nodes with selected input
+      const mockNodes = [
+        createMockNode("input-0", "input", "unchanged_input", true),
+      ];
+      mockGetNodes.mockReturnValue(mockNodes);
+
+      // New spec with same input name
+      const newSpec = createMockComponentSpec([
+        { name: "unchanged_input", type: "string" },
+      ]);
+
+      await act(async () => {
+        result.current.preserveIOSelectionOnSpecChange(newSpec);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(mockSetNodes).toHaveBeenCalledWith(expect.any(Function));
+
+      const setNodesCallback = mockSetNodes.mock.calls[0][0];
+      const updatedNodes = setNodesCallback(mockNodes);
+      const unchangedInput = updatedNodes.find(
+        (node: Node) => node.id === "input-0",
+      );
+
+      expect(unchangedInput?.selected).toBe(true);
+    });
+  });
+
+  describe("output name changes", () => {
+    it("should transfer selection when output name changes", async () => {
+      const { result } = renderHook(() => useIOSelectionPersistence());
+
+      // Set initial spec with original output name
+      const initialSpec = createMockComponentSpec(
+        [],
+        [{ name: "original_output", type: "string" }],
+      );
+
+      act(() => {
+        result.current.preserveIOSelectionOnSpecChange(initialSpec);
+      });
+
+      // Mock nodes with selected output using original name
+      const mockNodes = [
+        createMockNode("output-0", "output", "original_output", true),
+      ];
+      mockGetNodes.mockReturnValue(mockNodes);
+
+      // New spec with renamed output
+      const newSpec = createMockComponentSpec(
+        [],
+        [{ name: "renamed_output", type: "string" }],
+      );
+
+      await act(async () => {
+        result.current.preserveIOSelectionOnSpecChange(newSpec);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(mockSetNodes).toHaveBeenCalledWith(expect.any(Function));
+
+      // Test the callback with new nodes that have the renamed output
+      const setNodesCallback = mockSetNodes.mock.calls[0][0];
+      const newNodes = [
+        createMockNode("output-0", "output", "renamed_output", false),
+      ];
+
+      const updatedNodes = setNodesCallback(newNodes);
+      const renamedOutput = updatedNodes.find(
+        (node: Node) => node.id === "output-0",
+      );
+
+      // Selection should be preserved on the renamed output
+      expect(renamedOutput?.selected).toBe(true);
+    });
+
+    it("should handle multiple input and output name changes", async () => {
+      const { result } = renderHook(() => useIOSelectionPersistence());
+
+      // Set initial spec
+      const initialSpec = createMockComponentSpec(
+        [{ name: "old_input", type: "string" }],
+        [{ name: "old_output", type: "string" }],
+      );
+
+      act(() => {
+        result.current.preserveIOSelectionOnSpecChange(initialSpec);
+      });
+
+      // Mock nodes with both input and output selected
+      const mockNodes = [
+        createMockNode("input-0", "input", "old_input", true),
+        createMockNode("output-0", "output", "old_output", true),
+      ];
+      mockGetNodes.mockReturnValue(mockNodes);
+
+      // New spec with renamed input and output
+      const newSpec = createMockComponentSpec(
+        [{ name: "new_input", type: "string" }],
+        [{ name: "new_output", type: "string" }],
+      );
+
+      await act(async () => {
+        result.current.preserveIOSelectionOnSpecChange(newSpec);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(mockSetNodes).toHaveBeenCalledWith(expect.any(Function));
+
+      // Test the callback with new nodes
+      const setNodesCallback = mockSetNodes.mock.calls[0][0];
+      const newNodes = [
+        createMockNode("input-0", "input", "new_input", false),
+        createMockNode("output-0", "output", "new_output", false),
+      ];
+
+      const updatedNodes = setNodesCallback(newNodes);
+      const renamedInput = updatedNodes.find(
+        (node: Node) => node.id === "input-0",
+      );
+      const renamedOutput = updatedNodes.find(
+        (node: Node) => node.id === "output-0",
+      );
+
+      // Both selections should be preserved
+      expect(renamedInput?.selected).toBe(true);
+      expect(renamedOutput?.selected).toBe(true);
+    });
+  });
+
+  describe("no selection transfer needed", () => {
+    it("should not call setNodes when no IO nodes are selected", async () => {
+      const { result } = renderHook(() => useIOSelectionPersistence());
+
+      const initialSpec = createMockComponentSpec([
+        { name: "input1", type: "string" },
+      ]);
+
+      act(() => {
+        result.current.preserveIOSelectionOnSpecChange(initialSpec);
+      });
+
+      // Mock nodes with no selected IO nodes
+      const mockNodes = [
+        createMockNode("input-0", "input", "input1", false),
+        createMockNode("task-1", "task", "task1", true), // Only task selected
+      ];
+      mockGetNodes.mockReturnValue(mockNodes);
+
+      const newSpec = createMockComponentSpec([
+        { name: "renamed_input", type: "string" },
+      ]);
+
+      await act(async () => {
+        result.current.preserveIOSelectionOnSpecChange(newSpec);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      // Should not call setNodes since no IO nodes were selected
+      expect(mockSetNodes).not.toHaveBeenCalled();
+    });
+
+    it("should do nothing on initial spec set", () => {
+      const { result } = renderHook(() => useIOSelectionPersistence());
+
+      const newSpec = createMockComponentSpec([
+        { name: "input1", type: "string" },
+      ]);
+
+      act(() => {
+        result.current.preserveIOSelectionOnSpecChange(newSpec);
+      });
+
+      // Should not interact with ReactFlow on initial spec
+      expect(mockGetNodes).not.toHaveBeenCalled();
+      expect(mockSetNodes).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/hooks/useIOSelectionPersistence.ts
+++ b/src/hooks/useIOSelectionPersistence.ts
@@ -1,0 +1,95 @@
+import { useReactFlow } from "@xyflow/react";
+import { useCallback, useRef } from "react";
+
+import { type ComponentSpec } from "@/utils/componentSpec";
+
+export const useIOSelectionPersistence = () => {
+  const { setNodes, getNodes } = useReactFlow();
+  const prevSpecRef = useRef<ComponentSpec | null>(null);
+
+  const preserveIOSelectionOnSpecChange = useCallback(
+    (newSpec: ComponentSpec) => {
+      const prevSpec = prevSpecRef.current;
+
+      if (!prevSpec) {
+        prevSpecRef.current = newSpec;
+        return;
+      }
+
+      requestAnimationFrame(() => {
+        const currentNodes = getNodes();
+        const selectedIONodes = new Map<
+          string,
+          { type: "input" | "output"; index: number; name: string }
+        >();
+
+        currentNodes.forEach((node) => {
+          if (
+            !node.selected ||
+            (node.type !== "input" && node.type !== "output")
+          ) {
+            return;
+          }
+
+          const index = prevSpec[
+            node.type === "input" ? "inputs" : "outputs"
+          ]?.findIndex((input) => input.name === node.data.label);
+
+          if (index === undefined || index < 0) {
+            return;
+          }
+
+          selectedIONodes.set(`${node.type}-${index}`, {
+            type: node.type,
+            index,
+            name: node.data.label as string,
+          });
+        });
+
+        if (selectedIONodes.size > 0) {
+          requestAnimationFrame(() => {
+            setNodes((nodes) => {
+              return nodes.map((node) => {
+                if (node.type !== "input" && node.type !== "output") {
+                  return node;
+                }
+
+                const spec =
+                  node.type === "input" ? newSpec.inputs : newSpec.outputs;
+
+                const index = spec?.findIndex(
+                  (item) => item.name === node.data.label,
+                );
+
+                if (index === undefined || index < 0) {
+                  return node;
+                }
+
+                const selectionKey = `${node.type}-${index}`;
+                const wasSelected = selectedIONodes.has(selectionKey);
+
+                if (wasSelected) {
+                  return { ...node, selected: true };
+                }
+
+                return node;
+              });
+            });
+          });
+        }
+      });
+
+      prevSpecRef.current = newSpec;
+    },
+    [setNodes, getNodes],
+  );
+
+  const resetPrevSpec = useCallback(() => {
+    prevSpecRef.current = null;
+  }, []);
+
+  return {
+    preserveIOSelectionOnSpecChange,
+    resetPrevSpec,
+  };
+};


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Fixes an issue where IO Node Context Panel gets out of sync when using Undo-Redo with the panel open. This was occurring due to stale node selection state.

This PR works by comparing ComponentSpec changes on each ReactFlow render and looking for IO Node replacements. It then tries to preserve the selection state across that replacement. 


## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Progresses https://github.com/Shopify/oasis-frontend/issues/243

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
1. Create an input or output node
2. rename it
3. make sure the context panel for the node is still open
4. undo the rename action using the undo button or ctrl + z
5. the node should rename and stay selected and the panel should update accordingly
6. now redo the rename action and see if everything updates again as expected

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
The implemented solution is largely AI-generated and is not ideal. In future we should look to create a more stable node id system that is independent of `name`.

It is a known issue that in this PR users cannot tab from the `name` field to the next field. This is because changing the name results in a new node & context panel, so the tabbing is lost. What the user actually sees once the operation is complete is a completely different set of input fields

EDIT: this has been mitigated slightly by autofocusing the `name` field. Users will have to do a little extra tabbing for now.
