### PR TITLE
Improved Fetch/Backend Error Reporting

### DIFF
--- a/src/components/Home/RunSection/RunSection.tsx
+++ b/src/components/Home/RunSection/RunSection.tsx
@@ -20,6 +20,8 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { useBackend } from "@/providers/BackendProvider";
+import { getBackendStatusString } from "@/utils/backend";
+import { fetchWithErrorHandling } from "@/utils/fetchWithErrorHandling";
 
 import RunRow from "./RunRow";
 
@@ -31,7 +33,7 @@ const CREATED_BY_ME_FILTER = "created_by:me";
 type RunSectionSearch = { page_token?: string; filter?: string };
 
 export const RunSection = () => {
-  const { backendUrl, configured, available } = useBackend();
+  const { backendUrl, configured, available, ready } = useBackend();
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const search = useSearch({ strict: false }) as RunSectionSearch;
@@ -68,36 +70,23 @@ export const RunSection = () => {
   const pageToken = search.page_token;
   const [previousPageTokens, setPreviousPageTokens] = useState<string[]>([]);
 
-  const { data, isLoading, isFetching, error, refetch } =
+  const { data, isLoading, isFetching, error } =
     useQuery<ListPipelineJobsResponse>({
       queryKey: ["runs", backendUrl, pageToken, search.filter],
       refetchOnWindowFocus: false,
+      enabled: configured && available,
       queryFn: async () => {
         const u = new URL(PIPELINE_RUNS_QUERY_URL, backendUrl);
         if (pageToken) u.searchParams.set(PAGE_TOKEN_QUERY_KEY, pageToken);
         if (search.filter) u.searchParams.set(FILTER_QUERY_KEY, search.filter);
 
-        try {
-          const response = await fetch(u.toString());
-          if (!response.ok) {
-            throw new Error(
-              `Failed to fetch pipeline runs: ${response.statusText}`,
-            );
-          }
-          return response.json();
-        } catch (error) {
-          if (error instanceof Error) {
-            throw new Error(error.message);
-          } else {
-            throw new Error("An unknown error occurred");
-          }
+        if (!available) {
+          throw new Error("Backend is not available");
         }
+
+        return fetchWithErrorHandling(u.toString());
       },
     });
-
-  useEffect(() => {
-    refetch();
-  }, [backendUrl, search.filter, pageToken, refetch]);
 
   useEffect(() => {
     if (!search.page_token && search.filter === undefined) {
@@ -198,6 +187,14 @@ export const RunSection = () => {
     );
   }
 
+  if (isLoading || isFetching || !ready) {
+    return (
+      <div className="flex gap-2 items-center">
+        <Spinner /> Loading...
+      </div>
+    );
+  }
+
   if (!configured) {
     return (
       <InfoBox title="Backend not configured" variant="warning">
@@ -206,25 +203,8 @@ export const RunSection = () => {
     );
   }
 
-  if (isLoading || isFetching) {
-    return (
-      <div className="flex gap-2 items-center">
-        <Spinner /> Loading...
-      </div>
-    );
-  }
-
   if (error) {
-    const backendNotConfigured = "The backend is not configured.";
-    const backendUnavailable =
-      "The configured backend is currently unavailable.";
-    const backendAvailableString = "The configured backend is available.";
-    const backendStatusString = configured
-      ? available
-        ? backendAvailableString
-        : backendUnavailable
-      : backendNotConfigured;
-
+    const backendStatusString = getBackendStatusString(configured, available);
     return (
       <InfoBox title="Error loading runs" variant="error">
         <div className="mb-2">{error.message}</div>
@@ -234,7 +214,11 @@ export const RunSection = () => {
   }
 
   if (!data) {
-    return <div>Failed to load runs.</div>;
+    return (
+      <InfoBox title="Failed to load runs" variant="error">
+        No data was returned from the backend.
+      </InfoBox>
+    );
   }
 
   const searchMarkup = (
@@ -320,7 +304,7 @@ export const RunSection = () => {
           <Button
             variant="outline"
             onClick={handleNextPage}
-            disabled={!data?.next_page_token}
+            disabled={!data.next_page_token}
           >
             Next
             <ChevronRight className="h-4 w-4 ml-2" />

--- a/src/components/PipelineRun/RootExecutionStatusProvider.test.tsx
+++ b/src/components/PipelineRun/RootExecutionStatusProvider.test.tsx
@@ -104,6 +104,7 @@ describe("<RootExecutionStatusProvider />", () => {
     vi.mocked(useBackend).mockReturnValue({
       configured: true,
       available: true,
+      ready: true,
       backendUrl: "http://localhost:8000",
       isConfiguredFromEnv: false,
       isConfiguredFromRelativePath: false,
@@ -502,6 +503,7 @@ describe("<RootExecutionStatusProvider />", () => {
       vi.mocked(useBackend).mockReturnValue({
         configured: true,
         available: true,
+        ready: true,
         backendUrl: customBackendUrl,
         isConfiguredFromEnv: false,
         isConfiguredFromRelativePath: false,

--- a/src/components/PipelineRun/RunDetails.test.tsx
+++ b/src/components/PipelineRun/RunDetails.test.tsx
@@ -127,6 +127,7 @@ describe("<RunDetails/>", () => {
     vi.mocked(useBackend).mockReturnValue({
       configured: true,
       available: true,
+      ready: true,
       backendUrl: "http://localhost:8000",
       isConfiguredFromEnv: false,
       isConfiguredFromRelativePath: false,

--- a/src/components/PipelineRun/components/CancelPipelineRunButton.test.tsx
+++ b/src/components/PipelineRun/components/CancelPipelineRunButton.test.tsx
@@ -38,6 +38,7 @@ describe("<CancelPipelineRunButton/>", () => {
     vi.mocked(useBackend).mockReturnValue({
       configured: true,
       available: true,
+      ready: true,
       backendUrl: "http://localhost:8000",
       isConfiguredFromEnv: false,
       isConfiguredFromRelativePath: false,

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/tests/logs.test.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/tests/logs.test.tsx
@@ -15,6 +15,7 @@ describe("OpenLogsInNewWindowLink", () => {
   const defaultBackend = {
     configured: true,
     available: true,
+    ready: true,
     backendUrl: defaultBackendUrl,
     isConfiguredFromEnv: false,
     isConfiguredFromRelativePath: false,

--- a/src/providers/BackendProvider.tsx
+++ b/src/providers/BackendProvider.tsx
@@ -26,6 +26,7 @@ import {
 type BackendContextType = {
   configured: boolean;
   available: boolean;
+  ready: boolean;
   backendUrl: string;
   isConfiguredFromEnv: boolean;
   isConfiguredFromRelativePath: boolean;
@@ -51,6 +52,8 @@ export const BackendProvider = ({ children }: { children: ReactNode }) => {
   const [useEnv, setUseEnv] = useState(true);
   const [useRelativePath, setUseRelativePath] = useState(false);
   const [available, setAvailable] = useState(false);
+  const [settingsLoaded, setSettingsLoaded] = useState(false);
+  const [ready, setReady] = useState(false);
 
   let backendUrl = "";
   if (useEnv && backendUrlFromEnv) {
@@ -110,6 +113,9 @@ export const BackendProvider = ({ children }: { children: ReactNode }) => {
             else notify(`Backend unavailable: ${res.statusText}`, "error");
           }
           if (saveAvailability) setAvailable(res.ok);
+
+          setReady(true);
+
           return res.ok;
         })
         .catch(() => {
@@ -122,8 +128,10 @@ export const BackendProvider = ({ children }: { children: ReactNode }) => {
   );
 
   useEffect(() => {
-    ping({ notifyResult: false });
-  }, [backendUrl]);
+    if (settingsLoaded) {
+      ping({ notifyResult: false });
+    }
+  }, [backendUrl, settingsLoaded]);
 
   useEffect(() => {
     const getSettings = async () => {
@@ -135,6 +143,8 @@ export const BackendProvider = ({ children }: { children: ReactNode }) => {
 
       setUseEnv(envFlag === true);
       setUseRelativePath(relativeFlag === true && !backendUrlFromEnv);
+
+      setSettingsLoaded(true);
     };
     getSettings();
   }, []);
@@ -143,6 +153,7 @@ export const BackendProvider = ({ children }: { children: ReactNode }) => {
     () => ({
       configured,
       available,
+      ready,
       backendUrl,
       isConfiguredFromEnv: useEnv && !!backendUrlFromEnv,
       isConfiguredFromRelativePath: useRelativePath,
@@ -154,6 +165,7 @@ export const BackendProvider = ({ children }: { children: ReactNode }) => {
     [
       configured,
       available,
+      ready,
       backendUrl,
       useEnv,
       useRelativePath,

--- a/src/routes/PipelineRun/PipelineRun.tsx
+++ b/src/routes/PipelineRun/PipelineRun.tsx
@@ -20,7 +20,7 @@ import type { ComponentSpec } from "@/utils/componentSpec";
 const PipelineRun = () => {
   const { setComponentSpec, clearComponentSpec, componentSpec } =
     useComponentSpec();
-  const { backendUrl, configured, available } = useBackend();
+  const { backendUrl, configured, available, ready } = useBackend();
   const { id: rootExecutionId } = runDetailRoute.useParams() as RunDetailParams;
 
   const { data, isLoading, error, refetch } = useFetchExecutionInfo(
@@ -54,7 +54,7 @@ const PipelineRun = () => {
     refetch();
   }, [backendUrl, refetch]);
 
-  if (isLoading) {
+  if (isLoading || !ready) {
     return (
       <div className="flex items-center justify-center h-full w-full gap-2">
         <Spinner /> Loading Pipeline Run...
@@ -72,10 +72,22 @@ const PipelineRun = () => {
     );
   }
 
+  if (!available) {
+    return (
+      <div className="flex items-center justify-center h-full w-full">
+        <InfoBox title="Backend not available" variant="error">
+          The configured backend is not available.
+        </InfoBox>
+      </div>
+    );
+  }
+
   if (!componentSpec) {
     return (
       <div className="flex items-center justify-center h-full w-full">
-        No pipeline data available
+        <InfoBox title="Error loading pipeline run" variant="error">
+          No pipeline data available.
+        </InfoBox>
       </div>
     );
   }

--- a/src/services/executionService.ts
+++ b/src/services/executionService.ts
@@ -8,48 +8,30 @@ import type {
   GetGraphExecutionStateResponse,
 } from "@/api/types.gen";
 import type { TaskStatusCounts } from "@/types/pipelineRun";
+import { fetchWithErrorHandling } from "@/utils/fetchWithErrorHandling";
 
 export const fetchExecutionState = async (
   executionId: string,
   backendUrl: string,
 ) => {
-  const response = await fetch(
-    `${backendUrl}/api/executions/${executionId}/state`,
-  );
-  if (!response.ok) {
-    throw new Error(`Failed to fetch execution state: ${response.statusText}`);
-  }
-  return response.json();
+  const url = `${backendUrl}/api/executions/${executionId}/state`;
+  return fetchWithErrorHandling(url);
 };
 
 export const fetchExecutionDetails = async (
   executionId: string,
   backendUrl: string,
 ): Promise<GetExecutionInfoResponse> => {
-  const response = await fetch(
-    `${backendUrl}/api/executions/${executionId}/details`,
-  );
-  if (!response.ok) {
-    throw new Error(
-      `Failed to fetch execution details: ${response.statusText}`,
-    );
-  }
-  return response.json();
+  const url = `${backendUrl}/api/executions/${executionId}/details`;
+  return fetchWithErrorHandling(url);
 };
 
 const fetchContainerExecutionState = async (
   executionId: string,
   backendUrl: string,
 ): Promise<GetContainerExecutionStateResponse> => {
-  const response = await fetch(
-    `${backendUrl}/api/executions/${executionId}/container_state`,
-  );
-  if (!response.ok) {
-    throw new Error(
-      `Failed to fetch container execution state: ${response.statusText}`,
-    );
-  }
-  return response.json();
+  const url = `${backendUrl}/api/executions/${executionId}/container_state`;
+  return fetchWithErrorHandling(url);
 };
 
 export const useFetchContainerExecutionState = (
@@ -113,26 +95,14 @@ export const fetchExecutionStatus = async (
   backendUrl: string,
 ) => {
   try {
-    const response = await fetch(
-      `${backendUrl}/api/executions/${executionId}/details`,
+    const details: GetExecutionInfoResponse = await fetchExecutionDetails(
+      executionId,
+      backendUrl,
     );
-    if (!response.ok) {
-      throw new Error(
-        `Failed to fetch execution details: ${response.statusText}`,
-      );
-    }
-    const details: GetExecutionInfoResponse = await response.json();
-
-    const stateResponse = await fetch(
-      `${backendUrl}/api/executions/${executionId}/state`,
+    const stateData: GetGraphExecutionStateResponse = await fetchExecutionState(
+      executionId,
+      backendUrl,
     );
-    if (!stateResponse.ok) {
-      throw new Error(
-        `Failed to fetch execution state: ${stateResponse.statusText}`,
-      );
-    }
-    const stateData: GetGraphExecutionStateResponse =
-      await stateResponse.json();
 
     const taskStatuses = countTaskStatuses(details, stateData);
     const runStatus = getRunStatus(taskStatuses);
@@ -143,6 +113,7 @@ export const fetchExecutionStatus = async (
       `Error fetching task statuses for run ${executionId}:`,
       error,
     );
+    throw error;
   }
 };
 

--- a/src/utils/fetchWithErrorHandling.ts
+++ b/src/utils/fetchWithErrorHandling.ts
@@ -1,0 +1,35 @@
+export const fetchWithErrorHandling = async (
+  url: string,
+  options?: RequestInit,
+): Promise<any> => {
+  let response: Response;
+
+  try {
+    response = await fetch(url, options);
+  } catch (fetchError) {
+    const message =
+      fetchError instanceof Error ? fetchError.message : String(fetchError);
+    throw new Error(`Network error: ${message} (URL: ${url})`);
+  }
+
+  if (!response.ok) {
+    let errorBody = "";
+    try {
+      errorBody = await response.text();
+    } catch {
+      // Ignore if we can't read the error body
+    }
+
+    throw new Error(
+      `HTTP ${response.status} ${response.statusText}: ${errorBody || "No error details"} (URL: ${url})`,
+    );
+  }
+
+  try {
+    return await response.json();
+  } catch (parseError) {
+    const message =
+      parseError instanceof Error ? parseError.message : String(parseError);
+    throw new Error(`Invalid JSON response: ${message} (URL: ${url})`);
+  }
+};


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Adds logic for improved error reporting on Pipeline Run `fetch` requests via a new `fetchWithErrorHandling` method. Also reworks some logic to minimize the amount of requests made when the backend is not available, and improves backend loading logic to prevent unnecessary "backend unavailable" errors appearing while it is loading.

Also removes a few redundant backend-triggered refetches, as the refetch is done automatically by a changing `queryKey`

Additionally, backend availability issues in the above scenarios are now reported separately to network/fetch issues.


## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Prompted by multiple user reports of unhelpful error messages when loading/viewing runs.

Tangentially related to https://github.com/Shopify/oasis-frontend/issues/217 but not directly addressing.

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
1. mock some bad requests and try access a pipeline run or the run list
2. configure a bad backend and try the same
3. network errors for the above should no longer be caused by backend available (though will still report the status of the backend)

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
