### PR TITLE
AutoFocus ConfirmationDialog Continue Button

### DIFF
--- a/src/components/shared/Dialogs/ConfirmationDialog.tsx
+++ b/src/components/shared/Dialogs/ConfirmationDialog.tsx
@@ -1,4 +1,4 @@
-import type { MouseEvent, ReactNode } from "react";
+import { type MouseEvent, type ReactNode, useCallback } from "react";
 
 import {
   AlertDialog,
@@ -35,19 +35,25 @@ const ConfirmationDialog = ({
   onConfirm,
   onCancel = () => {},
 }: ConfirmationDialogProps) => {
-  const handleClick = (e: MouseEvent) => {
+  const handleClick = useCallback((e: MouseEvent) => {
     e.stopPropagation();
-  };
+  }, []);
 
-  const handleConfirm = (e: MouseEvent) => {
-    e.stopPropagation();
-    onConfirm();
-  };
+  const handleConfirm = useCallback(
+    (e: MouseEvent) => {
+      e.stopPropagation();
+      onConfirm();
+    },
+    [onConfirm],
+  );
 
-  const handleCancel = (e: MouseEvent) => {
-    e.stopPropagation();
-    onCancel();
-  };
+  const handleCancel = useCallback(
+    (e: MouseEvent) => {
+      e.stopPropagation();
+      onCancel();
+    },
+    [onCancel],
+  );
 
   return (
     <AlertDialog open={isOpen}>
@@ -60,7 +66,7 @@ const ConfirmationDialog = ({
           {trigger}
         </AlertDialogTrigger>
       )}
-      <AlertDialogContent className="z-[9999]">
+      <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>{title}</AlertDialogTitle>
           <AlertDialogDescription>{description}</AlertDialogDescription>
@@ -68,7 +74,7 @@ const ConfirmationDialog = ({
         {content}
         <AlertDialogFooter>
           <AlertDialogCancel onClick={handleCancel}>Cancel</AlertDialogCancel>
-          <AlertDialogAction onClick={handleConfirm}>
+          <AlertDialogAction onClick={handleConfirm} autoFocus>
             Continue
           </AlertDialogAction>
         </AlertDialogFooter>


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

Selection will now be on "continue" / confirm button, not cancel.

Also added `useCallback` to the component

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Closes https://github.com/Shopify/oasis-frontend/issues/255

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
