### PR TITLE
read only prop for code viwer

### DIFF
--- a/src/components/shared/CodeViewer/CodeSyntaxHighlighter.tsx
+++ b/src/components/shared/CodeViewer/CodeSyntaxHighlighter.tsx
@@ -4,11 +4,13 @@ import { memo } from "react";
 interface CodeSyntaxHighlighterProps {
   code: string;
   language: string;
+  readOnly?: boolean;
 }
 
 const CodeSyntaxHighlighter = memo(function CodeSyntaxHighlighter({
   code,
   language,
+  readOnly = true,
 }: CodeSyntaxHighlighterProps) {
   return (
     <MonacoEditor
@@ -17,7 +19,7 @@ const CodeSyntaxHighlighter = memo(function CodeSyntaxHighlighter({
       theme="vs-dark"
       defaultValue={code}
       options={{
-        readOnly: true,
+        readOnly: readOnly,
         minimap: {
           enabled: false,
         },

--- a/src/components/shared/CodeViewer/CodeViewer.tsx
+++ b/src/components/shared/CodeViewer/CodeViewer.tsx
@@ -11,6 +11,7 @@ interface CodeViewerProps {
   language?: string;
   title?: string;
   filename?: string;
+  readOnly?: boolean;
 }
 
 const DEFAULT_HEIGHT = 128;
@@ -19,6 +20,7 @@ const CodeViewer = ({
   code,
   language = "yaml",
   filename = "",
+  readOnly = true,
 }: CodeViewerProps) => {
   const [isFullscreen, setIsFullscreen] = useState(false);
 
@@ -68,7 +70,7 @@ const CodeViewer = ({
             className="absolute inset-0 overflow-y-auto bg-slate-900"
             style={{ willChange: "transform", minHeight: DEFAULT_HEIGHT }}
           >
-            <CodeSyntaxHighlighter code={code} language={language} />
+            <CodeSyntaxHighlighter code={code} language={language} readOnly={readOnly} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description

Added a `readOnly` prop to the `CodeViewer` and `CodeSyntaxHighlighter` components to allow for editable code blocks. The prop defaults to `true` to maintain backward compatibility with existing usage.

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Test Instructions

1. Import and use the `CodeViewer` component with `readOnly={false}` to create an editable code block
2. Verify that the Monaco editor allows editing when `readOnly` is set to false
3. Confirm that existing code blocks remain read-only by default