### PR TITLE
Fix flakey async test

### DIFF
--- a/src/components/PipelineRun/components/RerunPipelineButton.test.tsx
+++ b/src/components/PipelineRun/components/RerunPipelineButton.test.tsx
@@ -12,10 +12,24 @@ import { PipelineRunsProvider } from "@/providers/PipelineRunsProvider";
 
 import { RerunPipelineButton } from "./RerunPipelineButton";
 
+const testOrigin = import.meta.env.VITE_BASE_URL || "http://localhost:3000";
+
+Object.defineProperty(window, "location", {
+  value: {
+    origin: testOrigin,
+  },
+  writable: true,
+});
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+const mockSubmit = vi.fn();
+
 vi.mock("@/providers/PipelineRunsProvider", async (importOriginal) => ({
   ...(await importOriginal()),
   usePipelineRuns: vi.fn(() => ({
-    submit: vi.fn(),
+    submit: mockSubmit,
     isSubmitting: false,
     runs: [],
     latestRun: null,
@@ -45,29 +59,107 @@ describe("<RerunPipelineButton/>", () => {
         <PipelineRunsProvider pipelineName="Test Pipeline">
           {ui}
         </PipelineRunsProvider>
-        ,
       </BackendProvider>,
     );
 
   beforeEach(() => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      statusText: "Not Found",
+    });
+
     navigateMock.mockClear();
     notifyMock.mockClear();
+    mockSubmit.mockClear();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    vi.clearAllMocks();
+
     cleanup();
-    return new Promise((resolve) => setTimeout(resolve, 0));
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
   });
 
-  test("renders rerun button", () => {
-    renderWithProvider(<RerunPipelineButton componentSpec={componentSpec} />);
+  test("renders rerun button", async () => {
+    await act(async () => {
+      renderWithProvider(<RerunPipelineButton componentSpec={componentSpec} />);
+    });
+
     expect(screen.getByTestId("rerun-pipeline-button")).toBeInTheDocument();
   });
 
-  test("calls submit on click", () => {
-    renderWithProvider(<RerunPipelineButton componentSpec={componentSpec} />);
+  test("calls submit on click", async () => {
+    await act(async () => {
+      renderWithProvider(<RerunPipelineButton componentSpec={componentSpec} />);
+    });
+
     const rerunButton = screen.getByTestId("rerun-pipeline-button");
-    act(() => fireEvent.click(rerunButton));
+
+    await act(async () => {
+      fireEvent.click(rerunButton);
+    });
+
+    expect(mockSubmit).toHaveBeenCalledWith(
+      componentSpec,
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      }),
+    );
     expect(rerunButton).not.toBeDisabled();
+  });
+
+  test("handles successful rerun", async () => {
+    await act(async () => {
+      renderWithProvider(<RerunPipelineButton componentSpec={componentSpec} />);
+    });
+
+    const rerunButton = screen.getByTestId("rerun-pipeline-button");
+
+    await act(async () => {
+      fireEvent.click(rerunButton);
+    });
+
+    const submitCall = mockSubmit.mock.calls[0];
+    const { onSuccess } = submitCall[1];
+
+    const mockPipelineRun = { root_execution_id: 123 };
+
+    await act(async () => {
+      onSuccess(mockPipelineRun);
+    });
+
+    expect(navigateMock).toHaveBeenCalledWith({
+      to: "/runs/123",
+    });
+  });
+
+  test("handles rerun error", async () => {
+    await act(async () => {
+      renderWithProvider(<RerunPipelineButton componentSpec={componentSpec} />);
+    });
+
+    const rerunButton = screen.getByTestId("rerun-pipeline-button");
+
+    await act(async () => {
+      fireEvent.click(rerunButton);
+    });
+
+    const submitCall = mockSubmit.mock.calls[0];
+    const { onError } = submitCall[1];
+
+    const testError = new Error("Test error");
+
+    await act(async () => {
+      onError(testError);
+    });
+
+    expect(notifyMock).toHaveBeenCalledWith(
+      "Failed to submit pipeline. Test error",
+      "error",
+    );
   });
 });


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->

When running tests we often end up with a cleanup error occurring in `PipelineRunButton.test.tsx`

This PR aims to resolve that.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

Closes https://github.com/Shopify/oasis-frontend/issues/268

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
Tests should all pass without any errors

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
