### PR TITLE
add_icon_next_to_subgraph tasknode

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
@@ -6,12 +6,14 @@ import { PublishedComponentBadge } from "@/components/shared/ManageComponent/Pub
 import { trimDigest } from "@/components/shared/ManageComponent/utils/digest";
 import { useBetaFlagValue } from "@/components/shared/Settings/useBetaFlags";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Icon } from "@/components/ui/icon";
 import { BlockStack } from "@/components/ui/layout";
 import { QuickTooltip } from "@/components/ui/tooltip";
 import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 import { useContextPanel } from "@/providers/ContextPanelProvider";
 import { useTaskNode } from "@/providers/TaskNodeProvider";
+import { isGraphImplementation } from "@/utils/componentSpec";
 
 import {
   type NotifyMessage,
@@ -50,6 +52,7 @@ const TaskNodeCard = () => {
 
   const { name, state, callbacks, nodeId, taskSpec, taskId } = taskNode;
   const { dimensions, selected, highlighted, isCustomComponent } = state;
+  const implementation = taskSpec.componentRef.spec?.implementation;
 
   const onNotify = useCallback((message: NotifyMessage) => {
     switch (message.type) {
@@ -157,6 +160,9 @@ const TaskNodeCard = () => {
     </QuickTooltip>
   );
 
+
+  const isGraph = implementation ? isGraphImplementation(implementation) : false;
+
   return (
     <Card
       className={cn(
@@ -173,8 +179,8 @@ const TaskNodeCard = () => {
     >
       <CardHeader className="border-b border-slate-200 px-2 py-2.5 flex flex-row justify-between items-start">
         <BlockStack>
-          <CardTitle className="break-words text-left text-xs text-slate-900">
-            {name}
+          <CardTitle className="break-words text-left text-xs text-slate-900 flex gap-2">
+            {isGraph && <Icon name="Workflow" size="md" />} {name}
           </CardTitle>
           {taskId &&
             taskId !== name &&


### PR DESCRIPTION
## Description

Added a graph icon to task nodes that represent graph implementations. This visual indicator helps users distinguish between graph implementations and other types of components in the flow canvas.

## Type of Change

- [x] Improvement
- [x] New feature

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Screenshots (if applicable)

*Task nodes with graph implementations now display a workflow icon next to their name*

## Test Instructions

1. Create or open a flow with graph implementation components
2. Verify that graph implementation nodes display the workflow icon next to their name
3. Confirm that non-graph implementation nodes do not show the icon

![Screenshot 2025-09-25 at 1.17.24 PM.png](https://app.graphite.dev/user-attachments/assets/4e76d98c-f7b7-47c8-ac4d-0cfa9dc8b390.png)

