### PR TITLE
Open new runs in a new tab when beta is active

### DIFF
--- a/src/betaFlags.ts
+++ b/src/betaFlags.ts
@@ -16,8 +16,7 @@ export const ExistingBetaFlags = {
 
   ["redirect-on-new-pipeline-run"]: {
     name: "Redirect on new pipeline run",
-    description:
-      "Automatically redirect from the editor to the pipeline run page after starting a new execution.",
+    description: "Automatically open a new tab after starting a new execution.",
     default: false,
   } as BetaFlag,
 

--- a/src/components/shared/Submitters/Oasis/OasisSubmitter.tsx
+++ b/src/components/shared/Submitters/Oasis/OasisSubmitter.tsx
@@ -41,9 +41,12 @@ const OasisSubmitter = ({
   );
 
   const handleViewRun = useCallback(
-    (runId: number) => {
-      if (runId) {
-        navigate({ to: `${APP_ROUTES.RUNS}/${runId}` });
+    (runId: number, newTab = false) => {
+      const href = `${APP_ROUTES.RUNS}/${runId}`;
+      if (newTab) {
+        window.open(href, "_blank");
+      } else {
+        navigate({ to: href });
       }
     },
     [navigate],
@@ -58,11 +61,9 @@ const OasisSubmitter = ({
               Pipeline successfully submitted
             </span>
           </div>
-          {!isAutoRedirect && (
-            <Button onClick={() => handleViewRun(runId)} className="w-full">
-              View Run
-            </Button>
-          )}
+          <Button onClick={() => handleViewRun(runId)} className="w-full">
+            View Run
+          </Button>
         </div>
       );
       notify(<SuccessComponent />, "success");
@@ -78,7 +79,7 @@ const OasisSubmitter = ({
       showSuccessNotification(response.root_execution_id);
 
       if (isAutoRedirect) {
-        handleViewRun(response.root_execution_id);
+        handleViewRun(response.root_execution_id, true);
       }
     },
     [


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

User-requested. If the beta is active, new runs will open in a new tab. Restored the existing "view run" button in the toast for when a tab is created, in case the user switches back.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Closes https://github.com/Shopify/oasis-frontend/issues/252

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
