### PR TITLE
Fix Bug in Run Submission

### DIFF
--- a/src/utils/submitPipeline.test.ts
+++ b/src/utils/submitPipeline.test.ts
@@ -6,7 +6,6 @@ import * as pipelineRunService from "@/services/pipelineRunService";
 import type { PipelineRun } from "@/types/pipelineRun";
 
 import { type ComponentSpec, isGraphImplementation } from "./componentSpec";
-import * as getComponentName from "./getComponentName";
 import { submitPipelineRun } from "./submitPipeline";
 
 // Mock dependencies
@@ -21,10 +20,6 @@ vi.mock(
     getArgumentsFromInputs: vi.fn(),
   }),
 );
-
-vi.mock("./getComponentName", () => ({
-  getInitialName: vi.fn(),
-}));
 
 describe("submitPipelineRun", () => {
   const mockBackendUrl = "https://api.example.com";
@@ -49,7 +44,6 @@ describe("submitPipelineRun", () => {
     global.fetch = mockFetch;
 
     // Setup default mocks
-    vi.mocked(getComponentName.getInitialName).mockReturnValue("test-pipeline");
     vi.mocked(getArgumentsFromInputs.getArgumentsFromInputs).mockReturnValue(
       {},
     );
@@ -102,7 +96,7 @@ describe("submitPipelineRun", () => {
       );
       expect(pipelineRunService.savePipelineRun).toHaveBeenCalledWith(
         mockPipelineRun,
-        "test-pipeline",
+        "simple-component",
         undefined,
       );
       expect(mockOnSuccess).toHaveBeenCalledWith(mockPipelineRun);
@@ -153,6 +147,22 @@ describe("submitPipelineRun", () => {
       expect(pipelineRunService.createPipelineRun).toHaveBeenCalledWith(
         expect.any(Object),
         mockBackendUrl,
+        undefined,
+      );
+    });
+
+    it("should use 'Pipeline' as default name when componentSpec.name is undefined", async () => {
+      const componentSpec: ComponentSpec = {
+        implementation: { container: { image: "test:latest" } },
+      };
+
+      // Act
+      await submitPipelineRun(componentSpec, mockBackendUrl);
+
+      // Assert
+      expect(pipelineRunService.savePipelineRun).toHaveBeenCalledWith(
+        mockPipelineRun,
+        "Pipeline",
         undefined,
       );
     });
@@ -716,7 +726,7 @@ describe("submitPipelineRun", () => {
       // Assert
       expect(pipelineRunService.savePipelineRun).toHaveBeenCalledWith(
         expect.any(Object),
-        "test-pipeline",
+        "digest-component",
         testDigest,
       );
     });

--- a/src/utils/submitPipeline.ts
+++ b/src/utils/submitPipeline.ts
@@ -9,7 +9,6 @@ import {
 import type { PipelineRun } from "@/types/pipelineRun";
 
 import type { ComponentReference, ComponentSpec } from "./componentSpec";
-import { getInitialName } from "./getComponentName";
 
 export async function submitPipelineRun(
   componentSpec: ComponentSpec,
@@ -20,7 +19,7 @@ export async function submitPipelineRun(
     onError?: (error: Error) => void;
   },
 ) {
-  const pipelineName = getInitialName(componentSpec);
+  const pipelineName = componentSpec.name ?? "Pipeline";
 
   try {
     const specCopy = structuredClone(componentSpec);


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes made in this pull request. Include any relevant context or reasoning for the changes. -->
Fixes a bug introduced in #746 that resulted in pipelines runs being saved with the incorrect pipeline name, resulting in the pipeline having the inability to fetch them back again.

## Related Issue and Pull requests

<!-- Link to any related issues using the format #<issue-number> -->
Fixes some of the items in https://github.com/Shopify/oasis-frontend/issues/284

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix

## Checklist

<!-- Please ensure the following are completed before submitting the PR -->

- [ ] I have tested this does not break current pipelines / runs functionality
- [ ] I have tested the changes on staging

## Screenshots (if applicable)

<!-- Include any screenshots that might help explain the changes or provide visual context -->

## Test Instructions

<!-- Detail steps and prerequisites for testing the changes in this PR -->

## Additional Comments

<!-- Add any additional context or information that reviewers might need to know regarding this PR -->
