### PR TITLE
Fix Radio Button misplaced circle

### DIFF
--- a/src/components/ui/radiogroup.tsx
+++ b/src/components/ui/radiogroup.tsx
@@ -34,7 +34,10 @@ const RadioGroupItem = forwardRef<
       {...props}
     >
       <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
-        <Icon name="Circle" className="h-1.5 w-1.5 fill-current text-current" />
+        <Icon
+          name="Circle"
+          className="!h-1.5 w-1.5 fill-current text-current"
+        />
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>
   );


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Height was not applying to the `Icon` component. We may want to investigate that component further since it seems to be struggling to apply all inherent styling.

"selected" dot is now back inside the circle

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Closes https://github.com/Shopify/oasis-frontend/issues/267

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->
<img width="204" height="157" alt="image" src="https://github.com/user-attachments/assets/550b0969-2d9f-4b7f-8b32-f23c6d2dec19" />


## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
