### PR TITLE
Rework TaskInput and TaskOutput logic

### DIFF
--- a/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/IONode/IONode.tsx
@@ -27,12 +27,7 @@ interface IONodeProps {
 }
 
 const IONode = ({ type, data, selected = false }: IONodeProps) => {
-  const {
-    getInputNodeId,
-    getOutputNodeId,
-    getTaskInputNodeId,
-    getTaskOutputNodeId,
-  } = useNodeManager();
+  const { getInputNodeId, getOutputNodeId } = useNodeManager();
   const { graphSpec, componentSpec } = useComponentSpec();
   const { setContent, clearContent } = useContextPanel();
 
@@ -63,13 +58,12 @@ const IONode = ({ type, data, selected = false }: IONodeProps) => {
     [componentSpec.outputs, spec.name],
   );
 
-  const nodeId = isInput
-    ? getInputNodeId(inputNameToInputId(spec.name))
-    : getOutputNodeId(outputNameToOutputId(spec.name));
+  const inputId = inputNameToInputId(spec.name);
+  const outputId = outputNameToOutputId(spec.name);
 
-  const nodeHandleId = isInput
-    ? getTaskOutputNodeId(inputNameToInputId(spec.name))
-    : getTaskInputNodeId(outputNameToOutputId(spec.name));
+  const nodeId = isInput ? getInputNodeId(inputId) : getOutputNodeId(outputId);
+
+  const nodeHandleId = `${nodeId}_handle`;
 
   const handleHandleClick = useCallback(() => {
     if (ENABLE_DEBUG_MODE) {

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/Handles.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/Handles.tsx
@@ -16,10 +16,6 @@ import { cn } from "@/lib/utils";
 import { useTaskNode } from "@/providers/TaskNodeProvider";
 import type { InputSpec, OutputSpec } from "@/utils/componentSpec";
 import { ENABLE_DEBUG_MODE } from "@/utils/constants";
-import {
-  inputNameToInputId,
-  outputNameToOutputId,
-} from "@/utils/nodes/conversions";
 
 type InputHandleProps = {
   input: InputSpec;
@@ -39,7 +35,7 @@ export const InputHandle = ({
   onHandleSelectionChange,
 }: InputHandleProps) => {
   const { getTaskInputNodeId } = useNodeManager();
-  const { nodeId, state, name } = useTaskNode();
+  const { taskId, nodeId, state, name } = useTaskNode();
 
   const fromHandle = useConnection((connection) => connection.fromHandle?.id);
   const toHandle = useConnection((connection) => connection.toHandle?.id);
@@ -51,7 +47,7 @@ export const InputHandle = ({
   const [selected, setSelected] = useState(false);
   const [active, setActive] = useState(false);
 
-  const handleId = getTaskInputNodeId(inputNameToInputId(input.name));
+  const handleId = getTaskInputNodeId(taskId, input.name);
 
   const missing = invalid ? "bg-red-700!" : "bg-gray-500!";
   const hasValue = value !== undefined && value !== null;
@@ -235,7 +231,7 @@ export const OutputHandle = ({
   onHandleSelectionChange,
 }: OutputHandleProps) => {
   const { getTaskOutputNodeId } = useNodeManager();
-  const { nodeId, state, name } = useTaskNode();
+  const { taskId, nodeId, state, name } = useTaskNode();
 
   const fromHandle = useConnection((connection) => connection.fromHandle?.id);
   const toHandle = useConnection((connection) => connection.toHandle?.id);
@@ -247,7 +243,7 @@ export const OutputHandle = ({
   const [selected, setSelected] = useState(false);
   const [active, setActive] = useState(false);
 
-  const handleId = getTaskOutputNodeId(outputNameToOutputId(output.name));
+  const handleId = getTaskOutputNodeId(taskId, output.name);
   const hasValue = value !== undefined && value !== "" && value !== null;
 
   const handleHandleClick = useCallback(

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeInputs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeInputs.tsx
@@ -11,7 +11,6 @@ import { useTaskNode } from "@/providers/TaskNodeProvider";
 import { inputsWithInvalidArguments } from "@/services/componentService";
 import type { InputSpec } from "@/utils/componentSpec";
 import { ComponentSearchFilter } from "@/utils/constants";
-import { inputNameToInputId } from "@/utils/nodes/conversions";
 import { checkArtifactMatchesSearchFilters } from "@/utils/searchUtils";
 
 import { InputHandle } from "./Handles";
@@ -28,8 +27,8 @@ export function TaskNodeInputs({
   expanded,
   onBackgroundClick,
 }: TaskNodeInputsProps) {
-  const { getInputNodeId } = useNodeManager();
-  const { inputs, taskSpec, state, select } = useTaskNode();
+  const { getTaskInputNodeId } = useNodeManager();
+  const { taskId, inputs, taskSpec, state, select } = useTaskNode();
   const { graphSpec } = useComponentSpec();
   const {
     highlightSearchFilter,
@@ -147,7 +146,7 @@ export function TaskNodeInputs({
     }
 
     const input = inputs.find(
-      (i) => getInputNodeId(inputNameToInputId(i.name)) === fromHandle?.id,
+      (i) => getTaskInputNodeId(taskId, i.name) === fromHandle?.id,
     );
 
     if (!input) return;

--- a/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeOutputs.tsx
+++ b/src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskNodeCard/TaskNodeOutputs.tsx
@@ -8,7 +8,6 @@ import { isValidFilterRequest } from "@/providers/ComponentLibraryProvider/types
 import { useTaskNode } from "@/providers/TaskNodeProvider";
 import type { OutputSpec } from "@/utils/componentSpec";
 import { ComponentSearchFilter } from "@/utils/constants";
-import { outputNameToOutputId } from "@/utils/nodes/conversions";
 import { checkArtifactMatchesSearchFilters } from "@/utils/searchUtils";
 
 import { OutputHandle } from "./Handles";
@@ -25,7 +24,7 @@ export function TaskNodeOutputs({
   onBackgroundClick,
 }: TaskNodeOutputsProps) {
   const { getTaskOutputNodeId } = useNodeManager();
-  const { nodeId, outputs, state, select } = useTaskNode();
+  const { taskId, nodeId, outputs, state, select } = useTaskNode();
   const {
     highlightSearchFilter,
     resetSearchFilter,
@@ -42,8 +41,7 @@ export function TaskNodeOutputs({
     edges.some(
       (edge) =>
         edge.source === nodeId &&
-        edge.sourceHandle ===
-          getTaskOutputNodeId(outputNameToOutputId(output.name)),
+        edge.sourceHandle === getTaskOutputNodeId(taskId, output.name),
     ),
   );
 
@@ -141,8 +139,7 @@ export function TaskNodeOutputs({
     }
 
     const output = outputs.find(
-      (o) =>
-        getTaskOutputNodeId(outputNameToOutputId(o.name)) === fromHandle?.id,
+      (o) => getTaskOutputNodeId(taskId, o.name) === fromHandle?.id,
     );
 
     if (!output) return;

--- a/src/hooks/useComponentSpecToEdges.ts
+++ b/src/hooks/useComponentSpecToEdges.ts
@@ -110,17 +110,22 @@ const createTaskOutputEdge = (
   nodeManager: NodeManager,
 ): Edge => {
   const sourceNodeId = nodeManager.getNodeId(taskOutput.taskId, "task");
-  const sourceOutputId = outputNameToOutputId(taskOutput.outputName);
-  const sourceHandleNodeId = nodeManager.getNodeId(
-    sourceOutputId,
+  const targetNodeId = nodeManager.getNodeId(taskId, "task");
+
+  const sourceHandleNodeId = nodeManager.getTaskHandleNodeId(
+    taskOutput.taskId,
+    taskOutput.outputName,
     "taskOutput",
   );
-  const targetNodeId = nodeManager.getNodeId(taskId, "task");
-  const targetInputId = inputNameToInputId(inputName);
-  const targetHandleNodeId = nodeManager.getNodeId(targetInputId, "taskInput");
+
+  const targetHandleNodeId = nodeManager.getTaskHandleNodeId(
+    taskId,
+    inputName,
+    "taskInput",
+  );
 
   return {
-    id: `${taskOutput.taskId}_${sourceOutputId}-${taskId}_${targetInputId}`,
+    id: `${taskOutput.taskId}_${taskOutput.outputName}-${taskId}_${inputName}`,
     source: sourceNodeId,
     sourceHandle: sourceHandleNodeId,
     target: targetNodeId,
@@ -139,11 +144,15 @@ const createGraphInputEdge = (
   const inputId = inputNameToInputId(graphInput.inputName);
   const sourceNodeId = nodeManager.getNodeId(inputId, "input");
   const targetNodeId = nodeManager.getNodeId(taskId, "task");
-  const targetInputId = inputNameToInputId(inputName);
-  const targetHandleNodeId = nodeManager.getNodeId(targetInputId, "taskInput");
+
+  const targetHandleNodeId = nodeManager.getTaskHandleNodeId(
+    taskId,
+    inputName,
+    "taskInput",
+  );
 
   return {
-    id: `Input_${inputId}-${taskId}_${targetInputId}`,
+    id: `Input_${inputId}-${taskId}_${inputName}`,
     source: sourceNodeId,
     sourceHandle: null,
     target: targetNodeId,
@@ -162,18 +171,17 @@ const createOutputEdgesFromGraphSpec = (
       const taskOutput = argument.taskOutput;
 
       const sourceNodeId = nodeManager.getNodeId(taskOutput.taskId, "task");
-      const sourceOutputId = outputNameToOutputId(taskOutput.outputName);
-      const sourceHandleNodeId = nodeManager.getNodeId(
-        sourceOutputId,
-        "taskOutput",
-      );
       const targetOutputId = outputNameToOutputId(outputName);
       const targetNodeId = nodeManager.getNodeId(targetOutputId, "output");
 
-      // console.log({ sourceNodeId, targetNodeId, sourceHandleNodeId });
+      const sourceHandleNodeId = nodeManager.getTaskHandleNodeId(
+        taskOutput.taskId,
+        taskOutput.outputName,
+        "taskOutput",
+      );
 
       const edge: Edge = {
-        id: `${taskOutput.taskId}_${sourceOutputId}-Output_${targetOutputId}`,
+        id: `${taskOutput.taskId}_${taskOutput.outputName}-Output_${outputName}`,
         source: sourceNodeId,
         sourceHandle: sourceHandleNodeId,
         target: targetNodeId,


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Moves TaskInput node type and TaskOutput node type to be stored inside the node manager as a subset of their respective task node. This also reworks input and output nodes to no longer rely on TaskInput and TaskOutput types; instead it is assumed that the node handles are unique and distinct to the node itself.

This PR is a continuation of the previous and may be merged down into it to simplify.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [x] Cleanup/Refactor
- [ ] Breaking change
- [ ] Documentation update

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
