### PR TITLE
Change favicon to match PipelineRun status

### DIFF
--- a/src/favicon.ts
+++ b/src/favicon.ts
@@ -1,0 +1,32 @@
+class FaviconManager {
+  private defaultFavicon = "/favicon.ico";
+  private statusIcons = {
+    success: "/favicon-success.ico",
+    failed: "/favicon-failed.ico",
+    loading: "/favicon-loading.ico",
+    paused: "/favicon-paused.ico",
+  };
+
+  updateFavicon(
+    status: "success" | "failed" | "loading" | "paused" | "default",
+  ) {
+    const link =
+      (document.querySelector("link[rel*='icon']") as HTMLLinkElement) ||
+      document.createElement("link");
+
+    link.type = "image/x-icon";
+    link.rel = "shortcut icon";
+    link.href =
+      status === "default" ? this.defaultFavicon : this.statusIcons[status];
+
+    if (!document.querySelector("link[rel*='icon']")) {
+      document.getElementsByTagName("head")[0].appendChild(link);
+    }
+  }
+
+  reset() {
+    this.updateFavicon("default");
+  }
+}
+
+export const faviconManager = new FaviconManager();


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
favicon will now update to match run status in that tab.

Icon will revert to default if not on a run route.

Icons will only update if the tab is open -- I will explore streaming/realtime updates separately.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Closes https://github.com/Shopify/oasis-frontend/issues/253

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Improvement

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

Running pipeline (left), old icon (right)
![image.png](https://app.graphite.dev/user-attachments/assets/84654c0a-6b19-4145-b52b-fbd73da3613f.png)

Failed pipeline
![image.png](https://app.graphite.dev/user-attachments/assets/dd313ba3-7028-45b4-9fb4-92c60ca25b63.png)

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
