### PR TITLE
fix ComponentItemIcon to be used behind the betaflag only

### DIFF
--- a/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/components/ComponentItem.tsx
@@ -24,14 +24,20 @@ interface ComponentMarkupProps {
   error?: string | null;
 }
 
+type ComponentIconProps = {
+  component: ComponentReference;
+} & ComponentProps<typeof Icon>;
+
+const ComponentIconSkeleton = ({
+  ...iconProps
+}: Partial<ComponentIconProps>) => {
+  return (
+    <Icon name="File" className="flex-shrink-0 text-gray-400" {...iconProps} />
+  );
+};
+
 const ComponentIcon = withSuspenseWrapper(
-  ({
-    component,
-    className,
-    ...iconProps
-  }: {
-    component: ComponentReference;
-  } & ComponentProps<typeof Icon>) => {
+  ({ component, className, ...iconProps }: ComponentIconProps) => {
     const { data: outdatedComponents } = useOutdatedComponents([component]);
 
     const hasOutdatedComponents = outdatedComponents.length > 0;
@@ -41,6 +47,7 @@ const ComponentIcon = withSuspenseWrapper(
 
     return <Icon name="BookAlert" className="text-orange-500" />;
   },
+  ComponentIconSkeleton,
 );
 
 const ComponentMarkup = ({
@@ -50,6 +57,9 @@ const ComponentMarkup = ({
 }: ComponentMarkupProps) => {
   const isHighlightTasksOnComponentHoverEnabled = useBetaFlagValue(
     "highlight-node-on-component-hover",
+  );
+  const isRemoteComponentLibrarySearchEnabled = useBetaFlagValue(
+    "remote-component-library-search",
   );
 
   // TODO: respect selected node as a starting point
@@ -158,11 +168,18 @@ const ComponentMarkup = ({
             data-component-name={displayName}
           >
             <div className="flex gap-2 w-full items-center">
-              <ComponentIcon
-                name={owned ? "FileBadge" : "File"}
-                className="flex-shrink-0 text-gray-400"
-                component={component}
-              />
+              {isRemoteComponentLibrarySearchEnabled ? (
+                <ComponentIcon
+                  name={owned ? "FileBadge" : "File"}
+                  className="flex-shrink-0 text-gray-400"
+                  component={component}
+                />
+              ) : (
+                <Icon
+                  name={owned ? "FileBadge" : "File"}
+                  className="flex-shrink-0 text-gray-400"
+                />
+              )}
 
               <div
                 className="flex flex-col w-[144px]"

--- a/src/components/shared/SuspenseWrapper.tsx
+++ b/src/components/shared/SuspenseWrapper.tsx
@@ -56,14 +56,12 @@ SuspenseWrapper.displayName = "SuspenseWrapper";
  */
 export function withSuspenseWrapper<T extends ComponentType<any>>(
   Component: T,
-  Skeleton?: ComponentType<{}>,
+  Skeleton?: ComponentType<Partial<ComponentProps<T>>>,
   errorFallback?: (props: FallbackProps) => ReactNode,
 ) {
-  const SkeletonMarkup = Skeleton ? <Skeleton /> : undefined;
-
   const ComponentWithSuspense = (props: ComponentProps<T>) => (
     <SuspenseWrapper
-      fallback={SkeletonMarkup}
+      fallback={Skeleton ? <Skeleton {...props} /> : undefined}
       errorFallback={errorFallback ?? ErrorFallback}
     >
       <Component {...props} />


### PR DESCRIPTION
## Description

Enhanced the `ComponentIcon` component with a skeleton fallback and added conditional rendering based on a beta flag. The changes include:

1. Created a `ComponentIconSkeleton` component to serve as a fallback during loading
2. Improved the `withSuspenseWrapper` function to pass props to the Skeleton component
3. Added conditional rendering for component icons based on the `remote-component-library-search` beta flag

## Type of Change

- [x] Improvement
- [x] New feature

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Test Instructions

1. Enable the `remote-component-library-search` beta flag to see the ComponentIcon with outdated component detection
2. Disable the flag to see the standard icon behavior
3. Verify that the skeleton appears correctly during loading states