### PR TITLE
adds_view_subgraph_button_placeholder

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/TaskConfiguration.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/TaskConfiguration.tsx
@@ -27,12 +27,12 @@ import IOSection from "./IOSection/IOSection";
 import Logs, { OpenLogsInNewWindowLink } from "./logs";
 import OutputsList from "./OutputsList";
 
-interface ButtonPropsWithTooltip extends ButtonProps {
+export interface TaskConfigurationAction extends ButtonProps {
   tooltip?: string;
 }
 interface TaskConfigurationProps {
   taskNode: TaskNodeContextType;
-  actions?: ButtonPropsWithTooltip[];
+  actions?: TaskConfigurationAction[];
 }
 
 const TaskConfiguration = ({ taskNode, actions }: TaskConfigurationProps) => {

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/index.ts
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./TaskConfiguration";
+export { default, type TaskConfigurationAction } from "./TaskConfiguration";

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeCard.tsx
@@ -20,7 +20,9 @@ import {
   type UpdateOverlayMessage,
   useNodesOverlay,
 } from "../../../NodesOverlay/NodesOverlayProvider";
-import TaskConfiguration from "../TaskConfiguration";
+import TaskConfiguration, {
+  type TaskConfigurationAction,
+} from "../TaskConfiguration";
 import { TaskNodeInputs } from "./TaskNodeInputs";
 import { TaskNodeOutputs } from "./TaskNodeOutputs";
 import { UpgradeNodePopover } from "./UpgradeNodePopover";
@@ -53,6 +55,13 @@ const TaskNodeCard = () => {
   const { name, state, callbacks, nodeId, taskSpec, taskId } = taskNode;
   const { dimensions, selected, highlighted, isCustomComponent } = state;
   const implementation = taskSpec.componentRef.spec?.implementation;
+  const isGraph = implementation
+    ? isGraphImplementation(implementation)
+    : false;
+
+  const onOpenGraph = () => {
+    console.log("onOpenGraph");
+  };
 
   const onNotify = useCallback((message: NotifyMessage) => {
     switch (message.type) {
@@ -92,29 +101,43 @@ const TaskNodeCard = () => {
       <TaskConfiguration
         taskNode={taskNode}
         key={nodeId}
-        actions={[
-          {
-            children: (
-              <div className="flex items-center gap-2">
-                <CopyIcon />
-              </div>
-            ),
-            variant: "secondary",
-            tooltip: "Duplicate Task",
-            onClick: callbacks.onDuplicate,
-          },
-          {
-            children: (
-              <div className="flex items-center gap-2">
-                <CircleFadingArrowUp />
-              </div>
-            ),
-            variant: "secondary",
-            className: cn(isCustomComponent && "hidden"),
-            tooltip: "Update Task from Source URL",
-            onClick: callbacks.onUpgrade,
-          },
-        ]}
+        actions={
+          [
+            {
+              children: (
+                <div className="flex items-center gap-2">
+                  <CopyIcon />
+                </div>
+              ),
+              variant: "secondary",
+              tooltip: "Duplicate Task",
+              onClick: callbacks.onDuplicate,
+            },
+            {
+              children: (
+                <div className="flex items-center gap-2">
+                  <CircleFadingArrowUp />
+                </div>
+              ),
+              variant: "secondary",
+              className: cn(isCustomComponent && "hidden"),
+              tooltip: "Update Task from Source URL",
+              onClick: callbacks.onUpgrade,
+            },
+            isGraph
+              ? {
+                children: (
+                  <div className="flex items-center gap-2">
+                    <Icon name="Workflow" size="md" />
+                  </div>
+                ),
+                variant: "secondary",
+                tooltip: "View Subgraph",
+                onClick: onOpenGraph,
+              }
+              : null,
+          ].filter(Boolean) as TaskConfigurationAction[]
+        }
       />
     ),
     [nodeId, callbacks.onDuplicate, callbacks.onUpgrade, isCustomComponent],
@@ -159,9 +182,6 @@ const TaskNodeCard = () => {
       </div>
     </QuickTooltip>
   );
-
-
-  const isGraph = implementation ? isGraphImplementation(implementation) : false;
 
   return (
     <Card


### PR DESCRIPTION
## Description

Added a "View Subgraph" button to task nodes that have graph implementations. This allows users to navigate directly to subgraphs from the task configuration panel.

## Type of Change

- [x] New feature
- [x] Improvement

## Checklist

- [x] I have tested this does not break current pipelines / runs functionality
- [x] I have tested the changes on staging

## Technical Details

- Renamed `ButtonPropsWithTooltip` to `TaskConfigurationAction` and exported the type
- Added a conditional button that appears only for tasks with graph implementations
- Implemented initial `onOpenGraph` handler (currently just logs to console)
- Refactored the actions array to filter out null values for cleaner conditional rendering

## Test Instructions

1. Open a workflow that contains a task with a graph implementation
2. Select the task node
3. Verify that a "View Subgraph" button appears in the task configuration panel
4. Click the button and confirm the console log appears (full functionality to be implemented in a future PR)

Subgraph
![Screenshot 2025-09-25 at 2.55.11 PM.png](https://app.graphite.dev/user-attachments/assets/5deaa40a-bce0-4da0-bbf4-c4a71e933a8b.png)

No subgraph
![Screenshot 2025-09-25 at 2.55.27 PM.png](https://app.graphite.dev/user-attachments/assets/014da5b4-3a1e-499b-addc-efc73029b721.png)

