### PR TITLE
Hide Inspect Button if Pipeline does not exist in Storage

### DIFF
--- a/src/components/PipelineRun/RunDetails.tsx
+++ b/src/components/PipelineRun/RunDetails.tsx
@@ -2,6 +2,7 @@ import { Frown, Videotape } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { Spinner } from "@/components/ui/spinner";
+import { useLoadComponentSpecFromPath } from "@/hooks/useLoadComponentSpecFromPath";
 import { useBackend } from "@/providers/BackendProvider";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import {
@@ -23,12 +24,18 @@ import { RerunPipelineButton } from "./components/RerunPipelineButton";
 import { useRootExecutionContext } from "./RootExecutionStatusProvider";
 
 export const RunDetails = () => {
+  const { configured, backendUrl } = useBackend();
+  const { componentSpec } = useComponentSpec();
   const { details, state, runId, isLoading, error } = useRootExecutionContext();
 
-  const { configured } = useBackend();
+  const editorRoute = `/editor/${componentSpec.name}`;
+
+  const { error: loadEditorError, isLoading: isLoadingEditor } =
+    useLoadComponentSpecFromPath(backendUrl, editorRoute, !componentSpec.name);
+
+  const hideInspectButton = !!isLoadingEditor || !!loadEditorError;
 
   const [metadata, setMetadata] = useState<PipelineRun | null>(null);
-  const { componentSpec } = useComponentSpec();
 
   useEffect(() => {
     const fetchData = async () => {
@@ -130,7 +137,9 @@ export const RunDetails = () => {
 
       <div>
         <div className="flex gap-2">
-          <InspectPipelineButton pipelineName={componentSpec.name} />
+          {!hideInspectButton && (
+            <InspectPipelineButton pipelineName={componentSpec.name} />
+          )}
           <ClonePipelineButton componentSpec={componentSpec} />
           {isInProgress && <CancelPipelineRunButton runId={runId} />}
           {isComplete && <RerunPipelineButton componentSpec={componentSpec} />}


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Hides the "Inspect Pipeline" button from the run details if the user does not have the associated pipeline stored in local storage (i.e. if they do not have access to the editor route for that pipeline).

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Noted by @Zruty0 in Slack.

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->
<img width="332" height="229" alt="image" src="https://github.com/user-attachments/assets/9230e377-fe77-4531-ab47-504101782076" />


## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
1. Create a pipeline
2. Run the pipeline
3. Inspect button should be present on the run
4. Go to pipeline list & delete the pipeline
5. Revisit the run
6. Inspect button should no longer be visible

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
