### PR TITLE
Fix outdated ReactFlowInstance in useNodeCallbacks

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/FlowCanvas.tsx
@@ -266,7 +266,6 @@ const FlowCanvas = ({
   );
 
   const nodeCallbacks = useNodeCallbacks({
-    reactFlowInstance,
     triggerConfirmation,
     onElementsRemove,
     updateOrAddNodes,

--- a/src/hooks/useNodeCallbacks.ts
+++ b/src/hooks/useNodeCallbacks.ts
@@ -1,4 +1,4 @@
-import type { Node, ReactFlowInstance } from "@xyflow/react";
+import { type Node, useReactFlow } from "@xyflow/react";
 import { useCallback } from "react";
 
 import { getDeleteConfirmationDetails } from "@/components/shared/ReactFlow/FlowCanvas/ConfirmationDialogs/DeleteConfirmation";
@@ -18,7 +18,6 @@ import type { TriggerDialogProps } from "./useConfirmationDialog";
 import useToastNotification from "./useToastNotification";
 
 interface UseNodeCallbacksProps {
-  reactFlowInstance: ReactFlowInstance | undefined;
   triggerConfirmation: (data: TriggerDialogProps) => Promise<boolean>;
   onElementsRemove: (params: NodesAndEdges) => void;
   updateOrAddNodes: (params: {
@@ -28,12 +27,12 @@ interface UseNodeCallbacksProps {
 }
 
 export const useNodeCallbacks = ({
-  reactFlowInstance,
   triggerConfirmation,
   onElementsRemove,
   updateOrAddNodes,
 }: UseNodeCallbacksProps) => {
   const notify = useToastNotification();
+  const reactFlowInstance = useReactFlow();
 
   const { graphSpec, updateGraphSpec, componentSpec, setComponentSpec } =
     useComponentSpec();


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Closes https://github.com/Shopify/oasis-frontend/issues/258

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
