### PR TITLE
fix published component node card badge error message

### DIFF
--- a/src/components/shared/ManageComponent/PublishedComponentBadge.tsx
+++ b/src/components/shared/ManageComponent/PublishedComponentBadge.tsx
@@ -58,4 +58,10 @@ export const PublishedComponentBadge = withSuspenseWrapper(
     );
   },
   PublishedComponentBadgeSkeleton,
+  /**
+   * Show just inner part of the component when there is an error
+   */
+  ({ originalProps }) => {
+    return originalProps?.children;
+  },
 );

--- a/src/components/shared/SuspenseWrapper.tsx
+++ b/src/components/shared/SuspenseWrapper.tsx
@@ -13,12 +13,18 @@ import { Spinner } from "@/components/ui/spinner";
 
 import { InfoBox } from "./InfoBox";
 
+type ErrorFallbackProps<T extends ComponentType<any>> = FallbackProps & {
+  originalProps?: Partial<ComponentProps<T>>;
+};
+
 interface SuspenseWrapperProps {
   fallback?: ReactNode;
   errorFallback?: (props: FallbackProps) => ReactNode;
 }
 
-const ErrorFallback = ({ resetErrorBoundary }: FallbackProps) => {
+const ErrorFallback = <T extends ComponentType<any>>({
+  resetErrorBoundary,
+}: ErrorFallbackProps<T>) => {
   return (
     <InfoBox title="There was an error!" variant="error">
       <Button onClick={() => resetErrorBoundary()} variant={"ghost"} size="xs">
@@ -57,12 +63,15 @@ SuspenseWrapper.displayName = "SuspenseWrapper";
 export function withSuspenseWrapper<T extends ComponentType<any>>(
   Component: T,
   Skeleton?: ComponentType<Partial<ComponentProps<T>>>,
-  errorFallback?: (props: FallbackProps) => ReactNode,
+  errorFallback?: (props: ErrorFallbackProps<T>) => ReactNode,
 ) {
+  const ErrorFallbackComponent = errorFallback ?? ErrorFallback<T>;
   const ComponentWithSuspense = (props: ComponentProps<T>) => (
     <SuspenseWrapper
       fallback={Skeleton ? <Skeleton {...props} /> : undefined}
-      errorFallback={errorFallback ?? ErrorFallback}
+      errorFallback={(errorProps) => (
+        <ErrorFallbackComponent {...errorProps} originalProps={props} />
+      )}
     >
       <Component {...props} />
     </SuspenseWrapper>


### PR DESCRIPTION
## Description

Enhanced the error handling in `PublishedComponentBadge` by adding a custom error fallback that displays the component's children when an error occurs. This improves the user experience by showing partial content instead of a complete error state.

## Type of Change

- [x] Improvement
- [x] Bug fix

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Additional Comments

The `withSuspenseWrapper` function has been updated to pass the original component props to error fallbacks, allowing for more contextual error handling. This enables components to gracefully degrade by showing partial content when errors occur rather than completely failing.