### PR TITLE
Resolve Issues with useLoadComponentSpecFromPath making permanent changes when checking a url

### DIFF
--- a/src/components/PipelineRun/RunDetails.tsx
+++ b/src/components/PipelineRun/RunDetails.tsx
@@ -2,7 +2,7 @@ import { Frown, Videotape } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { Spinner } from "@/components/ui/spinner";
-import { useLoadComponentSpecFromPath } from "@/hooks/useLoadComponentSpecFromPath";
+import { useCheckComponentSpecFromPath } from "@/hooks/useCheckComponentSpecFromPath";
 import { useBackend } from "@/providers/BackendProvider";
 import { useComponentSpec } from "@/providers/ComponentSpecProvider";
 import {
@@ -24,16 +24,16 @@ import { RerunPipelineButton } from "./components/RerunPipelineButton";
 import { useRootExecutionContext } from "./RootExecutionStatusProvider";
 
 export const RunDetails = () => {
-  const { configured, backendUrl } = useBackend();
+  const { configured } = useBackend();
   const { componentSpec } = useComponentSpec();
   const { details, state, runId, isLoading, error } = useRootExecutionContext();
 
   const editorRoute = `/editor/${componentSpec.name}`;
 
-  const { error: loadEditorError, isLoading: isLoadingEditor } =
-    useLoadComponentSpecFromPath(backendUrl, editorRoute, !componentSpec.name);
-
-  const hideInspectButton = !!isLoadingEditor || !!loadEditorError;
+  const canAccessEditorSpec = useCheckComponentSpecFromPath(
+    editorRoute,
+    !componentSpec.name,
+  );
 
   const [metadata, setMetadata] = useState<PipelineRun | null>(null);
 
@@ -137,7 +137,7 @@ export const RunDetails = () => {
 
       <div>
         <div className="flex gap-2">
-          {!hideInspectButton && (
+          {canAccessEditorSpec && (
             <InspectPipelineButton pipelineName={componentSpec.name} />
           )}
           <ClonePipelineButton componentSpec={componentSpec} />

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/TaskConfiguration.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskConfiguration/TaskConfiguration.tsx
@@ -50,6 +50,8 @@ const TaskConfiguration = ({ taskNode, actions }: TaskConfigurationProps) => {
     return null;
   }
 
+  const executionId = taskSpec.annotations?.executionId as string | undefined;
+
   return (
     <div
       className="flex flex-col h-full"
@@ -92,7 +94,7 @@ const TaskConfiguration = ({ taskNode, actions }: TaskConfigurationProps) => {
           <TabsContent value="details" className="h-full">
             <TaskDetails
               displayName={name}
-              executionId={taskSpec.annotations?.executionId as string}
+              executionId={executionId}
               componentSpec={componentSpec}
               taskId={taskId}
               componentDigest={taskSpec.componentRef.digest}
@@ -142,22 +144,21 @@ const TaskConfiguration = ({ taskNode, actions }: TaskConfigurationProps) => {
               <IOSection
                 taskSpec={taskSpec}
                 readOnly={readOnly}
-                executionId={taskSpec.annotations?.executionId as string}
+                executionId={executionId}
               />
             )}
           </TabsContent>
           {readOnly && (
             <TabsContent value="logs" className="h-full">
-              <div className="flex w-full justify-end pr-4">
-                <OpenLogsInNewWindowLink
-                  executionId={taskSpec.annotations?.executionId as string}
-                  status={runStatus}
-                />
-              </div>
-              <Logs
-                executionId={taskSpec.annotations?.executionId as string}
-                status={runStatus}
-              />
+              {!!executionId && (
+                <div className="flex w-full justify-end pr-4">
+                  <OpenLogsInNewWindowLink
+                    executionId={executionId}
+                    status={runStatus}
+                  />
+                </div>
+              )}
+              <Logs executionId={executionId} status={runStatus} />
             </TabsContent>
           )}
           {!readOnly && (

--- a/src/hooks/useCheckComponentSpecFromPath.ts
+++ b/src/hooks/useCheckComponentSpecFromPath.ts
@@ -1,0 +1,27 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+import { RUNS_BASE_PATH } from "@/routes/router";
+import { loadPipelineByName } from "@/services/pipelineService";
+import { getIdOrTitleFromPath } from "@/utils/URL";
+
+export const useCheckComponentSpecFromPath = (
+  url: string,
+  disabled: boolean = false,
+) => {
+  const isRunPath = url.includes(RUNS_BASE_PATH);
+
+  const { title } = useMemo(() => getIdOrTitleFromPath(url), [url]);
+
+  const { data: existsLocal } = useQuery({
+    queryKey: ["component-spec-local", url],
+    queryFn: async () =>
+      loadPipelineByName(title as string).then(
+        (result) => !!result.experiment?.componentRef?.spec,
+      ),
+    enabled: !disabled && !isRunPath && !!title,
+    staleTime: 1000 * 60 * 60 * 24,
+  });
+
+  return existsLocal ?? false;
+};

--- a/src/routes/Editor/Editor.tsx
+++ b/src/routes/Editor/Editor.tsx
@@ -8,11 +8,9 @@ import { InfoBox } from "@/components/shared/InfoBox";
 import { BlockStack } from "@/components/ui/layout";
 import { Text } from "@/components/ui/typography";
 import { useLoadComponentSpecFromPath } from "@/hooks/useLoadComponentSpecFromPath";
-import { useBackend } from "@/providers/BackendProvider";
 
 const Editor = () => {
-  const { backendUrl } = useBackend();
-  const { componentSpec, error } = useLoadComponentSpecFromPath(backendUrl);
+  const { componentSpec, error } = useLoadComponentSpecFromPath();
 
   if (error) {
     return (

--- a/src/routes/PipelineRun/PipelineRun.test.tsx
+++ b/src/routes/PipelineRun/PipelineRun.test.tsx
@@ -1,0 +1,299 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type {
+  ComponentSpecOutput,
+  GetExecutionInfoResponse,
+  GetGraphExecutionStateResponse,
+} from "@/api/types.gen";
+import { ComponentSpecProvider } from "@/providers/ComponentSpecProvider";
+import * as executionService from "@/services/executionService";
+
+import PipelineRun from "./PipelineRun";
+
+// Mock the router and other dependencies
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  return {
+    ...(await importOriginal()),
+    useNavigate: () => vi.fn(),
+    useLocation: () => ({
+      pathname: "/runs/test-run-id-123",
+      search: {},
+      hash: "",
+      href: "/runs/test-run-id-123",
+      state: {},
+    }),
+  };
+});
+
+vi.mock("@/routes/router", () => ({
+  runDetailRoute: {
+    useParams: () => ({ id: "test-run-id-123" }),
+  },
+  RUNS_BASE_PATH: "/runs",
+}));
+
+vi.mock("@/providers/BackendProvider", () => ({
+  useBackend: () => ({
+    backendUrl: "http://localhost:8000",
+    configured: true,
+    available: true,
+    ready: true,
+    isConfiguredFromEnv: false,
+    isConfiguredFromRelativePath: false,
+    setEnvConfig: vi.fn(),
+    setRelativePathConfig: vi.fn(),
+    setBackendUrl: vi.fn(),
+    ping: vi.fn(),
+  }),
+}));
+
+vi.mock("@/services/executionService", () => ({
+  useFetchExecutionInfo: vi.fn(),
+  useFetchPipelineRun: () => ({
+    data: null,
+    isLoading: false,
+    error: null,
+    isFetching: false,
+    refetch: () => {},
+    enabled: false,
+  }),
+  countTaskStatuses: vi.fn(),
+  getRunStatus: vi.fn(),
+  STATUS: {
+    SUCCEEDED: "SUCCEEDED",
+    FAILED: "FAILED",
+    RUNNING: "RUNNING",
+    WAITING: "WAITING",
+    CANCELLED: "CANCELLED",
+    UNKNOWN: "UNKNOWN",
+  },
+}));
+
+const mockUseComponentSpec = vi.fn();
+vi.mock("@/providers/ComponentSpecProvider", async (importOriginal) => {
+  const actual = (await importOriginal()) as object;
+  return {
+    ...actual,
+    useComponentSpec: () => mockUseComponentSpec(),
+  };
+});
+
+vi.mock("@/hooks/useDocumentTitle", () => ({
+  useDocumentTitle: () => {},
+}));
+
+vi.mock("@/hooks/useFavicon", () => ({
+  useFavicon: () => {},
+}));
+
+describe("<PipelineRun/>", () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  const mockComponentSpec: ComponentSpecOutput = {
+    name: "Test Pipeline",
+    description: "Test pipeline description",
+    inputs: [],
+    outputs: [],
+    metadata: {
+      annotations: undefined,
+    },
+    implementation: {
+      graph: {
+        tasks: {
+          "task-1": {
+            componentRef: {
+              spec: {
+                name: "Task 1",
+                inputs: [],
+                outputs: [],
+                metadata: {
+                  annotations: undefined,
+                },
+                implementation: {
+                  container: {
+                    image: "test-image",
+                    command: ["test-command"],
+                  },
+                },
+              },
+            },
+          },
+          "task-2": {
+            componentRef: {
+              spec: {
+                name: "Task 2",
+                inputs: [],
+                outputs: [],
+                metadata: {
+                  annotations: undefined,
+                },
+                implementation: {
+                  container: {
+                    image: "test-image-2",
+                    command: ["test-command-2"],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const mockExecutionDetails: GetExecutionInfoResponse = {
+    id: "test-execution-id",
+    pipeline_run_id: "test-run-id-123",
+    task_spec: {
+      componentRef: {
+        spec: mockComponentSpec,
+      },
+    },
+    child_task_execution_ids: {
+      "task-1": "execution-1",
+      "task-2": "execution-2",
+    },
+  };
+
+  const mockExecutionState: GetGraphExecutionStateResponse = {
+    child_execution_status_stats: {
+      "execution-1": { SUCCEEDED: 1 },
+      "execution-2": { RUNNING: 1 },
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(executionService.useFetchExecutionInfo).mockReturnValue({
+      data: {
+        details: mockExecutionDetails,
+        state: mockExecutionState,
+      },
+      isLoading: false,
+      error: null,
+      isFetching: false,
+      refetch: () => {},
+      enabled: true,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    queryClient.clear();
+  });
+
+  describe("Task Execution IDs", () => {
+    test("should add execution IDs to tasks when on runs route", async () => {
+      // arrange
+      const setComponentSpecSpy = vi.fn();
+      mockUseComponentSpec.mockReturnValue({
+        componentSpec: null,
+        setComponentSpec: setComponentSpecSpy,
+        clearComponentSpec: vi.fn(),
+        setTaskStatusMap: vi.fn(),
+      });
+
+      // act
+      await act(async () =>
+        render(
+          <QueryClientProvider client={queryClient}>
+            <ComponentSpecProvider spec={undefined}>
+              <PipelineRun />
+            </ComponentSpecProvider>
+          </QueryClientProvider>,
+        ),
+      );
+
+      // assert - verify that setComponentSpec was called with execution IDs added
+      expect(setComponentSpecSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          implementation: expect.objectContaining({
+            graph: expect.objectContaining({
+              tasks: expect.objectContaining({
+                "task-1": expect.objectContaining({
+                  annotations: expect.objectContaining({
+                    executionId: "execution-1",
+                  }),
+                }),
+                "task-2": expect.objectContaining({
+                  annotations: expect.objectContaining({
+                    executionId: "execution-2",
+                  }),
+                }),
+              }),
+            }),
+          }),
+        }),
+      );
+    });
+
+    test("should not add execution IDs when child_task_execution_ids is missing", async () => {
+      // arrange
+      const setComponentSpecSpy = vi.fn();
+      mockUseComponentSpec.mockReturnValue({
+        componentSpec: null,
+        setComponentSpec: setComponentSpecSpy,
+        clearComponentSpec: vi.fn(),
+        setTaskStatusMap: vi.fn(),
+      });
+
+      const mockExecutionDetailsWithoutIds = {
+        ...mockExecutionDetails,
+        child_task_execution_ids: {},
+      };
+
+      vi.mocked(executionService.useFetchExecutionInfo).mockReturnValue({
+        data: {
+          details: mockExecutionDetailsWithoutIds,
+          state: mockExecutionState,
+        },
+        isLoading: false,
+        error: null,
+        isFetching: false,
+        refetch: () => {},
+        enabled: true,
+      });
+
+      // act
+      await act(async () =>
+        render(
+          <QueryClientProvider client={queryClient}>
+            <ComponentSpecProvider spec={undefined}>
+              <PipelineRun />
+            </ComponentSpecProvider>
+          </QueryClientProvider>,
+        ),
+      );
+
+      // assert - verify that tasks don't have executionId annotations
+      expect(setComponentSpecSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          implementation: expect.objectContaining({
+            graph: expect.objectContaining({
+              tasks: expect.objectContaining({
+                "task-1": expect.not.objectContaining({
+                  annotations: expect.objectContaining({
+                    executionId: expect.anything(),
+                  }),
+                }),
+                "task-2": expect.not.objectContaining({
+                  annotations: expect.objectContaining({
+                    executionId: expect.anything(),
+                  }),
+                }),
+              }),
+            }),
+          }),
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Resolves an issue introduced in #970 that resulted in a Run's editor version of the component spec being loaded. This resulted in tasks on the runs having missing (or outdated) execution ids and thus missing (or outdated) artifacts and logs.

This PR resolves that by separating out the `check if spec exists` use case from the original `load the spec` use case. In particular, the issue was caused by `setComponentSpec` being trigged when a url was checked.

Adds tests to the PipelineRun Route to check that tasks have execution ids attached to them.

**Original Issue**
In PR #970 `useLoadComponentSpecFromPath` is being used to test a url and see if the editor route from a pipeline can be loaded. I added some escape hatches to the hook for this scenario to avoid any permanent state changes but missed two cases of `setComponentSpec`. This resulted in the run's spec  being overwritten with the editor's version of the spec (which does not have execution ids).

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

this should resolve the underlying issues for https://github.com/Shopify/oasis-frontend/issues/280 and https://github.com/Shopify/oasis-frontend/issues/281

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->
1. run a pipeline
2. task details, artifacts and logs should be viewable (previously not)
3. inspect pipeline button should not be viewable if you don't have the pipeline saved in your browser (intended behaviour introduced by #970 )

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
