### PR TITLE
Added task name to the component card

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
@@ -6,7 +6,9 @@ import { PublishedComponentBadge } from "@/components/shared/ManageComponent/Pub
 import { trimDigest } from "@/components/shared/ManageComponent/utils/digest";
 import { useBetaFlagValue } from "@/components/shared/Settings/useBetaFlags";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { BlockStack } from "@/components/ui/layout";
 import { QuickTooltip } from "@/components/ui/tooltip";
+import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 import { useContextPanel } from "@/providers/ContextPanelProvider";
 import { useTaskNode } from "@/providers/TaskNodeProvider";
@@ -170,18 +172,18 @@ const TaskNodeCard = () => {
       ref={nodeRef}
     >
       <CardHeader className="border-b border-slate-200 px-2 py-2.5 flex flex-row justify-between items-start">
-        <div className="flex flex-col">
+        <BlockStack>
           <CardTitle className="break-words text-left text-xs text-slate-900">
             {name}
           </CardTitle>
           {taskId &&
             taskId !== name &&
             !taskId.match(new RegExp(`^${name}\\s*\\d+$`)) && (
-              <div className="text-xs text-muted-foreground font-light">
+              <Text size="xs" tone="subdued" className="font-light">
                 {taskId}
-              </div>
+              </Text>
             )}
-        </div>
+        </BlockStack>
 
         {isRemoteComponentLibrarySearchEnabled ? (
           <PublishedComponentBadge componentRef={taskSpec.componentRef}>

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
@@ -46,7 +46,7 @@ const TaskNodeCard = () => {
   const [expandedInputs, setExpandedInputs] = useState(false);
   const [expandedOutputs, setExpandedOutputs] = useState(false);
 
-  const { name, state, callbacks, nodeId, taskSpec } = taskNode;
+  const { name, state, callbacks, nodeId, taskSpec, taskId } = taskNode;
   const { dimensions, selected, highlighted, isCustomComponent } = state;
 
   const onNotify = useCallback((message: NotifyMessage) => {
@@ -170,9 +170,18 @@ const TaskNodeCard = () => {
       ref={nodeRef}
     >
       <CardHeader className="border-b border-slate-200 px-2 py-2.5 flex flex-row justify-between items-start">
-        <CardTitle className="break-words text-left text-xs text-slate-900">
-          {name}
-        </CardTitle>
+        <div className="flex flex-col">
+          <CardTitle className="break-words text-left text-xs text-slate-900">
+            {name}
+          </CardTitle>
+          {taskId &&
+            taskId !== name &&
+            !taskId.match(new RegExp(`^${name}\\s*\\d+$`)) && (
+              <div className="text-xs text-muted-foreground font-light">
+                {taskId}
+              </div>
+            )}
+        </div>
 
         {isRemoteComponentLibrarySearchEnabled ? (
           <PublishedComponentBadge componentRef={taskSpec.componentRef}>


### PR DESCRIPTION
## Description

Added the task ID display in the TaskNodeCard component when it differs from the node name and doesn't follow the pattern of "name + number". This helps users identify tasks with custom IDs that differ from their display names.

## Related Issue and Pull requests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

![image.png](https://app.graphite.dev/user-attachments/assets/3ac1881b-4e3e-4f06-8a6e-53e97dcd253b.png)

## Test Instructions

1. Create a task with a custom ID that differs from its name or open an existing run e.g. [01993cf05ac24c9d3e90](https://oasis.shopify.io/runs/01993cf05ac24c9d3e90) (change the host to the localhost or staging)
2. Verify that the ID appears below the task name in the node card
3. Verify that IDs that match the pattern "name + number" are not displayed
4. Verify that IDs identical to the name are not displayed
