### PR TITLE
rm scrollbar in autosave message

### DIFF
--- a/src/components/shared/ReactFlow/FlowSidebar/sections/FileActions.tsx
+++ b/src/components/shared/ReactFlow/FlowSidebar/sections/FileActions.tsx
@@ -111,7 +111,11 @@ const FileActions = ({ isOpen }: { isOpen: boolean }) => {
     <SidebarGroup>
       <SidebarGroupLabel>Pipeline Actions</SidebarGroupLabel>
       <SidebarContent>
-        <InlineStack blockAlign="center" className="ml-2" gap="1">
+        <InlineStack
+          blockAlign="center"
+          className="ml-2 overflow-y-hidden"
+          gap="1"
+        >
           {autoSaveStatus.isSaving && <Spinner size={16} />}
           <span className="text-xs text-muted-foreground">
             {getAutoSaveStatusText()}


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Fix an issue where the "saving..." message + spinner while autosave would have a tiny scrollbar.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->
Before:
<img width="250" height="83" alt="image" src="https://github.com/user-attachments/assets/9cbbdcfe-423c-45d5-a564-9085eb8e4ec6" />


After:
<img width="248" height="71" alt="image" src="https://github.com/user-attachments/assets/33b2a062-4a6e-4cdb-a0b5-316033d6ce48" />


## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
